### PR TITLE
feat: add web extract plus providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ tools:
     - web-search-plus
 ```
 
-Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_search_plus`.
+Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use the plugin tools:
+
+- `web_search_plus` — multi-provider web search and auto-routing
+- `web_extract_plus` — provider-specific URL extraction via Firecrawl, Linkup, or Tavily
+
+Both tools are exposed by the `web-search-plus` toolset; enabling `web-search-plus` enables both.
 
 ---
 
@@ -52,6 +57,7 @@ Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use `web_
 - **Adaptive fallback** — automatically skips providers on cooldown (1h after failure)
 - **Routing transparency** — every response includes a `routing` object explaining provider choice
 - **Time & domain filtering** — `time_range`, `include_domains`, `exclude_domains`
+- **URL extraction** — `web_extract_plus` extracts clean content via Firecrawl, Linkup, or Tavily
 - **Local caching** — avoids duplicate API calls (1h TTL)
 
 ---
@@ -87,8 +93,10 @@ TAVILY_API_KEY=***        # https://tavily.com — 1,000 free/mo
 EXA_API_KEY=***           # https://exa.ai — 1,000 free/mo
 
 # Optional
-QUERIT_API_KEY=your-key        # https://querit.ai
-PERPLEXITY_API_KEY=your-key    # https://perplexity.ai/settings/api
+QUERIT_API_KEY=***        # https://querit.ai
+LINKUP_API_KEY=***        # https://linkup.so — source-backed search + fetch
+FIRECRAWL_API_KEY=***     # https://firecrawl.dev — search + scrape/extract
+PERPLEXITY_API_KEY=***    # https://perplexity.ai/settings/api
 KILOCODE_API_KEY=your-key      # Perplexity via Kilo Gateway fallback
 YOU_API_KEY=your-key           # https://api.you.com
 SEARXNG_INSTANCE_URL=https://your-instance.example.com
@@ -109,10 +117,25 @@ SEARXNG_INSTANCE_URL=https://your-instance.example.com
 | `depth` | string | `"normal"` | Exa only: `normal`, `deep`, `deep-reasoning` |
 | `count` | integer | `5` | Results (1–20) |
 | `time_range` | string | — | `day`, `week`, `month`, `year` |
-| `include_domains` | array | — | Whitelist: `["arxiv.org"]` |
-| `exclude_domains` | array | — | Blacklist: `["reddit.com"]` |
+| `include_domains` | string[] | — | Restrict search to domains |
+| `exclude_domains` | string[] | — | Exclude domains |
 
-### Examples
+### `web_extract_plus`
+
+Extract content from specific URLs using provider-specific extraction backends.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `urls` | string[] | **required** | URLs to extract |
+| `provider` | string | `"auto"` | Force: `firecrawl`, `linkup`, `tavily` |
+| `format` | string | `"markdown"` | `markdown` or `html` |
+| `include_images` | boolean | `false` | Include image metadata when supported |
+| `include_raw_html` | boolean | `false` | Include raw HTML when supported |
+| `render_js` | boolean | `false` | Render JavaScript before extraction when supported |
+
+Auto extraction currently tries Firecrawl, then Linkup, then Tavily when keys are available.
+
+Examples:
 
 ```python
 web_search_plus(query="Graz weather today")
@@ -135,6 +158,12 @@ web_search_plus(query="YC startups web scraping", provider="firecrawl")
 
 web_search_plus(query="find credible sources and citations for AI tutoring outcomes", provider="linkup")
 # → Linkup source-grounded retrieval
+
+web_extract_plus(urls=["https://example.com"], provider="firecrawl")
+# → Extract clean markdown from a URL
+
+web_extract_plus(urls=["https://docs.linkup.so"], provider="linkup", render_js=False)
+# → Linkup fetch endpoint
 
 web_search_plus(query="LoRA fine-tuning", include_domains=["arxiv.org"])
 # → arxiv only

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tools:
 Finally restart Hermes (or `/restart` + `/reset` in gateway chats) and use the plugin tools:
 
 - `web_search_plus` — multi-provider web search and auto-routing
-- `web_extract_plus` — provider-specific URL extraction via Firecrawl, Linkup, or Tavily
+- `web_extract_plus` — provider-specific URL extraction via Firecrawl, Linkup, Tavily, Exa, or You.com
 
 Both tools are exposed by the `web-search-plus` toolset; enabling `web-search-plus` enables both.
 
@@ -57,7 +57,7 @@ Both tools are exposed by the `web-search-plus` toolset; enabling `web-search-pl
 - **Adaptive fallback** — automatically skips providers on cooldown (1h after failure)
 - **Routing transparency** — every response includes a `routing` object explaining provider choice
 - **Time & domain filtering** — `time_range`, `include_domains`, `exclude_domains`
-- **URL extraction** — `web_extract_plus` extracts clean content via Firecrawl, Linkup, or Tavily
+- **URL extraction** — `web_extract_plus` extracts clean content via Firecrawl, Linkup, Tavily, Exa, or You.com
 - **Local caching** — avoids duplicate API calls (1h TTL)
 
 ---
@@ -127,13 +127,13 @@ Extract content from specific URLs using provider-specific extraction backends.
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `urls` | string[] | **required** | URLs to extract |
-| `provider` | string | `"auto"` | Force: `firecrawl`, `linkup`, `tavily` |
+| `provider` | string | `"auto"` | Force: `firecrawl`, `linkup`, `tavily`, `exa`, `you` |
 | `format` | string | `"markdown"` | `markdown` or `html` |
 | `include_images` | boolean | `false` | Include image metadata when supported |
 | `include_raw_html` | boolean | `false` | Include raw HTML when supported |
 | `render_js` | boolean | `false` | Render JavaScript before extraction when supported |
 
-Auto extraction currently tries Firecrawl, then Linkup, then Tavily when keys are available.
+Auto extraction currently tries Firecrawl, then Linkup, Tavily, Exa, and You.com when keys are available.
 
 Examples:
 

--- a/__init__.py
+++ b/__init__.py
@@ -99,6 +99,49 @@ def _run_search(
         return {"error": str(e), "provider": provider, "query": query, "results": []}
 
 
+def _run_extract(
+    urls: List[str],
+    provider: str = "auto",
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+) -> dict:
+    """Call search.py extract mode and return parsed JSON result."""
+    cmd = [
+        sys.executable,
+        str(_SEARCH_SCRIPT),
+        "--extract-urls",
+        *urls,
+        "--provider",
+        provider,
+        "--format",
+        output_format,
+        "--compact",
+    ]
+    if include_images:
+        cmd.append("--extract-images")
+    if include_raw_html:
+        cmd.append("--include-raw-html")
+    if render_js:
+        cmd.append("--render-js")
+
+    env = os.environ.copy()
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=90, env=env)
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            try:
+                return json.loads(stderr)
+            except json.JSONDecodeError:
+                return {"error": stderr or "Extract failed", "provider": provider, "results": []}
+        return json.loads(result.stdout)
+    except subprocess.TimeoutExpired:
+        return {"error": "Extract timed out after 90s", "provider": provider, "results": []}
+    except Exception as e:
+        return {"error": str(e), "provider": provider, "results": []}
+
+
 def _format_results(data: dict) -> str:
     """Format search results for LLM consumption."""
     if "error" in data and not data.get("results"):
@@ -133,6 +176,26 @@ def _format_results(data: dict) -> str:
             lines.append(f"   {snippet}")
         lines.append("")
 
+    return "\n".join(lines).strip()
+
+
+def _format_extract_results(data: dict) -> str:
+    """Format extracted URL content for LLM consumption."""
+    if "error" in data and not data.get("results"):
+        return f"Extract error: {data['error']}"
+    provider = data.get("provider", "unknown")
+    lines = [f"[Provider: {provider}]"]
+    for i, r in enumerate(data.get("results", []), 1):
+        title = r.get("title") or "No title"
+        url = r.get("url", "")
+        content = r.get("content") or r.get("raw_content") or ""
+        lines.append(f"\n{i}. {title}")
+        if url:
+            lines.append(url)
+        if r.get("error"):
+            lines.append(f"Error: {r['error']}")
+        elif content:
+            lines.append(content)
     return "\n".join(lines).strip()
 
 
@@ -236,4 +299,59 @@ def register(ctx: Any) -> None:
         requires_env=[],
         description="Multi-provider web search with intelligent auto-routing",
         emoji="🔍",
+    )
+
+    extract_schema = {
+        "name": "web_extract_plus",
+        "description": (
+            "Multi-provider URL content extraction. Use Firecrawl for robust scraping, "
+            "Linkup for clean markdown fetches with monthly free credits, or Tavily for extraction."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "urls": {"type": "array", "items": {"type": "string"}, "description": "URLs to extract"},
+                "provider": {"type": "string", "enum": ["auto", "firecrawl", "linkup", "tavily"], "default": "auto"},
+                "format": {"type": "string", "enum": ["markdown", "html"], "default": "markdown"},
+                "include_images": {"type": "boolean", "default": False},
+                "include_raw_html": {"type": "boolean", "default": False},
+                "render_js": {"type": "boolean", "default": False},
+            },
+            "required": ["urls"],
+        },
+    }
+
+    def extract_handler(args_or_urls, provider: str = "auto", format: str = "markdown",
+                        include_images: bool = False, include_raw_html: bool = False,
+                        render_js: bool = False, **kwargs) -> str:
+        if isinstance(args_or_urls, dict):
+            urls = args_or_urls.get("urls", [])
+            provider = args_or_urls.get("provider", provider)
+            format = args_or_urls.get("format", format)
+            include_images = args_or_urls.get("include_images", include_images)
+            include_raw_html = args_or_urls.get("include_raw_html", include_raw_html)
+            render_js = args_or_urls.get("render_js", render_js)
+        else:
+            urls = args_or_urls
+        if isinstance(urls, str):
+            urls = [urls]
+        data = _run_extract(
+            urls=urls,
+            provider=provider,
+            output_format=format,
+            include_images=include_images,
+            include_raw_html=include_raw_html,
+            render_js=render_js,
+        )
+        return _format_extract_results(data)
+
+    ctx.register_tool(
+        name="web_extract_plus",
+        toolset=_TOOLSET_NAME,
+        schema=extract_schema,
+        handler=extract_handler,
+        check_fn=check_fn,
+        requires_env=[],
+        description="Multi-provider URL extraction",
+        emoji="📄",
     )

--- a/__init__.py
+++ b/__init__.py
@@ -26,6 +26,13 @@ _PROVIDER_ENV_KEYS = [
     "YOU_API_KEY",
     "SEARXNG_INSTANCE_URL",
 ]
+_EXTRACT_PROVIDER_ENV_KEYS = [
+    "FIRECRAWL_API_KEY",
+    "LINKUP_API_KEY",
+    "TAVILY_API_KEY",
+    "EXA_API_KEY",
+    "YOU_API_KEY",
+]
 
 
 def _load_plugin_env() -> None:
@@ -287,8 +294,12 @@ def register(ctx: Any) -> None:
         return _format_results(data)
 
     def check_fn() -> bool:
-        """Plugin is available if at least one provider credential is configured."""
+        """Search is available if at least one search provider credential is configured."""
         return any(os.environ.get(k) for k in _PROVIDER_ENV_KEYS)
+
+    def extract_check_fn() -> bool:
+        """Extraction is available if at least one extraction-capable provider credential is configured."""
+        return any(os.environ.get(k) for k in _EXTRACT_PROVIDER_ENV_KEYS)
 
     ctx.register_tool(
         name="web_search_plus",
@@ -350,7 +361,7 @@ def register(ctx: Any) -> None:
         toolset=_TOOLSET_NAME,
         schema=extract_schema,
         handler=extract_handler,
-        check_fn=check_fn,
+        check_fn=extract_check_fn,
         requires_env=[],
         description="Multi-provider URL extraction",
         emoji="📄",

--- a/__init__.py
+++ b/__init__.py
@@ -305,13 +305,13 @@ def register(ctx: Any) -> None:
         "name": "web_extract_plus",
         "description": (
             "Multi-provider URL content extraction. Use Firecrawl for robust scraping, "
-            "Linkup for clean markdown fetches with monthly free credits, or Tavily for extraction."
+            "Linkup for clean markdown fetches with monthly free credits, Tavily for extraction, Exa Contents, or You.com Contents."
         ),
         "parameters": {
             "type": "object",
             "properties": {
                 "urls": {"type": "array", "items": {"type": "string"}, "description": "URLs to extract"},
-                "provider": {"type": "string", "enum": ["auto", "firecrawl", "linkup", "tavily"], "default": "auto"},
+                "provider": {"type": "string", "enum": ["auto", "firecrawl", "linkup", "tavily", "exa", "you"], "default": "auto"},
                 "format": {"type": "string", "enum": ["markdown", "html"], "default": "markdown"},
                 "include_images": {"type": "boolean", "default": False},
                 "include_raw_html": {"type": "boolean", "default": False},

--- a/search.py
+++ b/search.py
@@ -2317,7 +2317,85 @@ def extract_tavily(
     return {"provider": "tavily", "results": results}
 
 
-EXTRACT_PROVIDER_PRIORITY = ["firecrawl", "linkup", "tavily"]
+def extract_exa(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://api.exa.ai/contents",
+    timeout: int = 30,
+) -> dict:
+    """Extract URL content using Exa Contents API."""
+    headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+    body: Dict[str, Any] = {"urls": urls, "text": True}
+    data = make_request(api_url, headers, body, timeout=timeout)
+    results: List[Dict[str, Any]] = []
+    for item in data.get("results", []):
+        url = item.get("url") or item.get("id") or ""
+        content = item.get("text") or item.get("summary") or ""
+        results.append(_normalize_extract_result(
+            "exa",
+            url,
+            title=item.get("title", ""),
+            content=content,
+            raw_content=content,
+            summary=item.get("summary"),
+            highlights=item.get("highlights"),
+            published_date=item.get("publishedDate"),
+            author=item.get("author"),
+            image=item.get("image") if include_images else None,
+            favicon=item.get("favicon"),
+        ))
+    return {
+        "provider": "exa",
+        "results": results,
+        "request_id": data.get("requestId"),
+        "cost_dollars": data.get("costDollars"),
+        "statuses": data.get("statuses"),
+    }
+
+
+def extract_you(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://ydc-index.io/v1/contents",
+    timeout: int = 30,
+) -> dict:
+    """Extract URL content using You.com Contents API."""
+    formats = ["html" if output_format == "html" else "markdown"]
+    if include_raw_html and "html" not in formats:
+        formats.append("html")
+    if "metadata" not in formats:
+        formats.append("metadata")
+    headers = {"X-API-Key": api_key, "Content-Type": "application/json"}
+    body = {"urls": urls, "formats": formats, "crawl_timeout": max(1, min(timeout, 60))}
+    data = make_request(api_url, headers, body, timeout=timeout)
+    raw_items = data if isinstance(data, list) else data.get("results", []) or data.get("data", [])
+    results: List[Dict[str, Any]] = []
+    for item in raw_items:
+        url = item.get("url", "")
+        markdown = item.get("markdown") or ""
+        html = item.get("html") or ""
+        content = html if output_format == "html" else markdown or html
+        results.append(_normalize_extract_result(
+            "you",
+            url,
+            title=item.get("title", ""),
+            content=content,
+            raw_content=content,
+            raw_html=html if html else None,
+            metadata=item.get("metadata"),
+        ))
+    return {"provider": "you", "results": results}
+
+
+EXTRACT_PROVIDER_PRIORITY = ["firecrawl", "linkup", "tavily", "exa", "you"]
 
 
 def extract_plus(
@@ -2349,9 +2427,15 @@ def extract_plus(
             elif prov == "linkup":
                 lu = config.get("linkup", {})
                 result = extract_linkup(urls, key, output_format, include_images, include_raw_html, render_js, api_url=lu.get("fetch_url", "https://api.linkup.so/v1/fetch"), timeout=int(lu.get("timeout", 30)))
-            else:
+            elif prov == "tavily":
                 tv = config.get("tavily", {})
                 result = extract_tavily(urls, key, output_format, include_images, include_raw_html, render_js, api_url=tv.get("extract_url", "https://api.tavily.com/extract"), timeout=int(tv.get("timeout", 30)))
+            elif prov == "exa":
+                exa = config.get("exa", {})
+                result = extract_exa(urls, key, output_format, include_images, include_raw_html, render_js, api_url=exa.get("contents_url", "https://api.exa.ai/contents"), timeout=int(exa.get("timeout", 30)))
+            else:
+                you = config.get("you", {})
+                result = extract_you(urls, key, output_format, include_images, include_raw_html, render_js, api_url=you.get("contents_url", "https://ydc-index.io/v1/contents"), timeout=int(you.get("timeout", 30)))
             result["routing"] = {"provider": prov, "fallback_used": bool(errors), "fallback_errors": errors}
             return result
         except Exception as e:

--- a/search.py
+++ b/search.py
@@ -2176,6 +2176,191 @@ def search_firecrawl(
 
 
 # =============================================================================
+# Extract Plus (URL Content Extraction)
+# =============================================================================
+
+def _normalize_extract_result(
+    provider: str,
+    url: str,
+    title: str = "",
+    content: str = "",
+    raw_content: Optional[str] = None,
+    **extra: Any,
+) -> Dict[str, Any]:
+    result = {
+        "url": url,
+        "title": title or _title_from_url(url),
+        "content": content or "",
+        "raw_content": raw_content if raw_content is not None else (content or ""),
+        "provider": provider,
+    }
+    for key, value in extra.items():
+        if value is not None:
+            result[key] = value
+    return result
+
+
+def extract_firecrawl(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://api.firecrawl.dev/v2/scrape",
+    timeout: int = 60,
+) -> dict:
+    """Extract URL content using Firecrawl scrape."""
+    formats = ["markdown"] if output_format != "html" else ["html"]
+    if include_raw_html and "html" not in formats:
+        formats.append("html")
+    if include_images and "screenshot" not in formats:
+        # Firecrawl supports richer formats; keep images metadata if returned.
+        pass
+
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    results: List[Dict[str, Any]] = []
+    for url in urls:
+        body: Dict[str, Any] = {"url": url, "formats": formats}
+        if render_js:
+            body["waitFor"] = 1000
+        data = make_request(api_url, headers, body, timeout=timeout)
+        if data.get("success") is False:
+            results.append(_normalize_extract_result("firecrawl", url, error=data.get("error") or data.get("warning") or "Firecrawl scrape failed"))
+            continue
+        payload = data.get("data") if isinstance(data.get("data"), dict) else data
+        metadata = payload.get("metadata") or {}
+        final_url = metadata.get("sourceURL") or metadata.get("url") or url
+        title = metadata.get("title") or ""
+        markdown = payload.get("markdown") or ""
+        html = payload.get("html") or payload.get("rawHtml") or ""
+        content = html if output_format == "html" else markdown or html
+        results.append(_normalize_extract_result(
+            "firecrawl",
+            final_url,
+            title=title,
+            content=content,
+            raw_content=content,
+            raw_html=html if html else None,
+            metadata=metadata,
+        ))
+    return {"provider": "firecrawl", "results": results}
+
+
+def extract_linkup(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://api.linkup.so/v1/fetch",
+    timeout: int = 30,
+) -> dict:
+    """Extract URL content using Linkup fetch."""
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    results: List[Dict[str, Any]] = []
+    for url in urls:
+        body = {
+            "url": url,
+            "extractImages": include_images,
+            "includeRawHtml": include_raw_html or output_format == "html",
+            "renderJs": render_js,
+        }
+        data = make_request(api_url, headers, body, timeout=timeout)
+        if data.get("error"):
+            results.append(_normalize_extract_result("linkup", url, error=str(data.get("error"))))
+            continue
+        markdown = data.get("markdown") or ""
+        raw_html = data.get("rawHtml") or data.get("raw_html") or ""
+        content = raw_html if output_format == "html" else markdown or raw_html
+        results.append(_normalize_extract_result(
+            "linkup",
+            url,
+            content=content,
+            raw_content=content,
+            raw_html=raw_html if raw_html else None,
+            images=data.get("images") if include_images else None,
+        ))
+    return {"provider": "linkup", "results": results}
+
+
+def extract_tavily(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://api.tavily.com/extract",
+    timeout: int = 30,
+) -> dict:
+    """Extract URL content using Tavily extract."""
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+    body = {"urls": urls, "include_images": include_images}
+    data = make_request(api_url, headers, body, timeout=timeout)
+    results: List[Dict[str, Any]] = []
+    for item in data.get("results", []):
+        url = item.get("url", "")
+        content = item.get("raw_content") or item.get("content") or ""
+        results.append(_normalize_extract_result(
+            "tavily",
+            url,
+            title=item.get("title", ""),
+            content=content,
+            raw_content=content,
+            images=item.get("images") if include_images else None,
+        ))
+    for failed in data.get("failed_results", []) or []:
+        failed_url = failed.get("url", "")
+        results.append(_normalize_extract_result("tavily", failed_url, error=failed.get("error") or "Tavily extract failed"))
+    return {"provider": "tavily", "results": results}
+
+
+EXTRACT_PROVIDER_PRIORITY = ["firecrawl", "linkup", "tavily"]
+
+
+def extract_plus(
+    urls: List[str],
+    provider: str = "auto",
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    config: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Extract URL content with provider fallback."""
+    config = config or load_config()
+    selected = provider or "auto"
+    providers = EXTRACT_PROVIDER_PRIORITY if selected == "auto" else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
+    errors = []
+    for prov in providers:
+        if prov not in EXTRACT_PROVIDER_PRIORITY:
+            errors.append({"provider": prov, "error": f"Provider {prov} does not support extraction"})
+            continue
+        key = get_api_key(prov, config)
+        if not key:
+            errors.append({"provider": prov, "error": "missing_api_key"})
+            continue
+        try:
+            if prov == "firecrawl":
+                fc = config.get("firecrawl", {})
+                result = extract_firecrawl(urls, key, output_format, include_images, include_raw_html, render_js, api_url=fc.get("scrape_url", "https://api.firecrawl.dev/v2/scrape"), timeout=int(fc.get("extract_timeout", 60)))
+            elif prov == "linkup":
+                lu = config.get("linkup", {})
+                result = extract_linkup(urls, key, output_format, include_images, include_raw_html, render_js, api_url=lu.get("fetch_url", "https://api.linkup.so/v1/fetch"), timeout=int(lu.get("timeout", 30)))
+            else:
+                tv = config.get("tavily", {})
+                result = extract_tavily(urls, key, output_format, include_images, include_raw_html, render_js, api_url=tv.get("extract_url", "https://api.tavily.com/extract"), timeout=int(tv.get("timeout", 30)))
+            result["routing"] = {"provider": prov, "fallback_used": bool(errors), "fallback_errors": errors}
+            return result
+        except Exception as e:
+            errors.append({"provider": prov, "error": str(e)})
+            continue
+    return {"provider": selected, "results": [], "error": "All extraction providers failed", "fallback_errors": errors}
+
+
+# =============================================================================
 # Exa (Neural/Semantic/Deep Search)
 # =============================================================================
 
@@ -2807,6 +2992,21 @@ Full docs: See README.md and SKILL.md
         help="Search query"
     )
     parser.add_argument(
+        "--extract-urls",
+        nargs="+",
+        help="Extract content from one or more URLs instead of running a search"
+    )
+    parser.add_argument(
+        "--format",
+        dest="output_format",
+        default="markdown",
+        choices=["markdown", "html"],
+        help="Extraction output format"
+    )
+    parser.add_argument("--extract-images", action="store_true", help="Extract image metadata when supported")
+    parser.add_argument("--include-raw-html", action="store_true", help="Include raw HTML when supported")
+    parser.add_argument("--render-js", action="store_true", help="Render JavaScript before extraction when supported")
+    parser.add_argument(
         "--max-results", "-n", 
         type=int, 
         default=config.get("defaults", {}).get("max_results", 5),
@@ -3024,6 +3224,20 @@ Full docs: See README.md and SKILL.md
     
     if args.cache_stats:
         result = cache_stats()
+        indent = None if args.compact else 2
+        print(json.dumps(result, indent=indent, ensure_ascii=False))
+        return
+
+    if args.extract_urls:
+        result = extract_plus(
+            urls=args.extract_urls,
+            provider=args.provider or "auto",
+            output_format=args.output_format,
+            include_images=args.extract_images,
+            include_raw_html=args.include_raw_html,
+            render_js=args.render_js,
+            config=config,
+        )
         indent = None if args.compact else 2
         print(json.dumps(result, indent=indent, ensure_ascii=False))
         return

--- a/search.py
+++ b/search.py
@@ -2214,9 +2214,6 @@ def extract_firecrawl(
     formats = ["markdown"] if output_format != "html" else ["html"]
     if include_raw_html and "html" not in formats:
         formats.append("html")
-    if include_images and "screenshot" not in formats:
-        # Firecrawl supports richer formats; keep images metadata if returned.
-        pass
 
     headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
     results: List[Dict[str, Any]] = []
@@ -2235,6 +2232,18 @@ def extract_firecrawl(
         markdown = payload.get("markdown") or ""
         html = payload.get("html") or payload.get("rawHtml") or ""
         content = html if output_format == "html" else markdown or html
+        images = None
+        if include_images:
+            md_images = []
+            seen_image_urls = set()
+            for alt, image_url in re.findall(r"!\[([^\]]*)\]\(([^)]+)\)", markdown):
+                if image_url not in seen_image_urls:
+                    md_images.append({"alt": alt, "url": image_url})
+                    seen_image_urls.add(image_url)
+            og_image = metadata.get("ogImage") or metadata.get("og:image")
+            if og_image and og_image not in seen_image_urls:
+                md_images.insert(0, {"alt": "og:image", "url": og_image})
+            images = md_images or None
         results.append(_normalize_extract_result(
             "firecrawl",
             final_url,
@@ -2242,6 +2251,7 @@ def extract_firecrawl(
             content=content,
             raw_content=content,
             raw_html=html if html else None,
+            images=images,
             metadata=metadata,
         ))
     return {"provider": "firecrawl", "results": results}
@@ -2410,6 +2420,16 @@ def extract_plus(
     """Extract URL content with provider fallback."""
     config = config or load_config()
     selected = provider or "auto"
+    if not urls:
+        return {"provider": selected, "results": [], "error": "No URLs provided", "requested_provider": selected}
+    invalid = [u for u in urls if not (isinstance(u, str) and u.startswith(("http://", "https://")))]
+    if invalid:
+        return {
+            "provider": selected,
+            "results": [],
+            "error": f"Invalid URL(s) — must start with http:// or https://: {invalid}",
+            "requested_provider": selected,
+        }
     providers = EXTRACT_PROVIDER_PRIORITY if selected == "auto" else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
     errors = []
     for prov in providers:
@@ -2436,7 +2456,16 @@ def extract_plus(
             else:
                 you = config.get("you", {})
                 result = extract_you(urls, key, output_format, include_images, include_raw_html, render_js, api_url=you.get("contents_url", "https://ydc-index.io/v1/contents"), timeout=int(you.get("timeout", 30)))
-            result["routing"] = {"provider": prov, "fallback_used": bool(errors), "fallback_errors": errors}
+            res_list = result.get("results") or []
+            all_failed = bool(res_list) and all(r.get("error") for r in res_list)
+            if all_failed:
+                errors.append({
+                    "provider": prov,
+                    "error": "all_urls_failed",
+                    "details": [r.get("error") for r in res_list],
+                })
+                continue
+            result["routing"] = {"provider": prov, "requested_provider": selected, "fallback_used": bool(errors), "fallback_errors": errors}
             return result
         except Exception as e:
             errors.append({"provider": prov, "error": str(e)})
@@ -3077,7 +3106,7 @@ Full docs: See README.md and SKILL.md
     )
     parser.add_argument(
         "--extract-urls",
-        nargs="+",
+        nargs="*",
         help="Extract content from one or more URLs instead of running a search"
     )
     parser.add_argument(
@@ -3312,7 +3341,7 @@ Full docs: See README.md and SKILL.md
         print(json.dumps(result, indent=indent, ensure_ascii=False))
         return
 
-    if args.extract_urls:
+    if args.extract_urls is not None:
         result = extract_plus(
             urls=args.extract_urls,
             provider=args.provider or "auto",

--- a/tests/test_extract_plus.py
+++ b/tests/test_extract_plus.py
@@ -1,0 +1,142 @@
+import json
+import os
+import unittest
+from unittest import mock
+
+import search
+import __init__ as plugin
+
+
+class ExtractPlusCoreTests(unittest.TestCase):
+    def test_extract_firecrawl_parses_markdown(self):
+        fake_response = {
+            "success": True,
+            "data": {
+                "markdown": "# Example\nFirecrawl content",
+                "html": "<h1>Example</h1>",
+                "metadata": {"title": "Example Page", "sourceURL": "https://example.com"},
+            },
+        }
+        with mock.patch("search.make_request", return_value=fake_response) as mock_request:
+            result = search.extract_firecrawl(
+                urls=["https://example.com"],
+                api_key="fc-test",
+                output_format="markdown",
+            )
+
+        self.assertEqual(result["provider"], "firecrawl")
+        self.assertEqual(result["results"][0]["title"], "Example Page")
+        self.assertEqual(result["results"][0]["content"], "# Example\nFirecrawl content")
+        self.assertEqual(result["results"][0]["raw_content"], "# Example\nFirecrawl content")
+
+        url, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(url, "https://api.firecrawl.dev/v2/scrape")
+        self.assertEqual(headers["Authorization"], "Bearer fc-test")
+        self.assertEqual(body["url"], "https://example.com")
+        self.assertEqual(body["formats"], ["markdown"])
+
+    def test_extract_linkup_fetches_each_url(self):
+        fake_response = {
+            "markdown": "# Linkup page\nFetched content",
+            "rawHtml": "<h1>Linkup page</h1>",
+            "images": [{"alt": "Logo", "url": "https://example.com/logo.png"}],
+        }
+        with mock.patch("search.make_request", return_value=fake_response) as mock_request:
+            result = search.extract_linkup(
+                urls=["https://example.com"],
+                api_key="linkup-test",
+                output_format="markdown",
+                include_images=True,
+                include_raw_html=True,
+                render_js=True,
+            )
+
+        self.assertEqual(result["provider"], "linkup")
+        self.assertEqual(result["results"][0]["content"], "# Linkup page\nFetched content")
+        self.assertEqual(result["results"][0]["raw_html"], "<h1>Linkup page</h1>")
+        self.assertEqual(result["results"][0]["images"][0]["alt"], "Logo")
+
+        url, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(url, "https://api.linkup.so/v1/fetch")
+        self.assertEqual(headers["Authorization"], "Bearer linkup-test")
+        self.assertEqual(body["url"], "https://example.com")
+        self.assertTrue(body["extractImages"])
+        self.assertTrue(body["includeRawHtml"])
+        self.assertTrue(body["renderJs"])
+
+    def test_extract_tavily_parses_raw_content(self):
+        fake_response = {
+            "results": [
+                {
+                    "url": "https://example.com",
+                    "title": "Tavily Page",
+                    "raw_content": "Tavily extracted content",
+                }
+            ]
+        }
+        with mock.patch("search.make_request", return_value=fake_response) as mock_request:
+            result = search.extract_tavily(
+                urls=["https://example.com"],
+                api_key="tvly-test",
+            )
+
+        self.assertEqual(result["provider"], "tavily")
+        self.assertEqual(result["results"][0]["title"], "Tavily Page")
+        self.assertEqual(result["results"][0]["content"], "Tavily extracted content")
+
+        url, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(url, "https://api.tavily.com/extract")
+        self.assertEqual(headers["Authorization"], "Bearer tvly-test")
+        self.assertEqual(body["urls"], ["https://example.com"])
+
+    def test_extract_plus_auto_prefers_firecrawl_when_available(self):
+        with mock.patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test", "LINKUP_API_KEY": "linkup-test"}, clear=False):
+            with mock.patch("search.extract_firecrawl", return_value={"provider": "firecrawl", "results": []}) as mock_firecrawl:
+                result = search.extract_plus(["https://example.com"], provider="auto")
+
+        self.assertEqual(result["provider"], "firecrawl")
+        mock_firecrawl.assert_called_once()
+
+
+class ExtractPlusPluginTests(unittest.TestCase):
+    def test_run_extract_invokes_search_script_extract_mode(self):
+        completed = mock.Mock(returncode=0, stdout=json.dumps({"provider": "linkup", "results": []}), stderr="")
+        with mock.patch("subprocess.run", return_value=completed) as mock_run:
+            result = plugin._run_extract(
+                urls=["https://example.com"],
+                provider="linkup",
+                output_format="markdown",
+                include_images=True,
+                render_js=True,
+            )
+
+        self.assertEqual(result["provider"], "linkup")
+        cmd = mock_run.call_args.kwargs["args"] if "args" in mock_run.call_args.kwargs else mock_run.call_args.args[0]
+        self.assertIn("--extract-urls", cmd)
+        self.assertIn("https://example.com", cmd)
+        self.assertIn("--provider", cmd)
+        self.assertIn("linkup", cmd)
+        self.assertIn("--format", cmd)
+        self.assertIn("markdown", cmd)
+        self.assertIn("--extract-images", cmd)
+        self.assertIn("--render-js", cmd)
+
+    def test_register_exposes_web_extract_plus_tool(self):
+        registered = {}
+
+        class Ctx:
+            def register_tool(self, **kwargs):
+                registered[kwargs["name"]] = kwargs
+
+        plugin.register(Ctx())
+
+        self.assertIn("web_search_plus", registered)
+        self.assertIn("web_extract_plus", registered)
+        schema = registered["web_extract_plus"]["schema"]
+        self.assertEqual(schema["parameters"]["required"], ["urls"])
+        self.assertIn("firecrawl", schema["parameters"]["properties"]["provider"]["enum"])
+        self.assertIn("linkup", schema["parameters"]["properties"]["provider"]["enum"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_extract_plus.py
+++ b/tests/test_extract_plus.py
@@ -1,5 +1,7 @@
 import json
 import os
+import subprocess
+import sys
 import unittest
 from unittest import mock
 
@@ -167,6 +169,70 @@ class ExtractPlusCoreTests(unittest.TestCase):
         self.assertEqual(result["provider"], "exa")
         mock_exa.assert_called_once()
 
+    def test_extract_firecrawl_include_images_parses_markdown_and_og_image(self):
+        fake_response = {
+            "success": True,
+            "data": {
+                "markdown": "# Example\n![Hero](https://example.com/hero.png)\n![Hero again](https://example.com/hero.png)",
+                "metadata": {"title": "Example Page", "sourceURL": "https://example.com", "ogImage": "https://example.com/og.png"},
+            },
+        }
+        with mock.patch("search.make_request", return_value=fake_response):
+            result = search.extract_firecrawl(
+                urls=["https://example.com"],
+                api_key="fc-test",
+                include_images=True,
+            )
+
+        images = result["results"][0]["images"]
+        self.assertEqual(images[0], {"alt": "og:image", "url": "https://example.com/og.png"})
+        self.assertIn({"alt": "Hero", "url": "https://example.com/hero.png"}, images)
+
+    def test_extract_plus_falls_back_when_primary_returns_only_errors(self):
+        with mock.patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test", "LINKUP_API_KEY": "linkup-test"}, clear=True):
+            with mock.patch("search.extract_firecrawl", return_value={"provider": "firecrawl", "results": [{"url": "https://example.com", "error": "fetch failed"}]}) as mock_firecrawl:
+                with mock.patch("search.extract_linkup", return_value={"provider": "linkup", "results": [{"url": "https://example.com", "content": "fallback content"}]}) as mock_linkup:
+                    result = search.extract_plus(["https://example.com"], provider="firecrawl")
+
+        self.assertEqual(result["provider"], "linkup")
+        self.assertTrue(result["routing"]["fallback_used"])
+        self.assertEqual(result["routing"]["fallback_errors"][0]["error"], "all_urls_failed")
+        mock_firecrawl.assert_called_once()
+        mock_linkup.assert_called_once()
+
+    def test_extract_plus_empty_urls_returns_clean_error_without_provider_calls(self):
+        with mock.patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}, clear=True):
+            with mock.patch("search.extract_firecrawl") as mock_firecrawl:
+                result = search.extract_plus([], provider="firecrawl")
+
+        self.assertEqual(result["results"], [])
+        self.assertEqual(result["error"], "No URLs provided")
+        mock_firecrawl.assert_not_called()
+
+    def test_extract_plus_invalid_urls_return_clean_error_without_fallback(self):
+        with mock.patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test", "LINKUP_API_KEY": "linkup-test"}, clear=True):
+            with mock.patch("search.extract_firecrawl") as mock_firecrawl, mock.patch("search.extract_linkup") as mock_linkup:
+                result = search.extract_plus(["foo-bar"], provider="firecrawl")
+
+        self.assertEqual(result["results"], [])
+        self.assertIn("Invalid URL(s)", result["error"])
+        mock_firecrawl.assert_not_called()
+        mock_linkup.assert_not_called()
+
+    def test_cli_empty_extract_urls_returns_json_error(self):
+        completed = subprocess.run(
+            [sys.executable, "search.py", "--extract-urls", "--provider", "firecrawl", "--compact"],
+            cwd=os.path.dirname(search.__file__),
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        result = json.loads(completed.stdout)
+        self.assertEqual(result["results"], [])
+        self.assertEqual(result["error"], "No URLs provided")
+
 
 class ExtractPlusPluginTests(unittest.TestCase):
     def test_run_extract_invokes_search_script_extract_mode(self):
@@ -208,6 +274,23 @@ class ExtractPlusPluginTests(unittest.TestCase):
         self.assertIn("linkup", schema["parameters"]["properties"]["provider"]["enum"])
         self.assertIn("exa", schema["parameters"]["properties"]["provider"]["enum"])
         self.assertIn("you", schema["parameters"]["properties"]["provider"]["enum"])
+
+    def test_web_extract_plus_check_fn_requires_extract_capable_provider(self):
+        registered = {}
+
+        class Ctx:
+            def register_tool(self, **kwargs):
+                registered[kwargs["name"]] = kwargs
+
+        with mock.patch.dict(os.environ, {"SERPER_API_KEY": "serper-test"}, clear=True):
+            plugin.register(Ctx())
+            self.assertTrue(registered["web_search_plus"]["check_fn"]())
+            self.assertFalse(registered["web_extract_plus"]["check_fn"]())
+
+        registered.clear()
+        with mock.patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test"}, clear=True):
+            plugin.register(Ctx())
+            self.assertTrue(registered["web_extract_plus"]["check_fn"]())
 
 
 if __name__ == "__main__":

--- a/tests/test_extract_plus.py
+++ b/tests/test_extract_plus.py
@@ -89,6 +89,68 @@ class ExtractPlusCoreTests(unittest.TestCase):
         self.assertEqual(headers["Authorization"], "Bearer tvly-test")
         self.assertEqual(body["urls"], ["https://example.com"])
 
+    def test_extract_exa_parses_contents_text(self):
+        fake_response = {
+            "results": [
+                {
+                    "title": "Exa Page",
+                    "url": "https://example.com",
+                    "text": "Exa extracted markdown",
+                    "summary": "Short summary",
+                    "highlights": ["Important excerpt"],
+                }
+            ],
+            "costDollars": {"total": 0.003},
+        }
+        with mock.patch("search.make_request", return_value=fake_response) as mock_request:
+            result = search.extract_exa(
+                urls=["https://example.com"],
+                api_key="exa-test",
+                output_format="markdown",
+            )
+
+        self.assertEqual(result["provider"], "exa")
+        self.assertEqual(result["results"][0]["title"], "Exa Page")
+        self.assertEqual(result["results"][0]["content"], "Exa extracted markdown")
+        self.assertEqual(result["results"][0]["summary"], "Short summary")
+        self.assertEqual(result["cost_dollars"], {"total": 0.003})
+
+        url, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(url, "https://api.exa.ai/contents")
+        self.assertEqual(headers["x-api-key"], "exa-test")
+        self.assertEqual(body["urls"], ["https://example.com"])
+        self.assertTrue(body["text"])
+
+    def test_extract_you_parses_contents_markdown(self):
+        fake_response = [
+            {
+                "url": "https://example.com",
+                "title": "You Page",
+                "markdown": "You.com extracted markdown",
+                "html": "<h1>You Page</h1>",
+                "metadata": {"siteName": "Example"},
+            }
+        ]
+        with mock.patch("search.make_request", return_value=fake_response) as mock_request:
+            result = search.extract_you(
+                urls=["https://example.com"],
+                api_key="you-test",
+                output_format="markdown",
+                include_raw_html=True,
+            )
+
+        self.assertEqual(result["provider"], "you")
+        self.assertEqual(result["results"][0]["title"], "You Page")
+        self.assertEqual(result["results"][0]["content"], "You.com extracted markdown")
+        self.assertEqual(result["results"][0]["raw_html"], "<h1>You Page</h1>")
+        self.assertEqual(result["results"][0]["metadata"], {"siteName": "Example"})
+
+        url, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(url, "https://ydc-index.io/v1/contents")
+        self.assertEqual(headers["X-API-Key"], "you-test")
+        self.assertEqual(body["urls"], ["https://example.com"])
+        self.assertEqual(body["formats"], ["markdown", "html", "metadata"])
+
     def test_extract_plus_auto_prefers_firecrawl_when_available(self):
         with mock.patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test", "LINKUP_API_KEY": "linkup-test"}, clear=False):
             with mock.patch("search.extract_firecrawl", return_value={"provider": "firecrawl", "results": []}) as mock_firecrawl:
@@ -96,6 +158,14 @@ class ExtractPlusCoreTests(unittest.TestCase):
 
         self.assertEqual(result["provider"], "firecrawl")
         mock_firecrawl.assert_called_once()
+
+    def test_extract_plus_auto_uses_exa_when_only_exa_is_available(self):
+        with mock.patch.dict(os.environ, {"EXA_API_KEY": "exa-test"}, clear=True):
+            with mock.patch("search.extract_exa", return_value={"provider": "exa", "results": []}) as mock_exa:
+                result = search.extract_plus(["https://example.com"], provider="auto")
+
+        self.assertEqual(result["provider"], "exa")
+        mock_exa.assert_called_once()
 
 
 class ExtractPlusPluginTests(unittest.TestCase):
@@ -136,6 +206,8 @@ class ExtractPlusPluginTests(unittest.TestCase):
         self.assertEqual(schema["parameters"]["required"], ["urls"])
         self.assertIn("firecrawl", schema["parameters"]["properties"]["provider"]["enum"])
         self.assertIn("linkup", schema["parameters"]["properties"]["provider"]["enum"])
+        self.assertIn("exa", schema["parameters"]["properties"]["provider"]["enum"])
+        self.assertIn("you", schema["parameters"]["properties"]["provider"]["enum"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `web_extract_plus` as a companion tool to `web_search_plus`.
- Support multi-provider extraction through Firecrawl, Linkup, Tavily, Exa, and You.com.
- Add options for provider selection, markdown/html format, image inclusion, raw HTML inclusion, and JS rendering.
- Normalize provider responses into a consistent `{results: [...]}` shape with per-URL error handling.
- Document usage examples and required API keys.
- Add unit tests covering provider routing, request payloads, response normalization, and failure handling.

## Why
`web_search_plus` now has richer search providers, but extraction still needs the same provider-flexible path. This PR lets users fetch clean page content through the most suitable extraction backend while keeping the tool interface consistent.

## Verification
Ran locally:

```bash
python3 -m pytest -q
```

Result:

```text
26 passed in 0.05s
```

## Notes
- Branch has been rebased onto upstream `main` after PR #5 landed.
- Earlier Firecrawl/Linkup search commits were skipped during rebase because they are already included upstream.
