### PR TITLE
Add Firecrawl and Linkup search providers

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,8 +17,11 @@ EXA_API_KEY=
 # Querit (Multilingual AI Search) — https://querit.ai — 1,000 free/month
 QUERIT_API_KEY=
 
+# Linkup (Source-grounded AI search) — https://linkup.so — €5 free credits monthly
+LINKUP_API_KEY=***
+
 # Firecrawl search
-FIRECRAWL_API_KEY=
+FIRECRAWL_API_KEY=***
 
 # Perplexity (via Kilo Gateway) — uses KILOCODE_API_KEY if set
 # PERPLEXITY_API_KEY=

--- a/.env.template
+++ b/.env.template
@@ -17,6 +17,9 @@ EXA_API_KEY=
 # Querit (Multilingual AI Search) — https://querit.ai — 1,000 free/month
 QUERIT_API_KEY=
 
+# Firecrawl search
+FIRECRAWL_API_KEY=
+
 # Perplexity (via Kilo Gateway) — uses KILOCODE_API_KEY if set
 # PERPLEXITY_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_
 ## Features
 
 - **Intelligent auto-routing** — picks the best provider based on query intent
-- **8 providers** — Serper, Brave, Tavily, Exa, Querit, Perplexity, You.com, SearXNG
+- **9 providers** — Serper, Brave, Tavily, Exa, Querit, Firecrawl, Perplexity, You.com, SearXNG
 - **Exa Deep Research** — `depth=deep` for multi-source synthesis, `depth=deep-reasoning` for cross-document analysis
 - **Adaptive fallback** — automatically skips providers on cooldown (1h after failure)
 - **Routing transparency** — every response includes a `routing` object explaining provider choice
@@ -65,6 +65,7 @@ Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_
 | Tavily | Research, deep content, academic | 1,000/mo |
 | Exa | Semantic discovery, "alternatives to X", arxiv | 1,000/mo |
 | Querit | Multilingual, real-time queries | 1,000/mo |
+| Firecrawl | Web search with optional scrape-ready result content | 500 credits/free plan |
 | Perplexity | Direct AI-synthesized answers | API key |
 | You.com | LLM-ready real-time snippets | Limited |
 | SearXNG | Privacy-focused, self-hosted, no API cost | Free |
@@ -103,7 +104,7 @@ SEARXNG_INSTANCE_URL=https://your-instance.example.com
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `query` | string | **required** | The search query |
-| `provider` | string | `"auto"` | Force: `serper`, `brave`, `tavily`, `exa`, `querit`, `perplexity`, `you`, `searxng` |
+| `provider` | string | `"auto"` | Force: `serper`, `brave`, `tavily`, `exa`, `querit`, `firecrawl`, `perplexity`, `you`, `searxng` |
 | `depth` | string | `"normal"` | Exa only: `normal`, `deep`, `deep-reasoning` |
 | `count` | integer | `5` | Results (1–20) |
 | `time_range` | string | — | `day`, `week`, `month`, `year` |
@@ -126,7 +127,10 @@ web_search_plus(query="LLM scaling laws research", provider="exa", depth="deep")
 # → Exa deep synthesis (4–12s)
 
 web_search_plus(query="OpenAI news", time_range="day")
-# → Serper, last 24h
+# → Serper/Brave/Firecrawl, last 24h
+
+web_search_plus(query="YC startups web scraping", provider="firecrawl")
+# → Firecrawl search
 
 web_search_plus(query="LoRA fine-tuning", include_domains=["arxiv.org"])
 # → arxiv only

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_
 ## Features
 
 - **Intelligent auto-routing** — picks the best provider based on query intent
-- **9 providers** — Serper, Brave, Tavily, Exa, Querit, Firecrawl, Perplexity, You.com, SearXNG
+- **10 providers** — Serper, Brave, Tavily, Exa, Querit, Linkup, Firecrawl, Perplexity, You.com, SearXNG
 - **Exa Deep Research** — `depth=deep` for multi-source synthesis, `depth=deep-reasoning` for cross-document analysis
 - **Adaptive fallback** — automatically skips providers on cooldown (1h after failure)
 - **Routing transparency** — every response includes a `routing` object explaining provider choice
@@ -65,6 +65,7 @@ Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_
 | Tavily | Research, deep content, academic | 1,000/mo |
 | Exa | Semantic discovery, "alternatives to X", arxiv | 1,000/mo |
 | Querit | Multilingual, real-time queries | 1,000/mo |
+| Linkup | Source-backed grounding, citations, RAG-ready retrieval | €5 free monthly credits |
 | Firecrawl | Web search with optional scrape-ready result content | 500 credits/free plan |
 | Perplexity | Direct AI-synthesized answers | API key |
 | You.com | LLM-ready real-time snippets | Limited |
@@ -104,7 +105,7 @@ SEARXNG_INSTANCE_URL=https://your-instance.example.com
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `query` | string | **required** | The search query |
-| `provider` | string | `"auto"` | Force: `serper`, `brave`, `tavily`, `exa`, `querit`, `firecrawl`, `perplexity`, `you`, `searxng` |
+| `provider` | string | `"auto"` | Force: `serper`, `brave`, `tavily`, `exa`, `querit`, `linkup`, `firecrawl`, `perplexity`, `you`, `searxng` |
 | `depth` | string | `"normal"` | Exa only: `normal`, `deep`, `deep-reasoning` |
 | `count` | integer | `5` | Results (1–20) |
 | `time_range` | string | — | `day`, `week`, `month`, `year` |
@@ -131,6 +132,9 @@ web_search_plus(query="OpenAI news", time_range="day")
 
 web_search_plus(query="YC startups web scraping", provider="firecrawl")
 # → Firecrawl search
+
+web_search_plus(query="find credible sources and citations for AI tutoring outcomes", provider="linkup")
+# → Linkup source-grounded retrieval
 
 web_search_plus(query="LoRA fine-tuning", include_domains=["arxiv.org"])
 # → arxiv only

--- a/__init__.py
+++ b/__init__.py
@@ -20,6 +20,7 @@ _PROVIDER_ENV_KEYS = [
     "TAVILY_API_KEY",
     "EXA_API_KEY",
     "QUERIT_API_KEY",
+    "FIRECRAWL_API_KEY",
     "PERPLEXITY_API_KEY",
     "YOU_API_KEY",
     "SEARXNG_INSTANCE_URL",
@@ -144,6 +145,7 @@ def register(ctx: Any) -> None:
             "Automatically selects the best provider based on query intent: "
             "Serper for shopping/news/facts, Tavily for research/analysis, "
             "Exa for semantic discovery, Querit for multilingual/real-time, "
+            "Firecrawl for web search plus optional scrape-ready results, "
             "Perplexity for direct answers. "
             "Set depth='deep' for Exa multi-source synthesis, 'deep-reasoning' for complex cross-document analysis. "
             "Override with provider param if needed."
@@ -157,7 +159,7 @@ def register(ctx: Any) -> None:
                 },
                 "provider": {
                     "type": "string",
-                    "enum": ["auto", "serper", "brave", "tavily", "exa", "querit", "perplexity", "you", "searxng"],
+                    "enum": ["auto", "serper", "brave", "tavily", "exa", "querit", "firecrawl", "perplexity", "you", "searxng"],
                     "description": "Search provider. Use 'auto' for intelligent routing (default). Brave and Serper share generic web-search intents and ties are distributed deterministically per query.",
                     "default": "auto",
                 },

--- a/__init__.py
+++ b/__init__.py
@@ -20,6 +20,7 @@ _PROVIDER_ENV_KEYS = [
     "TAVILY_API_KEY",
     "EXA_API_KEY",
     "QUERIT_API_KEY",
+    "LINKUP_API_KEY",
     "FIRECRAWL_API_KEY",
     "PERPLEXITY_API_KEY",
     "YOU_API_KEY",
@@ -145,6 +146,7 @@ def register(ctx: Any) -> None:
             "Automatically selects the best provider based on query intent: "
             "Serper for shopping/news/facts, Tavily for research/analysis, "
             "Exa for semantic discovery, Querit for multilingual/real-time, "
+            "Linkup for source-backed grounding/citations, "
             "Firecrawl for web search plus optional scrape-ready results, "
             "Perplexity for direct answers. "
             "Set depth='deep' for Exa multi-source synthesis, 'deep-reasoning' for complex cross-document analysis. "
@@ -159,7 +161,7 @@ def register(ctx: Any) -> None:
                 },
                 "provider": {
                     "type": "string",
-                    "enum": ["auto", "serper", "brave", "tavily", "exa", "querit", "firecrawl", "perplexity", "you", "searxng"],
+                    "enum": ["auto", "serper", "brave", "tavily", "exa", "querit", "linkup", "firecrawl", "perplexity", "you", "searxng"],
                     "description": "Search provider. Use 'auto' for intelligent routing (default). Brave and Serper share generic web-search intents and ties are distributed deterministically per query.",
                     "default": "auto",
                 },

--- a/search.py
+++ b/search.py
@@ -277,7 +277,7 @@ DEFAULT_CONFIG = {
     "auto_routing": {
         "enabled": True,
         "fallback_provider": "serper",
-        "provider_priority": ["tavily", "querit", "exa", "perplexity", "brave", "serper", "you", "searxng"],
+        "provider_priority": ["tavily", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"],
         "disabled_providers": [],
         "confidence_threshold": 0.3,  # Below this, note low confidence
     },
@@ -308,6 +308,13 @@ DEFAULT_CONFIG = {
     "perplexity": {
         "api_url": "https://api.kilo.ai/api/gateway/chat/completions",
         "model": "perplexity/sonar-pro"
+    },
+    "firecrawl": {
+        "api_url": "https://api.firecrawl.dev/v2/search",
+        "country": "US",
+        "timeout": 30000,
+        "sources": ["web"],
+        "ignore_invalid_urls": False
     },
     "you": {
         "country": "us",
@@ -374,6 +381,7 @@ def get_api_key(provider: str, config: Dict[str, Any] = None) -> Optional[str]:
         "querit": "QUERIT_API_KEY",
         "exa": "EXA_API_KEY",
         "you": "YOU_API_KEY",
+        "firecrawl": "FIRECRAWL_API_KEY",
     }
     return os.environ.get(key_map.get(provider, ""))
 
@@ -493,7 +501,8 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
             "querit": "QUERIT_API_KEY",
             "exa": "EXA_API_KEY",
             "you": "YOU_API_KEY",
-            "perplexity": "KILOCODE_API_KEY"
+            "perplexity": "KILOCODE_API_KEY",
+            "firecrawl": "FIRECRAWL_API_KEY"
         }[provider]
         
         urls = {
@@ -503,7 +512,8 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
             "querit": "https://querit.ai",
             "exa": "https://exa.ai",
             "you": "https://api.you.com",
-            "perplexity": "https://api.kilo.ai"
+            "perplexity": "https://api.kilo.ai",
+            "firecrawl": "https://www.firecrawl.dev/app/api-keys"
         }
         
         error_msg = {
@@ -1185,6 +1195,7 @@ class QueryAnalyzer:
             "perplexity": direct_answer_score + (local_news_score * 0.4) + (recency_score * 0.55),
             "you": rag_score + (recency_score * 0.25),  # You.com good for real-time + RAG
             "searxng": privacy_score,  # SearXNG for privacy/multi-source queries
+            "firecrawl": discovery_score + (research_score * 0.35) + (recency_score * 0.25),
         }
         
         # Build match details per provider
@@ -1197,6 +1208,7 @@ class QueryAnalyzer:
             "perplexity": direct_answer_matches,
             "you": rag_matches,
             "searxng": privacy_matches,
+            "firecrawl": discovery_matches + research_matches,
         }
         
         return {
@@ -1243,7 +1255,7 @@ class QueryAnalyzer:
         total_score = sum(available.values()) or 1.0
         
         # Handle ties using deterministic per-query distribution
-        priority = self.auto_config.get("provider_priority", ["tavily", "querit", "exa", "perplexity", "brave", "serper", "you", "searxng"])
+        priority = self.auto_config.get("provider_priority", ["tavily", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"])
         winners = [p for p, s in available.items() if s == max_score]
         
         if len(winners) > 1:
@@ -1359,6 +1371,7 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             "rag_signals": len(analysis["provider_matches"]["you"]),
             "exa_deep_score": round(analysis.get("exa_deep_score", 0), 2),
             "exa_deep_reasoning_score": round(analysis.get("exa_deep_reasoning_score", 0), 2),
+            "firecrawl_signals": len(analysis["provider_matches"].get("firecrawl", [])),
         },
         "query_analysis": {
             "word_count": analysis["complexity"]["word_count"],
@@ -1376,7 +1389,7 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             if matches
         },
         "available_providers": [
-            p for p in ["serper", "brave", "tavily", "querit", "exa", "perplexity", "you", "searxng"]
+            p for p in ["serper", "brave", "tavily", "querit", "exa", "firecrawl", "perplexity", "you", "searxng"]
             if get_api_key(p, config) and p not in config.get("auto_routing", {}).get("disabled_providers", [])
         ]
     }
@@ -1935,6 +1948,120 @@ def search_querit(
             "search_id": data.get("search_id"),
             "time_range": querit_time_range,
         }
+    }
+
+
+# =============================================================================
+# Firecrawl Search
+# =============================================================================
+
+def _map_firecrawl_time_range(time_range: Optional[str]) -> Optional[str]:
+    """Map generic time ranges to Firecrawl/Google tbs values."""
+    if not time_range:
+        return None
+    return {
+        "hour": "qdr:h",
+        "day": "qdr:d",
+        "week": "qdr:w",
+        "month": "qdr:m",
+        "year": "qdr:y",
+    }.get(time_range, time_range)
+
+
+def search_firecrawl(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    country: str = "US",
+    time_range: Optional[str] = None,
+    sources: Optional[List[str]] = None,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    scrape_markdown: bool = False,
+    ignore_invalid_urls: bool = False,
+    api_url: str = "https://api.firecrawl.dev/v2/search",
+    timeout_ms: int = 30000,
+) -> dict:
+    """Search using Firecrawl's v2 search endpoint."""
+    selected_sources = sources or ["web"]
+    body: Dict[str, Any] = {
+        "query": query,
+        "limit": max_results,
+        "sources": selected_sources,
+        "timeout": timeout_ms,
+        "ignoreInvalidURLs": ignore_invalid_urls,
+    }
+
+    if country:
+        body["country"] = country.upper()
+
+    tbs = _map_firecrawl_time_range(time_range)
+    if tbs:
+        body["tbs"] = tbs
+
+    if include_domains:
+        body["query"] += " " + " ".join(f"site:{domain}" for domain in include_domains)
+    if exclude_domains:
+        body["query"] += " " + " ".join(f"-site:{domain}" for domain in exclude_domains)
+
+    if scrape_markdown:
+        body["scrapeOptions"] = {"formats": ["markdown"]}
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    data = make_request(api_url, headers, body, timeout=max(1, int(timeout_ms / 1000)))
+    if data.get("success") is False:
+        raise ProviderRequestError(data.get("error") or data.get("warning") or "Firecrawl request failed")
+
+    response_data = data.get("data") or {}
+    raw_web = response_data.get("web") or []
+    results = []
+    for i, item in enumerate(raw_web[:max_results]):
+        snippet = item.get("description") or item.get("snippet") or ""
+        result = {
+            "title": item.get("title") or _title_from_url(item.get("url", "")),
+            "url": item.get("url", ""),
+            "snippet": snippet,
+            "score": round(1.0 - i * 0.05, 3),
+        }
+        if item.get("position") is not None:
+            result["position"] = item.get("position")
+        if item.get("category") is not None:
+            result["category"] = item.get("category")
+        if item.get("markdown"):
+            result["raw_content"] = item["markdown"]
+            if not result["snippet"]:
+                result["snippet"] = item["markdown"][:500]
+        metadata = item.get("metadata") or {}
+        if metadata.get("statusCode") is not None:
+            result["status_code"] = metadata.get("statusCode")
+        if metadata.get("error"):
+            result["error"] = metadata.get("error")
+        results.append(result)
+
+    images = []
+    for image in response_data.get("images") or []:
+        image_url = image.get("imageUrl")
+        if image_url:
+            images.append(image_url)
+
+    answer = results[0]["snippet"] if results else ""
+    return {
+        "provider": "firecrawl",
+        "query": query,
+        "results": results,
+        "images": images,
+        "answer": answer,
+        "warning": data.get("warning"),
+        "credits_used": data.get("creditsUsed"),
+        "metadata": {
+            "id": data.get("id"),
+            "sources": selected_sources,
+            "tbs": tbs,
+        },
     }
 
 
@@ -2562,7 +2689,7 @@ Full docs: See README.md and SKILL.md
     # Common arguments
     parser.add_argument(
         "--provider", "-p", 
-        choices=["serper", "brave", "tavily", "querit", "exa", "perplexity", "you", "searxng", "auto"],
+        choices=["serper", "brave", "tavily", "querit", "exa", "firecrawl", "perplexity", "you", "searxng", "auto"],
         help="Search provider (auto=intelligent routing)"
     )
     parser.add_argument(
@@ -2665,6 +2792,21 @@ Full docs: See README.md and SKILL.md
     parser.add_argument("--start-date")
     parser.add_argument("--end-date")
     parser.add_argument("--similar-url")
+
+    # Firecrawl-specific
+    firecrawl_config = config.get("firecrawl", {})
+    parser.add_argument(
+        "--firecrawl-scrape",
+        action="store_true",
+        help="Firecrawl: scrape result pages and include markdown as raw_content"
+    )
+    parser.add_argument(
+        "--firecrawl-sources",
+        nargs="+",
+        default=firecrawl_config.get("sources", ["web"]),
+        choices=["web", "news", "images"],
+        help="Firecrawl result sources"
+    )
     
     # You.com-specific
     you_config = config.get("you", {})
@@ -2802,7 +2944,7 @@ Full docs: See README.md and SKILL.md
     
     # Build provider fallback list
     auto_config = config.get("auto_routing", {})
-    provider_priority = auto_config.get("provider_priority", ["tavily", "querit", "exa", "perplexity", "brave", "serper", "you", "searxng"])
+    provider_priority = auto_config.get("provider_priority", ["tavily", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"])
     disabled_providers = auto_config.get("disabled_providers", [])
 
     # Start with the selected provider, then try others in priority order
@@ -2895,6 +3037,22 @@ Full docs: See README.md and SKILL.md
                 include_domains=args.include_domains,
                 exclude_domains=args.exclude_domains,
                 text_verbosity=args.exa_verbosity,
+            )
+        elif prov == "firecrawl":
+            firecrawl_config = config.get("firecrawl", {})
+            return search_firecrawl(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                country=firecrawl_config.get("country", args.country),
+                time_range=args.time_range or args.freshness,
+                sources=args.firecrawl_sources,
+                include_domains=args.include_domains,
+                exclude_domains=args.exclude_domains,
+                scrape_markdown=args.firecrawl_scrape or args.raw_content,
+                ignore_invalid_urls=firecrawl_config.get("ignore_invalid_urls", False),
+                api_url=firecrawl_config.get("api_url", "https://api.firecrawl.dev/v2/search"),
+                timeout_ms=int(firecrawl_config.get("timeout", 30000)),
             )
         elif prov == "perplexity":
             perplexity_config = config.get("perplexity", {})

--- a/search.py
+++ b/search.py
@@ -246,9 +246,14 @@ def cache_stats() -> Dict[str, Any]:
 # Auto-load .env from skill directory (if exists)
 # =============================================================================
 def _load_env_file():
-    """Load .env file from skill root directory if it exists."""
-    env_path = Path(__file__).parent.parent / ".env"
-    if env_path.exists():
+    """Load .env files from plugin-local and legacy parent locations."""
+    env_paths = [
+        Path(__file__).parent / ".env",
+        Path(__file__).parent.parent / ".env",
+    ]
+    for env_path in env_paths:
+        if not env_path.exists():
+            continue
         with open(env_path) as f:
             for line in f:
                 line = line.strip()

--- a/search.py
+++ b/search.py
@@ -277,7 +277,7 @@ DEFAULT_CONFIG = {
     "auto_routing": {
         "enabled": True,
         "fallback_provider": "serper",
-        "provider_priority": ["tavily", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"],
+        "provider_priority": ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"],
         "disabled_providers": [],
         "confidence_threshold": 0.3,  # Below this, note low confidence
     },
@@ -299,6 +299,12 @@ DEFAULT_CONFIG = {
         "base_url": "https://api.querit.ai",
         "base_path": "/v1/search",
         "timeout": 10
+    },
+    "linkup": {
+        "api_url": "https://api.linkup.so/v1/search",
+        "depth": "standard",
+        "output_type": "searchResults",
+        "timeout": 30
     },
     "exa": {
         "type": "neural",
@@ -379,6 +385,7 @@ def get_api_key(provider: str, config: Dict[str, Any] = None) -> Optional[str]:
         "brave": "BRAVE_API_KEY",
         "tavily": "TAVILY_API_KEY",
         "querit": "QUERIT_API_KEY",
+        "linkup": "LINKUP_API_KEY",
         "exa": "EXA_API_KEY",
         "you": "YOU_API_KEY",
         "firecrawl": "FIRECRAWL_API_KEY",
@@ -499,6 +506,7 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
             "brave": "BRAVE_API_KEY",
             "tavily": "TAVILY_API_KEY",
             "querit": "QUERIT_API_KEY",
+            "linkup": "LINKUP_API_KEY",
             "exa": "EXA_API_KEY",
             "you": "YOU_API_KEY",
             "perplexity": "KILOCODE_API_KEY",
@@ -510,6 +518,7 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
             "brave": "https://brave.com/search/api/",
             "tavily": "https://tavily.com",
             "querit": "https://querit.ai",
+            "linkup": "https://app.linkup.so",
             "exa": "https://exa.ai",
             "you": "https://api.you.com",
             "perplexity": "https://api.kilo.ai",
@@ -792,6 +801,30 @@ class QueryAnalyzer:
         r'\bnachrichten\b': 3.0,
     }
     
+    # Source-grounded/RAG retrieval signals → Linkup
+    # Linkup is strongest when the user wants source-backed evidence for LLM grounding.
+    LINKUP_SOURCE_SIGNALS = {
+        r'\bcitations?\b': 5.0,
+        r'\bsources?\b': 4.5,
+        r'\bsource.?backed\b': 5.0,
+        r'\bwith sources\b': 5.0,
+        r'\bwith references\b': 5.0,
+        r'\breferences?\b': 4.5,
+        r'\bevidence\b': 4.5,
+        r'\bcredible sources?\b': 5.5,
+        r'\bprimary sources?\b': 5.0,
+        r'\bsupporting links?\b': 4.5,
+        r'\bverify (this|the)?\b': 4.5,
+        r'\bfact.?check\b': 5.0,
+        r'\bground(ed|ing)?\b': 4.5,
+        r'\bground this\b': 5.0,
+        r'\bclaim\b': 2.5,
+        r'\bfind (credible )?sources?\b': 5.5,
+        r'\bfind pages? that support\b': 5.0,
+        r'\bwhere did this come from\b': 5.0,
+        r'\bsource material\b': 4.0,
+    }
+
     # RAG/AI signals → You.com
     # You.com excels at providing LLM-ready snippets and combined web+news
     RAG_SIGNALS = {
@@ -1142,6 +1175,9 @@ class QueryAnalyzer:
         privacy_score, privacy_matches = self._calculate_signal_score(
             query, self.PRIVACY_SIGNALS
         )
+        linkup_source_score, linkup_source_matches = self._calculate_signal_score(
+            query, self.LINKUP_SOURCE_SIGNALS
+        )
         direct_answer_score, direct_answer_matches = self._calculate_signal_score(
             query, self.DIRECT_ANSWER_SIGNALS
         )
@@ -1191,6 +1227,7 @@ class QueryAnalyzer:
             "brave": shopping_score + local_news_score + (recency_score * 0.35),
             "tavily": research_score + (complexity["complexity_score"] if not complexity["is_complex"] else 0) + (0.2 * recency_score),
             "querit": (research_score * 0.65) + (rag_score * 0.35) + (recency_score * 0.45),
+            "linkup": linkup_source_score + (rag_score * 0.7) + (research_score * 0.45) + (recency_score * 0.35),
             "exa": discovery_score + (1.0 if re.search(r"\b(similar|alternatives?|examples?)\b", query, re.IGNORECASE) else 0.0) + (exa_deep_score * 0.5) + (exa_deep_reasoning_score * 0.5),
             "perplexity": direct_answer_score + (local_news_score * 0.4) + (recency_score * 0.55),
             "you": rag_score + (recency_score * 0.25),  # You.com good for real-time + RAG
@@ -1204,6 +1241,7 @@ class QueryAnalyzer:
             "brave": shopping_matches + local_news_matches,
             "tavily": research_matches,
             "querit": research_matches,
+            "linkup": linkup_source_matches + rag_matches + research_matches,
             "exa": discovery_matches + exa_deep_matches + exa_deep_reasoning_matches,
             "perplexity": direct_answer_matches,
             "you": rag_matches,
@@ -1219,6 +1257,7 @@ class QueryAnalyzer:
             "complexity": complexity,
             "recency_focused": is_recency,
             "recency_score": recency_score,
+            "linkup_source_score": linkup_source_score,
             "exa_deep_score": exa_deep_score,
             "exa_deep_reasoning_score": exa_deep_reasoning_score,
         }
@@ -1255,7 +1294,7 @@ class QueryAnalyzer:
         total_score = sum(available.values()) or 1.0
         
         # Handle ties using deterministic per-query distribution
-        priority = self.auto_config.get("provider_priority", ["tavily", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"])
+        priority = self.auto_config.get("provider_priority", ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"])
         winners = [p for p, s in available.items() if s == max_score]
         
         if len(winners) > 1:
@@ -1367,6 +1406,8 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             "brave_signals": len(analysis["provider_matches"]["brave"]),
             "research_signals": len(analysis["provider_matches"]["tavily"]),
             "querit_signals": len(analysis["provider_matches"]["querit"]),
+            "linkup_signals": len(analysis["provider_matches"].get("linkup", [])),
+            "linkup_source_score": round(analysis.get("linkup_source_score", 0), 2),
             "discovery_signals": len(analysis["provider_matches"]["exa"]),
             "rag_signals": len(analysis["provider_matches"]["you"]),
             "exa_deep_score": round(analysis.get("exa_deep_score", 0), 2),
@@ -1389,7 +1430,7 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             if matches
         },
         "available_providers": [
-            p for p in ["serper", "brave", "tavily", "querit", "exa", "firecrawl", "perplexity", "you", "searxng"]
+            p for p in ["serper", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "you", "searxng"]
             if get_api_key(p, config) and p not in config.get("auto_routing", {}).get("disabled_providers", [])
         ]
     }
@@ -1948,6 +1989,70 @@ def search_querit(
             "search_id": data.get("search_id"),
             "time_range": querit_time_range,
         }
+    }
+
+
+# =============================================================================
+# Linkup Search
+# =============================================================================
+
+def search_linkup(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    depth: str = "standard",
+    output_type: str = "searchResults",
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    api_url: str = "https://api.linkup.so/v1/search",
+    timeout: int = 30,
+) -> dict:
+    """Search using Linkup's source-grounded web search API."""
+    body: Dict[str, Any] = {
+        "q": query,
+        "depth": depth,
+        "outputType": output_type,
+    }
+    if include_domains:
+        body["includeDomains"] = include_domains[:50]
+    if exclude_domains:
+        body["excludeDomains"] = exclude_domains[:50]
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    data = make_request(api_url, headers, body, timeout=timeout)
+    if data.get("error"):
+        raise ProviderRequestError(str(data.get("error")))
+
+    raw_results = data.get("results") or data.get("sources") or []
+    results = []
+    for i, item in enumerate(raw_results[:max_results]):
+        snippet = item.get("content") or item.get("snippet") or item.get("description") or ""
+        result = {
+            "title": item.get("name") or item.get("title") or _title_from_url(item.get("url", "")),
+            "url": item.get("url", ""),
+            "snippet": snippet,
+            "score": round(1.0 - i * 0.05, 3),
+        }
+        if item.get("type") is not None:
+            result["type"] = item["type"]
+        if item.get("favicon") is not None:
+            result["favicon"] = item["favicon"]
+        results.append(result)
+
+    return {
+        "provider": "linkup",
+        "query": query,
+        "results": results,
+        "images": data.get("images", []),
+        "answer": data.get("answer", ""),
+        "metadata": {
+            "depth": depth,
+            "output_type": output_type,
+        },
     }
 
 
@@ -2689,7 +2794,7 @@ Full docs: See README.md and SKILL.md
     # Common arguments
     parser.add_argument(
         "--provider", "-p", 
-        choices=["serper", "brave", "tavily", "querit", "exa", "firecrawl", "perplexity", "you", "searxng", "auto"],
+        choices=["serper", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "you", "searxng", "auto"],
         help="Search provider (auto=intelligent routing)"
     )
     parser.add_argument(
@@ -2760,6 +2865,21 @@ Full docs: See README.md and SKILL.md
         "--querit-base-path",
         default=querit_config.get("base_path", "/v1/search"),
         help="Querit API path"
+    )
+
+    # Linkup-specific
+    linkup_config = config.get("linkup", {})
+    parser.add_argument(
+        "--linkup-depth",
+        default=linkup_config.get("depth", "standard"),
+        choices=["fast", "standard", "deep"],
+        help="Linkup search depth: fast, standard, or deep"
+    )
+    parser.add_argument(
+        "--linkup-output-type",
+        default=linkup_config.get("output_type", "searchResults"),
+        choices=["searchResults", "sourcedAnswer"],
+        help="Linkup output type"
     )
 
     # Exa-specific
@@ -2944,7 +3064,7 @@ Full docs: See README.md and SKILL.md
     
     # Build provider fallback list
     auto_config = config.get("auto_routing", {})
-    provider_priority = auto_config.get("provider_priority", ["tavily", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"])
+    provider_priority = auto_config.get("provider_priority", ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"])
     disabled_providers = auto_config.get("disabled_providers", [])
 
     # Start with the selected provider, then try others in priority order
@@ -3004,6 +3124,19 @@ Full docs: See README.md and SKILL.md
                 exclude_domains=args.exclude_domains,
                 include_images=args.images,
                 include_raw_content=args.raw_content,
+            )
+        elif prov == "linkup":
+            linkup_config = config.get("linkup", {})
+            return search_linkup(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                depth=args.linkup_depth,
+                output_type=args.linkup_output_type,
+                include_domains=args.include_domains,
+                exclude_domains=args.exclude_domains,
+                api_url=linkup_config.get("api_url", "https://api.linkup.so/v1/search"),
+                timeout=int(linkup_config.get("timeout", 30)),
             )
         elif prov == "querit":
             return search_querit(

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import search
+
+
+class EnvLoadingTests(unittest.TestCase):
+    def test_load_env_file_reads_plugin_local_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "web-search-plus"
+            plugin_dir.mkdir()
+            fake_script = plugin_dir / "search.py"
+            fake_script.write_text("# fake")
+            (plugin_dir / ".env").write_text("LINKUP_API_KEY=local-plugin-key\n")
+
+            with mock.patch.object(search, "__file__", str(fake_script)):
+                with mock.patch.dict(os.environ, {}, clear=True):
+                    search._load_env_file()
+                    self.assertEqual(os.environ.get("LINKUP_API_KEY"), "local-plugin-key")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_firecrawl_provider.py
+++ b/tests/test_firecrawl_provider.py
@@ -1,0 +1,58 @@
+import os
+import unittest
+from unittest import mock
+
+import search
+from search import get_api_key, validate_api_key
+
+
+class FirecrawlProviderTests(unittest.TestCase):
+    def test_get_api_key_reads_firecrawl_env(self):
+        with mock.patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test-key"}, clear=False):
+            self.assertEqual(get_api_key("firecrawl", {}), "fc-test-key")
+
+    def test_validate_api_key_accepts_firecrawl(self):
+        with mock.patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test-key-12345"}, clear=False):
+            self.assertEqual(validate_api_key("firecrawl", {}), "fc-test-key-12345")
+
+    def test_search_firecrawl_parses_web_results(self):
+        fake_response = {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "Example result",
+                        "url": "https://example.com/page",
+                        "description": "Example snippet",
+                        "position": 1,
+                    }
+                ]
+            },
+            "creditsUsed": 1,
+        }
+        with mock.patch("search.make_request", return_value=fake_response) as mock_request:
+            result = search.search_firecrawl(
+                query="example query",
+                api_key="fc-test-key-12345",
+                max_results=5,
+                country="US",
+                time_range="week",
+            )
+
+        self.assertEqual(result["provider"], "firecrawl")
+        self.assertEqual(result["results"][0]["title"], "Example result")
+        self.assertEqual(result["results"][0]["url"], "https://example.com/page")
+        self.assertEqual(result["results"][0]["snippet"], "Example snippet")
+        self.assertEqual(result["credits_used"], 1)
+
+        _, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(headers["Authorization"], "Bearer fc-test-key-12345")
+        self.assertEqual(body["query"], "example query")
+        self.assertEqual(body["limit"], 5)
+        self.assertEqual(body["sources"], ["web"])
+        self.assertEqual(body["country"], "US")
+        self.assertEqual(body["tbs"], "qdr:w")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_linkup_provider.py
+++ b/tests/test_linkup_provider.py
@@ -1,0 +1,92 @@
+import os
+import unittest
+from unittest import mock
+
+import search
+from search import get_api_key, validate_api_key
+
+
+class LinkupProviderTests(unittest.TestCase):
+    def test_get_api_key_reads_linkup_env(self):
+        with mock.patch.dict(os.environ, {"LINKUP_API_KEY": "linkup-test-key"}, clear=False):
+            self.assertEqual(get_api_key("linkup", {}), "linkup-test-key")
+
+    def test_validate_api_key_accepts_linkup(self):
+        with mock.patch.dict(os.environ, {"LINKUP_API_KEY": "linkup-test-key-12345"}, clear=False):
+            self.assertEqual(validate_api_key("linkup", {}), "linkup-test-key-12345")
+
+    def test_search_linkup_parses_search_results(self):
+        fake_response = {
+            "results": [
+                {
+                    "name": "Evidence source",
+                    "url": "https://example.com/evidence",
+                    "content": "Useful evidence snippet",
+                    "type": "text",
+                    "favicon": "https://example.com/favicon.ico",
+                }
+            ]
+        }
+        with mock.patch("search.make_request", return_value=fake_response) as mock_request:
+            result = search.search_linkup(
+                query="find credible sources for AI tutoring outcomes",
+                api_key="linkup-test-key-12345",
+                max_results=5,
+                depth="standard",
+                output_type="searchResults",
+                include_domains=["example.com"],
+                exclude_domains=["wikipedia.org"],
+            )
+
+        self.assertEqual(result["provider"], "linkup")
+        self.assertEqual(result["results"][0]["title"], "Evidence source")
+        self.assertEqual(result["results"][0]["url"], "https://example.com/evidence")
+        self.assertEqual(result["results"][0]["snippet"], "Useful evidence snippet")
+        self.assertEqual(result["results"][0]["type"], "text")
+
+        _, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(headers["Authorization"], "Bearer linkup-test-key-12345")
+        self.assertEqual(body["q"], "find credible sources for AI tutoring outcomes")
+        self.assertEqual(body["depth"], "standard")
+        self.assertEqual(body["outputType"], "searchResults")
+        self.assertEqual(body["includeDomains"], ["example.com"])
+        self.assertEqual(body["excludeDomains"], ["wikipedia.org"])
+
+    def test_search_linkup_parses_sourced_answer(self):
+        fake_response = {
+            "answer": "The claim is supported by current studies.",
+            "sources": [
+                {
+                    "name": "Study source",
+                    "url": "https://example.org/study",
+                    "snippet": "A relevant study snippet",
+                }
+            ],
+        }
+        with mock.patch("search.make_request", return_value=fake_response):
+            result = search.search_linkup(
+                query="fact check AI tutoring outcomes with citations",
+                api_key="linkup-test-key-12345",
+                output_type="sourcedAnswer",
+            )
+
+        self.assertEqual(result["answer"], "The claim is supported by current studies.")
+        self.assertEqual(result["results"][0]["title"], "Study source")
+        self.assertEqual(result["results"][0]["snippet"], "A relevant study snippet")
+
+    def test_auto_router_prefers_linkup_for_source_grounding_queries(self):
+        config = {
+            "auto_routing": {"provider_priority": ["linkup", "tavily", "exa", "serper"]},
+        }
+        with mock.patch.dict(os.environ, {"LINKUP_API_KEY": "linkup-test-key"}, clear=False):
+            routing = search.auto_route_provider(
+                "find credible sources and citations to verify this claim",
+                config,
+            )
+
+        self.assertEqual(routing["provider"], "linkup")
+        self.assertGreater(routing["scores"]["linkup"], routing["scores"].get("tavily", 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add Firecrawl provider using the v2 search endpoint
- Add Linkup provider for source-backed grounding/citation-oriented retrieval
- Add autorouter scoring and provider priority entries for both providers
- Add CLI flags for Firecrawl scrape/source options and Linkup depth/output type
- Add FIRECRAWL_API_KEY and LINKUP_API_KEY support
- Load plugin-local .env from search.py for direct CLI usage
- Update README and .env.template

## Verification
- python3 -m py_compile search.py __init__.py
- python3 -m pytest -q
- Live Linkup smoke test succeeded locally
- Live Firecrawl smoke test succeeded locally

## Notes
- Runtime still needs restart/reload after install so plugin schema/env refreshes.