### PR TITLE
feat: add Brave Search and fix Hermes main compatibility

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,7 +5,7 @@
 # Serper (Google Search) — https://serper.dev — 2,500 free/month
 SERPER_API_KEY=***
 
-# Brave Search — https://brave.com/search/api/ — usage/quota depends on your Brave plan
+# Brave Search — https://brave.com/search/api/ — $5.00/mo in free credits; you won't be charged
 BRAVE_API_KEY=***
 
 # Tavily (Research/Analysis) — https://tavily.com — 1,000 free/month

--- a/.env.template
+++ b/.env.template
@@ -3,7 +3,10 @@
 # At least one key is required; more keys = better auto-routing coverage
 
 # Serper (Google Search) — https://serper.dev — 2,500 free/month
-SERPER_API_KEY=
+SERPER_API_KEY=***
+
+# Brave Search — https://brave.com/search/api/ — usage/quota depends on your Brave plan
+BRAVE_API_KEY=***
 
 # Tavily (Research/Analysis) — https://tavily.com — 1,000 free/month
 TAVILY_API_KEY=

--- a/README.md
+++ b/README.md
@@ -10,12 +10,36 @@ Multi-provider web search with intelligent auto-routing for [Hermes Agent](https
 
 ```bash
 git clone https://github.com/robbyczgw-cla/hermes-web-search-plus.git ~/.hermes/plugins/web-search-plus
+cd ~/.hermes/hermes-agent
+source venv/bin/activate
 cd ~/.hermes/plugins/web-search-plus
-cp .env.template .env          # fill in at least SERPER_API_KEY
-pip install requests
+cp .env.template .env          # fill in at least one provider key
+# Optional: pip install httpx  # only needed for Exa deep/deep-reasoning
 ```
 
-That's it. Start Hermes and use `web_search_plus`.
+Important:
+- Use the Hermes virtualenv, not your system Python.
+- Run `pip` only after `source ~/.hermes/hermes-agent/venv/bin/activate` (or from `~/.hermes/hermes-agent` via `source venv/bin/activate`).
+- If you test the plugin from the CLI, prefer `~/.hermes/hermes-agent/venv/bin/python` or activate the Hermes venv first.
+
+Then enable the plugin in `~/.hermes/config.yaml`:
+
+```yaml
+plugins:
+  enabled:
+    - web-search-plus
+```
+
+Also enable the plugin toolset alongside the built-in `web` toolset so both are available:
+
+```yaml
+tools:
+  enabled:
+    - web
+    - web-search-plus
+```
+
+Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_search_plus`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_
 
 | Provider | Best for | Free tier |
 |----------|----------|-----------|
-| Brave | General-purpose web search, independent index, broad factual queries | Monthly credits |
+| Brave | General-purpose web search, independent index, broad factual queries | $5.00/mo in free credits |
 | Serper (Google) | News, shopping, facts, local queries | 2,500/mo |
 | Tavily | Research, deep content, academic | 1,000/mo |
 | Exa | Semantic discovery, "alternatives to X", arxiv | 1,000/mo |
@@ -80,7 +80,7 @@ Auto-routing scores providers based on query signals (keywords, intent, linguist
 ```bash
 # Required (at least one)
 SERPER_API_KEY=***        # https://serper.dev — 2,500 free/mo
-BRAVE_API_KEY=***         # https://brave.com/search/api/ — monthly credits
+BRAVE_API_KEY=***         # https://brave.com/search/api/ — $5.00/mo in free credits; you won't be charged
 TAVILY_API_KEY=***        # https://tavily.com — 1,000 free/mo
 EXA_API_KEY=***           # https://exa.ai — 1,000 free/mo
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_
 ## Features
 
 - **Intelligent auto-routing** — picks the best provider based on query intent
-- **7 providers** — Serper, Tavily, Exa, Querit, Perplexity, You.com, SearXNG
+- **8 providers** — Serper, Brave, Tavily, Exa, Querit, Perplexity, You.com, SearXNG
 - **Exa Deep Research** — `depth=deep` for multi-source synthesis, `depth=deep-reasoning` for cross-document analysis
 - **Adaptive fallback** — automatically skips providers on cooldown (1h after failure)
 - **Routing transparency** — every response includes a `routing` object explaining provider choice
@@ -60,6 +60,7 @@ Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_
 
 | Provider | Best for | Free tier |
 |----------|----------|-----------|
+| Brave | General-purpose web search, independent index, broad factual queries | Monthly credits |
 | Serper (Google) | News, shopping, facts, local queries | 2,500/mo |
 | Tavily | Research, deep content, academic | 1,000/mo |
 | Exa | Semantic discovery, "alternatives to X", arxiv | 1,000/mo |
@@ -68,7 +69,7 @@ Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_
 | You.com | LLM-ready real-time snippets | Limited |
 | SearXNG | Privacy-focused, self-hosted, no API cost | Free |
 
-Auto-routing scores providers based on query signals (keywords, intent, linguistic patterns). Every response includes a `routing` field explaining why a provider was chosen. Override anytime with `provider="serper"` etc.
+Auto-routing scores providers based on query signals (keywords, intent, linguistic patterns). Brave and Serper share generic web-search intents; when they tie, the router uses deterministic per-query tie-breaking so the same query stays reproducible while ties are distributed across both providers. Override anytime with `provider="serper"`, `provider="brave"`, etc.
 
 ---
 
@@ -78,9 +79,10 @@ Auto-routing scores providers based on query signals (keywords, intent, linguist
 
 ```bash
 # Required (at least one)
-SERPER_API_KEY=your-key        # https://serper.dev — 2,500 free/mo
-TAVILY_API_KEY=your-key        # https://tavily.com — 1,000 free/mo
-EXA_API_KEY=your-key           # https://exa.ai — 1,000 free/mo
+SERPER_API_KEY=***        # https://serper.dev — 2,500 free/mo
+BRAVE_API_KEY=***         # https://brave.com/search/api/ — monthly credits
+TAVILY_API_KEY=***        # https://tavily.com — 1,000 free/mo
+EXA_API_KEY=***           # https://exa.ai — 1,000 free/mo
 
 # Optional
 QUERIT_API_KEY=your-key        # https://querit.ai
@@ -101,7 +103,7 @@ SEARXNG_INSTANCE_URL=https://your-instance.example.com
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `query` | string | **required** | The search query |
-| `provider` | string | `"auto"` | Force: `serper`, `tavily`, `exa`, `querit`, `perplexity`, `you`, `searxng` |
+| `provider` | string | `"auto"` | Force: `serper`, `brave`, `tavily`, `exa`, `querit`, `perplexity`, `you`, `searxng` |
 | `depth` | string | `"normal"` | Exa only: `normal`, `deep`, `deep-reasoning` |
 | `count` | integer | `5` | Results (1–20) |
 | `time_range` | string | — | `day`, `week`, `month`, `year` |
@@ -112,7 +114,10 @@ SEARXNG_INSTANCE_URL=https://your-instance.example.com
 
 ```python
 web_search_plus(query="Graz weather today")
-# → auto-routed to Serper (local/weather intent)
+# → auto-routed to Serper or Brave (generic weather/current-info intent)
+
+web_search_plus(query="Singapore CPI latest", provider="brave")
+# → Brave Search (independent general web index)
 
 web_search_plus(query="alternatives to Notion", provider="exa")
 # → Exa (discovery/similarity)

--- a/__init__.py
+++ b/__init__.py
@@ -13,6 +13,16 @@ from pathlib import Path
 from typing import Any, List, Optional
 
 _SEARCH_SCRIPT = Path(__file__).parent / "search.py"
+_TOOLSET_NAME = "web-search-plus"
+_PROVIDER_ENV_KEYS = [
+    "SERPER_API_KEY",
+    "TAVILY_API_KEY",
+    "EXA_API_KEY",
+    "QUERIT_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "YOU_API_KEY",
+    "SEARXNG_INSTANCE_URL",
+]
 
 
 def _load_plugin_env() -> None:
@@ -137,7 +147,7 @@ def register(ctx: Any) -> None:
             "Set depth='deep' for Exa multi-source synthesis, 'deep-reasoning' for complex cross-document analysis. "
             "Override with provider param if needed."
         ),
-        "input_schema": {
+        "parameters": {
             "type": "object",
             "properties": {
                 "query": {
@@ -209,17 +219,16 @@ def register(ctx: Any) -> None:
         return _format_results(data)
 
     def check_fn() -> bool:
-        """Plugin is available if at least one API key is configured."""
-        keys = ["SERPER_API_KEY", "TAVILY_API_KEY", "EXA_API_KEY", "QUERIT_API_KEY"]
-        return any(os.environ.get(k) for k in keys)
+        """Plugin is available if at least one provider credential is configured."""
+        return any(os.environ.get(k) for k in _PROVIDER_ENV_KEYS)
 
     ctx.register_tool(
         name="web_search_plus",
-        toolset="web",
+        toolset=_TOOLSET_NAME,
         schema=schema,
         handler=handler,
         check_fn=check_fn,
-        requires_env=["SERPER_API_KEY"],
+        requires_env=[],
         description="Multi-provider web search with intelligent auto-routing",
         emoji="🔍",
     )

--- a/__init__.py
+++ b/__init__.py
@@ -16,6 +16,7 @@ _SEARCH_SCRIPT = Path(__file__).parent / "search.py"
 _TOOLSET_NAME = "web-search-plus"
 _PROVIDER_ENV_KEYS = [
     "SERPER_API_KEY",
+    "BRAVE_API_KEY",
     "TAVILY_API_KEY",
     "EXA_API_KEY",
     "QUERIT_API_KEY",
@@ -156,8 +157,8 @@ def register(ctx: Any) -> None:
                 },
                 "provider": {
                     "type": "string",
-                    "enum": ["auto", "serper", "tavily", "exa", "querit", "perplexity", "you", "searxng"],
-                    "description": "Search provider. Use 'auto' for intelligent routing (default).",
+                    "enum": ["auto", "serper", "brave", "tavily", "exa", "querit", "perplexity", "you", "searxng"],
+                    "description": "Search provider. Use 'auto' for intelligent routing (default). Brave and Serper share generic web-search intents and ties are distributed deterministically per query.",
                     "default": "auto",
                 },
                 "depth": {

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "1.3.0"
+version: "1.3.2"
 description: "Multi-provider web search with intelligent auto-routing (Serper, Tavily, Exa, Querit, Perplexity, SearXNG)"
 author: robbyczgw-cla
 requires_env: []

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,10 +1,11 @@
 name: web-search-plus
-version: "1.3.2"
-description: "Multi-provider web search with intelligent auto-routing (Serper, Tavily, Exa, Querit, Perplexity, SearXNG)"
+version: "1.3.3"
+description: "Multi-provider web search with intelligent auto-routing (Serper, Brave, Tavily, Exa, Querit, Perplexity, SearXNG)"
 author: robbyczgw-cla
 requires_env: []
 optional_env:
   - SERPER_API_KEY
+  - BRAVE_API_KEY
   - TAVILY_API_KEY
   - EXA_API_KEY
   - QUERIT_API_KEY

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search with Intelligent Auto-Routing
-Supports: Serper (Google), Tavily (Research), Querit (Multilingual AI Search),
+Supports: Serper (Google), Brave Search, Tavily (Research), Querit (Multilingual AI Search),
 Exa (Neural), Perplexity (Direct Answers)
 
 Smart Routing uses multi-signal analysis:
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Optional, List, Dict, Any, Tuple
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote, urlparse
+from urllib.parse import quote, urlencode, urlparse
 
 
 # =============================================================================
@@ -277,7 +277,7 @@ DEFAULT_CONFIG = {
     "auto_routing": {
         "enabled": True,
         "fallback_provider": "serper",
-        "provider_priority": ["tavily", "querit", "exa", "perplexity", "serper", "you", "searxng"],
+        "provider_priority": ["tavily", "querit", "exa", "perplexity", "brave", "serper", "you", "searxng"],
         "disabled_providers": [],
         "confidence_threshold": 0.3,  # Below this, note low confidence
     },
@@ -285,6 +285,11 @@ DEFAULT_CONFIG = {
         "country": "us",
         "language": "en",
         "type": "search"
+    },
+    "brave": {
+        "country": "US",
+        "search_lang": "en",
+        "safesearch": "moderate",
     },
     "tavily": {
         "depth": "basic",
@@ -364,6 +369,7 @@ def get_api_key(provider: str, config: Dict[str, Any] = None) -> Optional[str]:
         return os.environ.get("PERPLEXITY_API_KEY") or os.environ.get("KILOCODE_API_KEY")
     key_map = {
         "serper": "SERPER_API_KEY",
+        "brave": "BRAVE_API_KEY",
         "tavily": "TAVILY_API_KEY",
         "querit": "QUERIT_API_KEY",
         "exa": "EXA_API_KEY",
@@ -482,6 +488,7 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
     if not key:
         env_var = {
             "serper": "SERPER_API_KEY",
+            "brave": "BRAVE_API_KEY",
             "tavily": "TAVILY_API_KEY",
             "querit": "QUERIT_API_KEY",
             "exa": "EXA_API_KEY",
@@ -491,6 +498,7 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
         
         urls = {
             "serper": "https://serper.dev",
+            "brave": "https://brave.com/search/api/",
             "tavily": "https://tavily.com",
             "querit": "https://querit.ai",
             "exa": "https://exa.ai",
@@ -1170,6 +1178,7 @@ class QueryAnalyzer:
         # Map intents to providers with final scores
         provider_scores = {
             "serper": shopping_score + local_news_score + (recency_score * 0.35),
+            "brave": shopping_score + local_news_score + (recency_score * 0.35),
             "tavily": research_score + (complexity["complexity_score"] if not complexity["is_complex"] else 0) + (0.2 * recency_score),
             "querit": (research_score * 0.65) + (rag_score * 0.35) + (recency_score * 0.45),
             "exa": discovery_score + (1.0 if re.search(r"\b(similar|alternatives?|examples?)\b", query, re.IGNORECASE) else 0.0) + (exa_deep_score * 0.5) + (exa_deep_reasoning_score * 0.5),
@@ -1181,6 +1190,7 @@ class QueryAnalyzer:
         # Build match details per provider
         provider_matches = {
             "serper": shopping_matches + local_news_matches,
+            "brave": shopping_matches + local_news_matches,
             "tavily": research_matches,
             "querit": research_matches,
             "exa": discovery_matches + exa_deep_matches + exa_deep_reasoning_matches,
@@ -1232,18 +1242,12 @@ class QueryAnalyzer:
         max_score = max(available.values())
         total_score = sum(available.values()) or 1.0
         
-        # Handle ties using priority
-        priority = self.auto_config.get("provider_priority", ["tavily", "querit", "exa", "perplexity", "serper", "you", "searxng"])
+        # Handle ties using deterministic per-query distribution
+        priority = self.auto_config.get("provider_priority", ["tavily", "querit", "exa", "perplexity", "brave", "serper", "you", "searxng"])
         winners = [p for p, s in available.items() if s == max_score]
         
         if len(winners) > 1:
-            # Use priority to break tie
-            for p in priority:
-                if p in winners:
-                    winner = p
-                    break
-            else:
-                winner = winners[0]
+            winner = _choose_tie_winner(query, winners, priority)
         else:
             winner = winners[0]
         
@@ -1348,6 +1352,7 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
         "top_signals": routing["top_signals"],
         "intent_breakdown": {
             "shopping_signals": len(analysis["provider_matches"]["serper"]),
+            "brave_signals": len(analysis["provider_matches"]["brave"]),
             "research_signals": len(analysis["provider_matches"]["tavily"]),
             "querit_signals": len(analysis["provider_matches"]["querit"]),
             "discovery_signals": len(analysis["provider_matches"]["exa"]),
@@ -1371,7 +1376,7 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             if matches
         },
         "available_providers": [
-            p for p in ["serper", "tavily", "querit", "exa", "perplexity", "you", "searxng"]
+            p for p in ["serper", "brave", "tavily", "querit", "exa", "perplexity", "you", "searxng"]
             if get_api_key(p, config) and p not in config.get("auto_routing", {}).get("disabled_providers", [])
         ]
     }
@@ -1499,6 +1504,22 @@ def deduplicate_results_across_providers(results_by_provider: List[Tuple[str, Di
                 return deduped, dedup_count
     return deduped, dedup_count
 
+def _choose_tie_winner(query: str, winners: List[str], priority: List[str]) -> str:
+    """Break score ties deterministically per query.
+
+    Uses a stable hash of the query to distribute ties across providers while
+    keeping the same query reproducible across runs.
+    """
+    ordered_winners = [p for p in priority if p in winners]
+    if not ordered_winners:
+        ordered_winners = sorted(winners)
+    if len(ordered_winners) == 1:
+        return ordered_winners[0]
+    digest = hashlib.sha256(f"{query}|{'|'.join(ordered_winners)}".encode("utf-8")).hexdigest()
+    idx = int(digest[:8], 16) % len(ordered_winners)
+    return ordered_winners[idx]
+
+
 # =============================================================================
 # HTTP Client
 # =============================================================================
@@ -1530,6 +1551,47 @@ def make_request(url: str, headers: dict, body: dict, timeout: int = 30) -> dict
             503: "Service unavailable. The search provider may be down."
         }
         
+        friendly_msg = error_messages.get(e.code, f"API error: {error_detail}")
+        raise ProviderRequestError(f"{friendly_msg} (HTTP {e.code})", status_code=e.code, transient=e.code in TRANSIENT_HTTP_CODES)
+    except URLError as e:
+        reason = str(getattr(e, "reason", e))
+        is_timeout = "timed out" in reason.lower()
+        raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
+    except IncompleteRead as e:
+        partial_len = len(getattr(e, "partial", b"") or b"")
+        raise ProviderRequestError(
+            f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
+            transient=True,
+        )
+    except TimeoutError:
+        raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)
+
+
+def make_get_request(url: str, headers: dict, timeout: int = 30) -> dict:
+    """Make HTTP GET request and return JSON response."""
+    if "User-Agent" not in headers:
+        headers["User-Agent"] = "ClawdBot-WebSearchPlus/2.1"
+    req = Request(url, headers=headers, method="GET")
+
+    try:
+        with urlopen(req, timeout=timeout) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HTTPError as e:
+        error_body = e.read().decode("utf-8") if e.fp else str(e)
+        try:
+            error_json = json.loads(error_body)
+            error_detail = error_json.get("error") or error_json.get("message") or error_body
+        except json.JSONDecodeError:
+            error_detail = error_body[:500]
+
+        error_messages = {
+            401: "Invalid or expired API key. Please check your credentials.",
+            403: "Access forbidden. Your API key may not have permission for this operation.",
+            429: "Rate limit exceeded. Please wait a moment and try again.",
+            500: "Server error. The search provider is experiencing issues.",
+            503: "Service unavailable. The search provider may be down."
+        }
+
         friendly_msg = error_messages.get(e.code, f"API error: {error_detail}")
         raise ProviderRequestError(f"{friendly_msg} (HTTP {e.code})", status_code=e.code, transient=e.code in TRANSIENT_HTTP_CODES)
     except URLError as e:
@@ -1629,6 +1691,83 @@ def search_serper(
         "answer": answer,
         "knowledge_graph": data.get("knowledgeGraph"),
         "related_searches": [r.get("query") for r in data.get("relatedSearches", [])]
+    }
+
+
+# =============================================================================
+# Brave Search
+# =============================================================================
+
+def search_brave(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    country: str = "US",
+    language: str = "en",
+    time_range: Optional[str] = None,
+    safesearch: str = "moderate",
+) -> dict:
+    """Search using Brave Search API."""
+    freshness_map = {
+        "hour": "pd",
+        "day": "pd",
+        "week": "pw",
+        "month": "pm",
+        "year": "py",
+    }
+    params = {
+        "q": query,
+        "count": max_results,
+        "country": country.upper(),
+        "search_lang": language,
+        "safesearch": safesearch,
+        "spellcheck": 1,
+    }
+    if time_range and time_range in freshness_map:
+        params["freshness"] = freshness_map[time_range]
+
+    url = f"https://api.search.brave.com/res/v1/web/search?{urlencode(params)}"
+    headers = {
+        "X-Subscription-Token": api_key,
+        "Accept": "application/json",
+        "Accept-Encoding": "gzip",
+    }
+
+    data = make_get_request(url, headers)
+
+    web_results = (data.get("web") or {}).get("results", [])[:max_results]
+    results = []
+    for i, item in enumerate(web_results):
+        snippet_parts = []
+        description = item.get("description") or item.get("snippet") or ""
+        if description:
+            snippet_parts.append(description)
+        extra_snippets = item.get("extra_snippets") or []
+        if extra_snippets:
+            snippet_parts.extend(extra_snippets[:2])
+        results.append({
+            "title": item.get("title", ""),
+            "url": item.get("url", ""),
+            "snippet": " ... ".join(part for part in snippet_parts if part),
+            "score": round(1.0 - i * 0.1, 2),
+            "age": item.get("age"),
+        })
+
+    answer = ""
+    if data.get("summary"):
+        answer = data.get("summary", "")
+    elif data.get("infobox", {}).get("description"):
+        answer = data["infobox"]["description"]
+    elif results:
+        answer = results[0]["snippet"]
+
+    return {
+        "provider": "brave",
+        "query": query,
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "mixed": data.get("mixed"),
     }
 
 
@@ -2423,7 +2562,7 @@ Full docs: See README.md and SKILL.md
     # Common arguments
     parser.add_argument(
         "--provider", "-p", 
-        choices=["serper", "tavily", "querit", "exa", "perplexity", "you", "searxng", "auto"],
+        choices=["serper", "brave", "tavily", "querit", "exa", "perplexity", "you", "searxng", "auto"],
         help="Search provider (auto=intelligent routing)"
     )
     parser.add_argument(
@@ -2663,7 +2802,7 @@ Full docs: See README.md and SKILL.md
     
     # Build provider fallback list
     auto_config = config.get("auto_routing", {})
-    provider_priority = auto_config.get("provider_priority", ["tavily", "querit", "exa", "perplexity", "serper", "you", "searxng"])
+    provider_priority = auto_config.get("provider_priority", ["tavily", "querit", "exa", "perplexity", "brave", "serper", "you", "searxng"])
     disabled_providers = auto_config.get("disabled_providers", [])
 
     # Start with the selected provider, then try others in priority order
@@ -2700,6 +2839,17 @@ Full docs: See README.md and SKILL.md
                 search_type=args.search_type,
                 time_range=args.time_range,
                 include_images=args.images,
+            )
+        elif prov == "brave":
+            brave_config = config.get("brave", {})
+            return search_brave(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                country=brave_config.get("country", args.country),
+                language=brave_config.get("search_lang", args.language),
+                time_range=args.time_range or args.freshness,
+                safesearch=brave_config.get("safesearch", "moderate"),
             )
         elif prov == "tavily":
             return search_tavily(

--- a/tests/test_brave_provider.py
+++ b/tests/test_brave_provider.py
@@ -1,0 +1,63 @@
+import os
+import unittest
+from unittest import mock
+
+import search
+from search import QueryAnalyzer, get_api_key, validate_api_key
+
+
+class BraveProviderTests(unittest.TestCase):
+    def test_get_api_key_reads_brave_env(self):
+        with mock.patch.dict(os.environ, {"BRAVE_API_KEY": "brave-test-key"}, clear=False):
+            self.assertEqual(get_api_key("brave", {}), "brave-test-key")
+
+    def test_validate_api_key_accepts_brave(self):
+        with mock.patch.dict(os.environ, {"BRAVE_API_KEY": "brave-test-key-12345"}, clear=False):
+            self.assertEqual(validate_api_key("brave", {}), "brave-test-key-12345")
+
+    def test_search_brave_parses_web_results(self):
+        fake_response = {
+            "web": {
+                "results": [
+                    {
+                        "title": "Example result",
+                        "url": "https://example.com/page",
+                        "description": "Example snippet",
+                        "age": "2 days ago",
+                    }
+                ]
+            }
+        }
+        with mock.patch("search.make_get_request", return_value=fake_response):
+            result = search.search_brave(
+                query="example query",
+                api_key="brave-test-key-12345",
+                max_results=5,
+                country="us",
+                language="en",
+                time_range="week",
+            )
+
+        self.assertEqual(result["provider"], "brave")
+        self.assertEqual(result["results"][0]["title"], "Example result")
+        self.assertEqual(result["results"][0]["url"], "https://example.com/page")
+        self.assertEqual(result["results"][0]["snippet"], "Example snippet")
+
+    def test_query_analyzer_can_route_to_brave(self):
+        config = search.DEFAULT_CONFIG.copy()
+        config["auto_routing"] = dict(search.DEFAULT_CONFIG["auto_routing"])
+        config["auto_routing"]["provider_priority"] = ["brave", "serper", "tavily", "querit", "exa", "perplexity", "you", "searxng"]
+        analyzer = QueryAnalyzer(config)
+
+        env = {
+            "BRAVE_API_KEY": "brave-test-key-12345",
+            "SERPER_API_KEY": "serper-test-key-12345",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            routing = analyzer.route("weather in singapore today")
+
+        self.assertIn(routing["provider"], {"brave", "serper"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- register `web_search_plus` under its own `web-search-plus` toolset instead of the built-in `web` toolset
- switch the tool schema from `input_schema` to Hermes/OpenAI-style `parameters`
- add Brave Search as a first-class provider with `BRAVE_API_KEY` support and result parsing
- integrate Brave into autorouting alongside Serper, with deterministic per-query tie-breaking for shared web-search intents
- update README / plugin metadata / env var docs for the new provider and compatibility behavior

## Why
Hermes main resolves built-in toolsets statically, so plugin tools registered into `web` are dropped from the final tool surface. This PR avoids that core limitation without requiring a Hermes patch.

On top of that compatibility fix, this branch also adds Brave Search so the plugin can use a non-Google-backed web search provider instead of relying only on Serper for general web queries.

## Test Plan
- verified the plugin registers successfully with toolset `web-search-plus`
- verified `validate_toolset("web-search-plus")` is true on Hermes main
- verified `resolve_toolset("web-search-plus")` returns `["web_search_plus"]`
- verified combining `web` + `web-search-plus` yields `web_extract`, `web_search`, and `web_search_plus`
- verified the registered schema now exposes `parameters` instead of `input_schema`
- ran `python3 -m py_compile __init__.py search.py tests/test_brave_provider.py`
- ran `python3 -m unittest tests/test_brave_provider.py -v`
