### PR TITLE
docs: clarify Hermes virtualenv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,27 @@ Multi-provider web search with intelligent auto-routing for [Hermes Agent](https
 
 ```bash
 git clone https://github.com/robbyczgw-cla/hermes-web-search-plus.git ~/.hermes/plugins/web-search-plus
+cd ~/.hermes/hermes-agent
+source venv/bin/activate
 cd ~/.hermes/plugins/web-search-plus
-cp .env.template .env          # fill in at least SERPER_API_KEY
-pip install requests
+cp .env.template .env          # fill in at least one provider key
+# Optional: pip install httpx  # only needed for Exa deep/deep-reasoning
 ```
 
-That's it. Start Hermes and use `web_search_plus`.
+Important:
+- Use the Hermes virtualenv, not your system Python.
+- Run `pip` only after `source ~/.hermes/hermes-agent/venv/bin/activate` (or from `~/.hermes/hermes-agent` via `source venv/bin/activate`).
+- If you test the plugin from the CLI, prefer `~/.hermes/hermes-agent/venv/bin/python` or activate the Hermes venv first.
+
+Then enable the plugin in `~/.hermes/config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - web-search-plus
+```
+
+Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_search_plus`.
 
 ---
 
@@ -105,7 +120,9 @@ web_search_plus(query="LoRA fine-tuning", include_domains=["arxiv.org"])
 ### CLI testing
 
 ```bash
-python3 ~/.hermes/plugins/web-search-plus/search.py \
+cd ~/.hermes/hermes-agent
+source venv/bin/activate
+python ~/.hermes/plugins/web-search-plus/search.py \
   --query "test query" --provider auto --max-results 5 --compact
 ```
 


### PR DESCRIPTION
## Summary
- clarify that installation/testing should use the Hermes virtualenv, not system Python
- update Quick Start to activate the Hermes venv before plugin setup
- update CLI testing examples to run from the Hermes venv
- keep home-directory paths generic (`~`) instead of machine-specific absolute paths

## Problem
The README made it easy to install or test the plugin with the wrong Python environment.

For Hermes plugins, this is confusing because the plugin is expected to run within the Hermes Agent environment. If users install dependencies or run CLI tests with system Python instead of the Hermes virtualenv, the setup may appear to succeed but behave inconsistently.

## What changed
- use:
  - `cd ~/.hermes/hermes-agent`
  - `source venv/bin/activate`
- explicitly call out that `pip` should be run only after activating the Hermes virtualenv
- update CLI testing docs to activate the Hermes virtualenv first
- avoid machine-specific home paths by using `~`
