### PR TITLE
feat: add quality report and research mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,9 @@
 .env
 config.json
 
-# Cache
+# Cache / generated local reports
 .cache/
+eval/
 __pycache__/
 *.pyc
 *.pyo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,19 @@
 - Research mode now has a best-effort `research_time_budget` defaulting to 55 seconds, exposed through the Hermes tool schema and CLI as `--research-time-budget`.
 - Extraction failures no longer fail the entire research response; partial search results are preserved and errors are reported in routing metadata.
 - Budget exhaustion now skips remaining provider/extraction work instead of hanging or spending API calls blindly.
+- Plugin metadata now matches the shipped tool surface: search, extraction, quality reports, and research mode.
+
+### 🧰 Maintenance
+- Added `requirements.txt` with bounded runtime dependencies.
+- Added GitHub Actions CI for Ruff, pytest, and Python compile checks.
+- Synchronized README, manifest, module headers, and CLI docs for the v1.7.0 release.
 
 ### 🧪 Tests
 - Added regression coverage for research-mode extraction failures and time-budget exhaustion.
 - Test suite: 47/47 unit tests passing.
+
+### 🙏 Contributors
+- Robby / **@robbyczgw-cla**
 
 ## [v1.6.1] — 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [v1.7.0] — 2026-05-03
+
+### ✨ Added
+- **Quality reports** for `web_search_plus` — optional diagnostics covering routing decisions, provider behavior, result counts, and quality metadata.
+- **Research mode** — opt-in `mode="research"` path for multi-provider discovery plus selected URL extraction.
+- **Golden query evaluator** — repeatable evaluation script and tests for tracking provider/research behavior over representative queries.
+
+### 🔧 Improved
+- Research mode now has a best-effort `research_time_budget` defaulting to 55 seconds, exposed through the Hermes tool schema and CLI as `--research-time-budget`.
+- Extraction failures no longer fail the entire research response; partial search results are preserved and errors are reported in routing metadata.
+- Budget exhaustion now skips remaining provider/extraction work instead of hanging or spending API calls blindly.
+
+### 🧪 Tests
+- Added regression coverage for research-mode extraction failures and time-budget exhaustion.
+- Test suite: 47/47 unit tests passing.
+
 ## [v1.6.1] — 2026-04-29
 
 ### 🔧 Improved

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # web-search-plus — Hermes Plugin
 
-Multi-provider web search with intelligent auto-routing for [Hermes Agent](https://github.com/NousResearch/hermes-agent).
+Multi-provider web search, URL extraction, quality reports, and opt-in research mode for [Hermes Agent](https://github.com/NousResearch/hermes-agent).
 
 > Ported from [web-search-plus-plugin](https://github.com/robbyczgw-cla/web-search-plus-plugin) (OpenClaw) to the Hermes Plugin API.
 
@@ -56,6 +56,8 @@ Both tools are exposed by the `web-search-plus` toolset; enabling `web-search-pl
 - **Exa Deep Research** — `depth=deep` for multi-source synthesis, `depth=deep-reasoning` for cross-document analysis
 - **Adaptive fallback** — automatically skips providers on cooldown (1h after failure)
 - **Routing transparency** — every response includes a `routing` object explaining provider choice
+- **Quality reports** — optional provider diagnostics, result-count summaries, and execution metadata
+- **Research mode** — opt-in multi-provider search + extraction with a best-effort time budget
 - **Time & domain filtering** — `time_range`, `include_domains`, `exclude_domains`
 - **URL extraction** — `web_extract_plus` extracts clean content via Firecrawl, Linkup, Tavily, Exa, or You.com
 - **Local caching** — avoids duplicate API calls (1h TTL)
@@ -119,6 +121,15 @@ SEARXNG_INSTANCE_URL=https://your-instance.example.com
 | `time_range` | string | — | `day`, `week`, `month`, `year` |
 | `include_domains` | string[] | — | Restrict search to domains |
 | `exclude_domains` | string[] | — | Exclude domains |
+| `quality_report` | boolean | `false` | Include provider diagnostics and result-quality metadata |
+| `mode` | string | `"normal"` | `normal` or opt-in `research` |
+| `research_time_budget` | number | `55.0` | Best-effort seconds budget for research mode provider/extraction work |
+
+### Quality report and research mode
+
+`quality_report=True` adds diagnostic metadata without changing provider selection. Use it when tuning routing, comparing providers, or debugging weak result sets.
+
+`mode="research"` is intentionally opt-in: it can query multiple providers and extract selected result URLs, so it is slower and may spend more API credits than normal search. The default `research_time_budget=55.0` keeps the run bounded; when the budget is exhausted, remaining providers or extraction steps are skipped and reported in routing metadata instead of hanging or failing the whole response. Search results already collected are preserved even if extraction fails.
 
 ### `web_extract_plus`
 
@@ -159,6 +170,12 @@ web_search_plus(query="YC startups web scraping", provider="firecrawl")
 web_search_plus(query="find credible sources and citations for AI tutoring outcomes", provider="linkup")
 # → Linkup source-grounded retrieval
 
+web_search_plus(query="best bookshelf speakers under 1000", quality_report=True)
+# → Normal search plus diagnostic routing/result-quality metadata
+
+web_search_plus(query="compare recent reviews of turntables under 1000", mode="research", research_time_budget=45)
+# → Opt-in multi-provider research; keeps partial results if extraction hits errors/budget
+
 web_extract_plus(urls=["https://example.com"], provider="firecrawl")
 # → Extract clean markdown from a URL
 
@@ -176,6 +193,10 @@ cd ~/.hermes/hermes-agent
 source venv/bin/activate
 python ~/.hermes/plugins/web-search-plus/search.py \
   --query "test query" --provider auto --max-results 5 --compact
+
+python ~/.hermes/plugins/web-search-plus/search.py \
+  --query "compare recent reviews of turntables under 1000" \
+  --mode research --quality-report --research-time-budget 45 --compact
 ```
 
 ---
@@ -185,6 +206,7 @@ python ~/.hermes/plugins/web-search-plus/search.py \
 ```
 __init__.py      — Hermes plugin entry, tool schema, handler
 search.py        — Core engine: providers, routing, caching, fallback
+scripts/         — Golden query evaluator and support scripts
 plugin.yaml      — Plugin manifest
 .env.template    — API key reference
 CHANGELOG.md     — Version history

--- a/__init__.py
+++ b/__init__.py
@@ -64,6 +64,8 @@ def _run_search(
     time_range: Optional[str] = None,
     include_domains: Optional[List[str]] = None,
     exclude_domains: Optional[List[str]] = None,
+    mode: str = "normal",
+    quality_report: bool = False,
 ) -> dict:
     """Call search.py subprocess and return parsed JSON result."""
     cmd = [
@@ -82,6 +84,10 @@ def _run_search(
         cmd += ["--include-domains"] + include_domains
     if exclude_domains:
         cmd += ["--exclude-domains"] + exclude_domains
+    if mode != "normal":
+        cmd += ["--mode", mode]
+    if quality_report:
+        cmd.append("--quality-report")
 
     env = os.environ.copy()
 
@@ -174,6 +180,30 @@ def _format_results(data: dict) -> str:
     if answer:
         lines.append(f"\nAnswer: {answer}\n")
 
+    quality_report = data.get("quality_report") or {}
+    if quality_report:
+        lines.append(
+            "Quality: "
+            f"{quality_report.get('confidence', 'unknown')} confidence | "
+            f"{quality_report.get('domain_count', 0)} domains | "
+            f"{quality_report.get('duplicate_count', 0)} duplicates | "
+            f"extract recommended: {quality_report.get('extract_recommended', False)}"
+        )
+        if quality_report.get("extract_reasons"):
+            lines.append("Quality reasons: " + ", ".join(quality_report["extract_reasons"]))
+        lines.append("")
+
+    source_summaries = data.get("source_summaries") or []
+    if source_summaries:
+        lines.append("Extracted source summaries:")
+        for i, src in enumerate(source_summaries, 1):
+            url = src.get("url", "")
+            content = (src.get("content") or src.get("raw_content") or "").strip()
+            lines.append(f"{i}. {url}")
+            if content:
+                lines.append(f"   {content[:500]}")
+        lines.append("")
+
     for i, r in enumerate(results, 1):
         title = r.get("title", "No title")
         url = r.get("url", "")
@@ -265,6 +295,17 @@ def register(ctx: Any) -> None:
                     "items": {"type": "string"},
                     "description": "Blacklist specific domains (e.g. ['reddit.com']). Optional.",
                 },
+                "mode": {
+                    "type": "string",
+                    "enum": ["normal", "research"],
+                    "description": "normal = fast routed search; research = multi-provider search plus top-source extraction.",
+                    "default": "normal",
+                },
+                "quality_report": {
+                    "type": "boolean",
+                    "description": "Attach routing/result quality diagnostics such as selected provider, skips, dedup count, domain diversity, and extraction recommendation.",
+                    "default": False,
+                },
             },
             "required": ["query"],
         },
@@ -272,7 +313,8 @@ def register(ctx: Any) -> None:
 
     def handler(args_or_query, provider: str = "auto", count: int = 5, depth: str = "normal",
                 time_range: Optional[str] = None, include_domains: Optional[List[str]] = None,
-                exclude_domains: Optional[List[str]] = None, **kwargs) -> str:
+                exclude_domains: Optional[List[str]] = None, mode: str = "normal",
+                quality_report: bool = False, **kwargs) -> str:
         # Hermes registry passes the entire input dict as first positional arg
         if isinstance(args_or_query, dict):
             query = args_or_query.get("query", "")
@@ -282,6 +324,8 @@ def register(ctx: Any) -> None:
             time_range = args_or_query.get("time_range", time_range)
             include_domains = args_or_query.get("include_domains", include_domains)
             exclude_domains = args_or_query.get("exclude_domains", exclude_domains)
+            mode = args_or_query.get("mode", mode)
+            quality_report = args_or_query.get("quality_report", quality_report)
         else:
             query = args_or_query
         data = _run_search(
@@ -292,6 +336,8 @@ def register(ctx: Any) -> None:
             time_range=time_range,
             include_domains=include_domains,
             exclude_domains=exclude_domains,
+            mode=mode,
+            quality_report=quality_report,
         )
         return _format_results(data)
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v1.6.1
-Multi-provider web search and URL extraction with intelligent auto-routing.
+web-search-plus — Hermes Plugin v1.7.0
+Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "1.6.1"
+__version__ = "1.7.0"
 
 import json
 import os

--- a/__init__.py
+++ b/__init__.py
@@ -66,6 +66,7 @@ def _run_search(
     exclude_domains: Optional[List[str]] = None,
     mode: str = "normal",
     quality_report: bool = False,
+    research_time_budget: float = 55.0,
 ) -> dict:
     """Call search.py subprocess and return parsed JSON result."""
     cmd = [
@@ -85,7 +86,7 @@ def _run_search(
     if exclude_domains:
         cmd += ["--exclude-domains"] + exclude_domains
     if mode != "normal":
-        cmd += ["--mode", mode]
+        cmd += ["--mode", mode, "--research-time-budget", str(research_time_budget)]
     if quality_report:
         cmd.append("--quality-report")
 
@@ -306,6 +307,13 @@ def register(ctx: Any) -> None:
                     "description": "Attach routing/result quality diagnostics such as selected provider, skips, dedup count, domain diversity, and extraction recommendation.",
                     "default": False,
                 },
+                "research_time_budget": {
+                    "type": "number",
+                    "description": "Best-effort wall-clock budget in seconds for research mode. Checked between provider calls and before extraction.",
+                    "default": 55.0,
+                    "minimum": 1,
+                    "maximum": 75,
+                },
             },
             "required": ["query"],
         },
@@ -314,7 +322,7 @@ def register(ctx: Any) -> None:
     def handler(args_or_query, provider: str = "auto", count: int = 5, depth: str = "normal",
                 time_range: Optional[str] = None, include_domains: Optional[List[str]] = None,
                 exclude_domains: Optional[List[str]] = None, mode: str = "normal",
-                quality_report: bool = False, **kwargs) -> str:
+                quality_report: bool = False, research_time_budget: float = 55.0, **kwargs) -> str:
         # Hermes registry passes the entire input dict as first positional arg
         if isinstance(args_or_query, dict):
             query = args_or_query.get("query", "")
@@ -326,6 +334,7 @@ def register(ctx: Any) -> None:
             exclude_domains = args_or_query.get("exclude_domains", exclude_domains)
             mode = args_or_query.get("mode", mode)
             quality_report = args_or_query.get("quality_report", quality_report)
+            research_time_budget = args_or_query.get("research_time_budget", research_time_budget)
         else:
             query = args_or_query
         data = _run_search(
@@ -338,6 +347,7 @@ def register(ctx: Any) -> None:
             exclude_domains=exclude_domains,
             mode=mode,
             quality_report=quality_report,
+            research_time_budget=research_time_budget,
         )
         return _format_results(data)
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-search-plus
-version: "1.6.1"
-description: "Multi-provider web search and URL extraction with intelligent auto-routing (10 search providers, 5 extract providers)"
+version: "1.7.0"
+description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []
 optional_env:

--- a/scripts/golden_eval.py
+++ b/scripts/golden_eval.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Golden query evaluator for web-search-plus local spikes.
+
+Runs a fixed set of representative queries against normal search and optional
+research mode, then writes machine-readable JSONL plus a compact markdown report.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+from urllib.parse import urlparse
+
+
+DEFAULT_GOLDEN_QUERIES: List[Dict[str, Any]] = [
+    {
+        "id": "hifi-turntables-under-1000",
+        "category": "hifi_product",
+        "query": "best turntables under 1000 euro 2026",
+        "notes": "HiFi/product query; should avoid SEO sludge where possible.",
+    },
+    {
+        "id": "graz-weather-today",
+        "category": "local_realtime",
+        "query": "Graz weather today",
+        "notes": "Local/current factual query.",
+    },
+    {
+        "id": "tailscale-release-notes",
+        "category": "tech_release",
+        "query": "latest Tailscale release notes subnet router",
+        "notes": "Current software/release query.",
+    },
+    {
+        "id": "eu-ai-act-small-business",
+        "category": "research_policy",
+        "query": "EU AI Act compliance requirements for small businesses 2026",
+        "notes": "Policy/research query where source grounding matters.",
+    },
+    {
+        "id": "deutsche-ki-news",
+        "category": "german_realtime",
+        "query": "aktuelle KI Regulierung Österreich Unternehmen 2026",
+        "notes": "German-language current query.",
+    },
+    {
+        "id": "reddit-local-llama",
+        "category": "reddit_community",
+        "query": "site:reddit.com/r/LocalLLaMA best local LLM inference server 2026",
+        "notes": "Community/reddit query; browser often blocked.",
+    },
+    {
+        "id": "academic-rag-eval",
+        "category": "academic",
+        "query": "recent papers retrieval augmented generation evaluation benchmark 2026",
+        "notes": "Academic discovery query.",
+    },
+    {
+        "id": "js-heavy-extraction",
+        "category": "js_extraction",
+        "query": "JavaScript heavy pricing page AI search API extraction example",
+        "notes": "Extraction-sensitive / JS-ish query.",
+    },
+]
+
+
+def load_golden_queries(path: Path | None = None) -> List[Dict[str, Any]]:
+    if path is None:
+        return [case.copy() for case in DEFAULT_GOLDEN_QUERIES]
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("Golden query file must contain a JSON list")
+    return data
+
+
+def _safe_domain(url: str) -> str:
+    try:
+        netloc = urlparse(url or "").netloc.lower()
+        return netloc[4:] if netloc.startswith("www.") else netloc
+    except Exception:
+        return ""
+
+
+def _json_from_stdout(stdout: str) -> Dict[str, Any]:
+    try:
+        parsed = json.loads(stdout or "{}")
+        return parsed if isinstance(parsed, dict) else {"error": "stdout was not a JSON object", "results": []}
+    except json.JSONDecodeError as e:
+        return {"error": f"invalid JSON stdout: {e}", "results": []}
+
+
+def summarize_result(
+    case: Dict[str, Any],
+    mode: str,
+    payload: Dict[str, Any],
+    latency_ms: int,
+    returncode: int,
+    stderr: str,
+) -> Dict[str, Any]:
+    results = payload.get("results") or []
+    source_summaries = payload.get("source_summaries") or []
+    quality = payload.get("quality_report") or {}
+    metadata = payload.get("metadata") or {}
+    routing = payload.get("routing") or {}
+    domains = quality.get("domains") or sorted({_safe_domain(r.get("url", "")) for r in results if r.get("url")})
+    domains = [d for d in domains if d]
+    extracted_chars = sum(len((s.get("content") or s.get("raw_content") or "")) for s in source_summaries)
+
+    failure_flags: List[str] = []
+    if not results:
+        failure_flags.append("no_results")
+    if payload.get("error"):
+        failure_flags.append("provider_error")
+    if returncode != 0:
+        failure_flags.append("nonzero_exit")
+    if mode == "research" and not source_summaries:
+        failure_flags.append("no_source_summaries")
+    if mode == "research" and source_summaries and extracted_chars == 0:
+        failure_flags.append("empty_source_summaries")
+    if latency_ms > (30000 if mode == "research" else 12000):
+        failure_flags.append("slow")
+
+    return {
+        "id": case["id"],
+        "category": case["category"],
+        "query": case["query"],
+        "mode": mode,
+        "status": "error" if (returncode != 0 or payload.get("error")) else "ok",
+        "failure_flags": failure_flags,
+        "latency_ms": latency_ms,
+        "provider": payload.get("provider"),
+        "routing_provider": routing.get("provider"),
+        "providers_queried": routing.get("providers_queried"),
+        "provider_errors": routing.get("provider_errors") or payload.get("provider_errors"),
+        "result_count": len(results),
+        "source_summary_count": len(source_summaries),
+        "extracted_chars": extracted_chars,
+        "domain_count": quality.get("domain_count", len(domains)),
+        "domain_diversity": quality.get("domain_diversity"),
+        "domains": domains,
+        "dedup_count": quality.get("duplicate_count", metadata.get("dedup_count", 0)),
+        "extract_recommended": quality.get("extract_recommended"),
+        "extract_reasons": quality.get("extract_reasons"),
+        "stderr_tail": stderr.strip()[-500:] if stderr else "",
+    }
+
+
+def run_case(
+    case: Dict[str, Any],
+    script_path: Path,
+    modes: List[str],
+    max_results: int,
+    research_extract_count: int,
+    timeout_seconds: int,
+    env: Dict[str, str],
+) -> List[Dict[str, Any]]:
+    rows = []
+    for mode in modes:
+        cmd = [
+            sys.executable,
+            str(script_path),
+            "--query",
+            case["query"],
+            "--provider",
+            case.get("provider", "auto"),
+            "--max-results",
+            str(max_results),
+            "--quality-report",
+            "--no-cache",
+            "--compact",
+        ]
+        if mode == "research":
+            cmd += ["--mode", "research", "--research-extract-count", str(research_extract_count)]
+            if case.get("research_providers"):
+                cmd += ["--research-providers", *case["research_providers"]]
+        start = time.perf_counter()
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_seconds, env=env)
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            payload = _json_from_stdout(proc.stdout if proc.returncode == 0 else (proc.stdout or proc.stderr))
+            rows.append(summarize_result(case, mode, payload, latency_ms, proc.returncode, proc.stderr))
+        except subprocess.TimeoutExpired as e:
+            latency_ms = int((time.perf_counter() - start) * 1000)
+            rows.append(summarize_result(
+                case,
+                mode,
+                {"error": f"timeout after {timeout_seconds}s", "provider": case.get("provider", "auto"), "results": []},
+                latency_ms,
+                124,
+                (e.stderr or "") if isinstance(e.stderr, str) else "",
+            ))
+    return rows
+
+
+def write_jsonl(rows: Iterable[Dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def write_markdown_report(rows: List[Dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    total = len(rows)
+    ok = sum(1 for r in rows if r.get("status") == "ok" and not r.get("failure_flags"))
+    errored = sum(1 for r in rows if r.get("status") != "ok")
+    flagged = sum(1 for r in rows if r.get("failure_flags"))
+    lines = [
+        "# web-search-plus Golden Query Evaluation",
+        "",
+        f"Generated: {datetime.now(timezone.utc).isoformat()}",
+        "",
+        "## Summary",
+        "",
+        f"- Rows: {total}",
+        f"- Clean: {ok}",
+        f"- Flagged: {flagged}",
+        f"- Errors: {errored}",
+        "",
+        "## Results",
+        "",
+    ]
+    for row in rows:
+        flags = ", ".join(row.get("failure_flags") or []) or "none"
+        providers = row.get("providers_queried") or row.get("provider") or "unknown"
+        lines.extend([
+            f"### {row['id']} — {row['mode']}",
+            f"- Category: {row.get('category')}",
+            f"- Provider(s): {providers}",
+            f"- Status: {row.get('status')} / flags: {flags}",
+            f"- Latency: {row.get('latency_ms')} ms",
+            f"- Results: {row.get('result_count')} / source summaries: {row.get('source_summary_count')}",
+            f"- Domains: {row.get('domain_count')} / diversity: {row.get('domain_diversity')}",
+            f"- Dedup: {row.get('dedup_count')} / extract recommended: {row.get('extract_recommended')}",
+            "",
+        ])
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run web-search-plus golden query evaluation")
+    parser.add_argument("--queries", type=Path, help="Optional JSON file with golden query cases")
+    parser.add_argument("--modes", nargs="+", default=["normal", "research"], choices=["normal", "research"])
+    parser.add_argument("--max-results", type=int, default=4)
+    parser.add_argument("--research-extract-count", type=int, default=2)
+    parser.add_argument("--timeout", type=int, default=90)
+    parser.add_argument("--out", type=Path, default=Path("eval/golden-results.jsonl"))
+    parser.add_argument("--report", type=Path, default=Path("eval/golden-report.md"))
+    parser.add_argument("--limit", type=int, help="Limit number of cases for smoke runs")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "search.py"
+    cases = load_golden_queries(args.queries)
+    if args.limit:
+        cases = cases[: args.limit]
+
+    env = os.environ.copy()
+    rows: List[Dict[str, Any]] = []
+    for case in cases:
+        rows.extend(run_case(
+            case=case,
+            script_path=script_path,
+            modes=args.modes,
+            max_results=args.max_results,
+            research_extract_count=args.research_extract_count,
+            timeout_seconds=args.timeout,
+            env=env,
+        ))
+
+    write_jsonl(rows, repo_root / args.out if not args.out.is_absolute() else args.out)
+    write_markdown_report(rows, repo_root / args.report if not args.report.is_absolute() else args.report)
+    print(json.dumps({
+        "cases": len(cases),
+        "rows": len(rows),
+        "out": str(args.out),
+        "report": str(args.report),
+        "flagged": sum(1 for r in rows if r.get("failure_flags")),
+        "errors": sum(1 for r in rows if r.get("status") != "ok"),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/search.py
+++ b/search.py
@@ -1689,12 +1689,28 @@ def run_research_mode(
     extract_urls,
     max_results: int,
     max_extract_urls: int = 3,
+    time_budget_seconds: float | None = None,
+    now_fn=None,
 ) -> Dict[str, Any]:
-    """Run broad search, deduplicate, then extract top sources for grounding."""
+    """Run broad search, deduplicate, then extract top sources for grounding.
+
+    Research mode is intentionally best-effort: provider/extraction failures should
+    produce diagnostics and partial search results instead of throwing away the
+    whole response. The optional time budget is checked between expensive calls so
+    the mode can degrade safely before starting more provider work or extraction.
+    """
     provider_results: List[Tuple[str, Dict[str, Any]]] = []
     provider_errors: List[Dict[str, Any]] = []
+    now = now_fn or time.monotonic
+    start = now()
+
+    def budget_exhausted() -> bool:
+        return time_budget_seconds is not None and (now() - start) >= time_budget_seconds
 
     for provider in research_providers:
+        if budget_exhausted():
+            provider_errors.append({"provider": provider, "error": "skipped: research time budget exhausted"})
+            continue
         try:
             payload = execute_search(provider)
             provider_results.append((provider, payload))
@@ -1702,24 +1718,40 @@ def run_research_mode(
             provider_errors.append({"provider": provider, "error": str(e)})
 
     deduped, dedup_count = deduplicate_results_across_providers(provider_results, max_results)
-    urls = [r.get("url") for r in deduped if r.get("url")][:max_extract_urls]
-    extracted = extract_urls(urls) if urls else {"provider": None, "results": []}
+    urls = [r.get("url") for r in deduped if r.get("url")][:max(0, max_extract_urls)]
+    extracted = {"provider": None, "results": []}
+    extraction_error = None
+    if urls:
+        if budget_exhausted():
+            extraction_error = "skipped: research time budget exhausted"
+        else:
+            try:
+                extracted = extract_urls(urls) or {"provider": None, "results": []}
+            except Exception as e:
+                extraction_error = str(e)
+                extracted = {"provider": None, "results": []}
+
+    routing = {
+        "providers_queried": [p for p, _ in provider_results],
+        "provider_errors": provider_errors,
+        "extraction_provider": extracted.get("provider"),
+    }
+    if extraction_error:
+        routing["extraction_error"] = extraction_error
+
+    source_summaries = extracted.get("results", []) or []
 
     return {
         "mode": "research",
         "provider": "research",
         "query": query,
         "results": deduped,
-        "source_summaries": extracted.get("results", []),
-        "routing": {
-            "providers_queried": [p for p, _ in provider_results],
-            "provider_errors": provider_errors,
-            "extraction_provider": extracted.get("provider"),
-        },
+        "source_summaries": source_summaries,
+        "routing": routing,
         "metadata": {
             "dedup_count": dedup_count,
             "providers_merged": [p for p, _ in provider_results],
-            "extracted_url_count": len(urls),
+            "extracted_url_count": len(source_summaries),
         },
     }
 
@@ -3506,6 +3538,12 @@ Full docs: See README.md and SKILL.md
         default=3,
         help="Number of top research-mode URLs to extract for grounding"
     )
+    parser.add_argument(
+        "--research-time-budget",
+        type=float,
+        default=55.0,
+        help="Best-effort wall-clock budget for research mode; skips remaining providers/extraction between calls when exhausted"
+    )
     
     # Caching options
     parser.add_argument(
@@ -3830,6 +3868,7 @@ Full docs: See README.md and SKILL.md
             ),
             max_results=args.max_results,
             max_extract_urls=args.research_extract_count,
+            time_budget_seconds=args.research_time_budget,
         )
         routing_info["mode"] = "research"
         routing_info["provider"] = "research"

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 1.6.1
+Version: 1.7.0
 Supports search providers: Serper (Google), Brave Search, Tavily, Querit,
 Linkup, Exa, Firecrawl, Perplexity, You.com, SearXNG.
 Supports extract providers: Firecrawl, Linkup, Tavily, Exa, You.com.

--- a/search.py
+++ b/search.py
@@ -1580,6 +1580,150 @@ def _choose_tie_winner(query: str, winners: List[str], priority: List[str]) -> s
     return ordered_winners[idx]
 
 
+def _result_domain(url: str) -> str:
+    try:
+        netloc = urlparse(url or "").netloc.lower()
+        return netloc[4:] if netloc.startswith("www.") else netloc
+    except Exception:
+        return ""
+
+
+def _snippet_text(item: Dict[str, Any]) -> str:
+    return " ".join(
+        str(item.get(k) or "")
+        for k in ("description", "snippet", "content", "raw_content", "summary")
+    ).strip()
+
+
+def build_quality_report(
+    query: str,
+    result: Dict[str, Any],
+    routing_info: Dict[str, Any],
+    providers_considered: List[str],
+    eligible_providers: List[str],
+    cooldown_skips: List[Dict[str, Any]],
+    errors: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Build transparent search-quality diagnostics without changing results."""
+    results = result.get("results", []) or []
+    domains = [_result_domain(r.get("url", "")) for r in results]
+    domains = [d for d in domains if d]
+    unique_domains = sorted(set(domains))
+    duplicate_count = int(result.get("metadata", {}).get("dedup_count", 0) or 0)
+
+    short_snippets = 0
+    for item in results:
+        if len(_snippet_text(item)) < 40:
+            short_snippets += 1
+
+    extract_reasons: List[str] = []
+    confidence_level = routing_info.get("confidence_level") or "unknown"
+    confidence_score = routing_info.get("confidence")
+    if confidence_level == "low" or (confidence_score is not None and float(confidence_score or 0) < 0.4):
+        extract_reasons.append("low routing confidence")
+    if len(results) < 3:
+        extract_reasons.append("few search results")
+    if results and len(unique_domains) <= 1:
+        extract_reasons.append("low domain diversity")
+    if duplicate_count:
+        extract_reasons.append("duplicate results detected")
+    if results and short_snippets / max(len(results), 1) >= 0.5:
+        extract_reasons.append("thin snippets")
+
+    skipped = []
+    for item in cooldown_skips:
+        skipped.append({
+            "provider": item.get("provider"),
+            "reason": "cooldown",
+            "cooldown_remaining_seconds": item.get("cooldown_remaining_seconds"),
+        })
+    for err in errors:
+        skipped.append({
+            "provider": err.get("provider"),
+            "reason": "error",
+            "error": err.get("error"),
+        })
+
+    return {
+        "query": query,
+        "selected_provider": routing_info.get("provider") or result.get("provider"),
+        "routing_reason": routing_info.get("reason"),
+        "confidence": confidence_level,
+        "confidence_score": routing_info.get("confidence"),
+        "providers_considered": providers_considered,
+        "eligible_providers": eligible_providers,
+        "skipped_providers": skipped,
+        "result_count": len(results),
+        "domain_count": len(unique_domains),
+        "domains": unique_domains,
+        "domain_diversity": (len(unique_domains) / len(results)) if results else 0.0,
+        "duplicate_count": duplicate_count,
+        "thin_snippet_count": short_snippets,
+        "extract_recommended": bool(extract_reasons),
+        "extract_reasons": extract_reasons,
+        "scores": routing_info.get("scores", {}),
+    }
+
+
+def select_research_providers(
+    primary_provider: str,
+    provider_priority: List[str],
+    available_providers: set,
+    max_providers: int = 3,
+) -> List[str]:
+    """Pick a compact provider set for research mode."""
+    preferred = [primary_provider, "linkup", "tavily", "exa", "firecrawl", "brave", "serper", "you", "querit"]
+    ordered: List[str] = []
+    for provider in preferred + provider_priority:
+        if provider and provider in available_providers and provider not in ordered:
+            ordered.append(provider)
+        if len(ordered) >= max_providers:
+            break
+    return ordered
+
+
+def run_research_mode(
+    query: str,
+    research_providers: List[str],
+    execute_search,
+    extract_urls,
+    max_results: int,
+    max_extract_urls: int = 3,
+) -> Dict[str, Any]:
+    """Run broad search, deduplicate, then extract top sources for grounding."""
+    provider_results: List[Tuple[str, Dict[str, Any]]] = []
+    provider_errors: List[Dict[str, Any]] = []
+
+    for provider in research_providers:
+        try:
+            payload = execute_search(provider)
+            provider_results.append((provider, payload))
+        except Exception as e:
+            provider_errors.append({"provider": provider, "error": str(e)})
+
+    deduped, dedup_count = deduplicate_results_across_providers(provider_results, max_results)
+    urls = [r.get("url") for r in deduped if r.get("url")][:max_extract_urls]
+    extracted = extract_urls(urls) if urls else {"provider": None, "results": []}
+
+    return {
+        "mode": "research",
+        "provider": "research",
+        "query": query,
+        "results": deduped,
+        "source_summaries": extracted.get("results", []),
+        "routing": {
+            "providers_queried": [p for p, _ in provider_results],
+            "provider_errors": provider_errors,
+            "extraction_provider": extracted.get("provider"),
+        },
+        "metadata": {
+            "dedup_count": dedup_count,
+            "providers_merged": [p for p, _ in provider_results],
+            "extracted_url_count": len(urls),
+        },
+    }
+
+
 # =============================================================================
 # HTTP Client
 # =============================================================================
@@ -3340,6 +3484,28 @@ Full docs: See README.md and SKILL.md
     
     # Output
     parser.add_argument("--compact", action="store_true")
+    parser.add_argument(
+        "--quality-report",
+        action="store_true",
+        help="Attach transparent routing/result diagnostics to the JSON output"
+    )
+    parser.add_argument(
+        "--mode",
+        default="normal",
+        choices=["normal", "research"],
+        help="Search mode: normal single-provider route or research multi-provider + extraction"
+    )
+    parser.add_argument(
+        "--research-providers",
+        nargs="+",
+        help="Explicit provider list for --mode research"
+    )
+    parser.add_argument(
+        "--research-extract-count",
+        type=int,
+        default=3,
+        help="Number of top research-mode URLs to extract for grounding"
+    )
     
     # Caching options
     parser.add_argument(
@@ -3615,7 +3781,71 @@ Full docs: See README.md and SKILL.md
         "exa_verbosity": args.exa_verbosity,
         "category": args.category,
         "similar_url": args.similar_url,
+        "mode": args.mode,
+        "quality_report": args.quality_report,
     }
+
+    providers_considered = providers_to_try.copy()
+
+    if args.mode == "research":
+        available_research_providers = {
+            p for p in providers_to_try
+            if p not in disabled_providers and get_api_key(p, config) and not provider_in_cooldown(p)[0]
+        }
+        if provider and get_api_key(provider, config) and not provider_in_cooldown(provider)[0]:
+            available_research_providers.add(provider)
+        if args.research_providers:
+            research_providers = [
+                p for p in args.research_providers
+                if p not in disabled_providers and get_api_key(p, config) and not provider_in_cooldown(p)[0]
+            ]
+        else:
+            research_providers = select_research_providers(
+                primary_provider=provider,
+                provider_priority=provider_priority,
+                available_providers=available_research_providers,
+                max_providers=3,
+            )
+
+        if not research_providers:
+            error_result = {
+                "error": "No configured providers available for research mode",
+                "provider": provider,
+                "query": args.query,
+                "routing": routing_info,
+                "cooldown_skips": cooldown_skips,
+            }
+            print(json.dumps(error_result, indent=2), file=sys.stderr)
+            sys.exit(1)
+
+        result = run_research_mode(
+            query=args.query,
+            research_providers=research_providers,
+            execute_search=execute_with_retry,
+            extract_urls=lambda urls: extract_plus(
+                urls=urls,
+                provider="linkup",
+                output_format="markdown",
+                config=config,
+            ),
+            max_results=args.max_results,
+            max_extract_urls=args.research_extract_count,
+        )
+        routing_info["mode"] = "research"
+        routing_info["provider"] = "research"
+        result["routing"].update(routing_info)
+        result["quality_report"] = build_quality_report(
+            query=args.query,
+            result=result,
+            routing_info=routing_info,
+            providers_considered=providers_considered,
+            eligible_providers=research_providers,
+            cooldown_skips=cooldown_skips,
+            errors=result.get("routing", {}).get("provider_errors", []),
+        )
+        indent = None if args.compact else 2
+        print(json.dumps(result, indent=indent, ensure_ascii=False))
+        return
 
     # Check cache first (unless --no-cache is set)
     cached_result = None
@@ -3714,6 +3944,17 @@ Full docs: See README.md and SKILL.md
             result["deduplicated"] = False
             result.setdefault("metadata", {})
             result["metadata"].setdefault("dedup_count", 0)
+
+        if args.quality_report:
+            result["quality_report"] = build_quality_report(
+                query=args.query,
+                result=result,
+                routing_info=routing_info,
+                providers_considered=providers_considered,
+                eligible_providers=eligible_providers,
+                cooldown_skips=cooldown_skips,
+                errors=errors,
+            )
 
         indent = None if args.compact else 2
         print(json.dumps(result, indent=indent, ensure_ascii=False))

--- a/tests/test_golden_eval.py
+++ b/tests/test_golden_eval.py
@@ -1,0 +1,125 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts import golden_eval
+
+
+class GoldenEvalTests(unittest.TestCase):
+    def test_load_golden_queries_has_core_categories(self):
+        cases = golden_eval.load_golden_queries()
+        categories = {case["category"] for case in cases}
+
+        self.assertGreaterEqual(len(cases), 8)
+        self.assertIn("hifi_product", categories)
+        self.assertIn("local_realtime", categories)
+        self.assertIn("tech_release", categories)
+        self.assertIn("research_policy", categories)
+        self.assertIn("german_realtime", categories)
+        self.assertIn("reddit_community", categories)
+        self.assertIn("academic", categories)
+        self.assertIn("js_extraction", categories)
+
+    def test_summarize_result_flags_failures_and_metrics(self):
+        payload = {
+            "provider": "research",
+            "results": [
+                {"url": "https://example.com/a"},
+                {"url": "https://example.org/b"},
+            ],
+            "source_summaries": [{"url": "https://example.com/a", "content": "x" * 120}],
+            "quality_report": {
+                "domain_count": 2,
+                "domain_diversity": 1.0,
+                "duplicate_count": 1,
+                "extract_recommended": False,
+            },
+            "metadata": {"dedup_count": 1},
+        }
+
+        row = golden_eval.summarize_result(
+            case={"id": "q1", "category": "research_policy", "query": "EU AI Act"},
+            mode="research",
+            payload=payload,
+            latency_ms=1234,
+            returncode=0,
+            stderr="",
+        )
+
+        self.assertEqual(row["id"], "q1")
+        self.assertEqual(row["mode"], "research")
+        self.assertEqual(row["provider"], "research")
+        self.assertEqual(row["result_count"], 2)
+        self.assertEqual(row["source_summary_count"], 1)
+        self.assertEqual(row["extracted_chars"], 120)
+        self.assertEqual(row["dedup_count"], 1)
+        self.assertEqual(row["status"], "ok")
+        self.assertEqual(row["failure_flags"], [])
+
+    def test_summarize_result_marks_empty_and_provider_error(self):
+        row = golden_eval.summarize_result(
+            case={"id": "q2", "category": "tech_release", "query": "latest release"},
+            mode="normal",
+            payload={"error": "All providers failed", "provider": "auto", "results": []},
+            latency_ms=50,
+            returncode=1,
+            stderr="boom",
+        )
+
+        self.assertEqual(row["status"], "error")
+        self.assertIn("no_results", row["failure_flags"])
+        self.assertIn("provider_error", row["failure_flags"])
+        self.assertIn("nonzero_exit", row["failure_flags"])
+
+    def test_write_jsonl_and_markdown_report(self):
+        rows = [
+            {"id": "q1", "mode": "normal", "status": "ok", "failure_flags": [], "latency_ms": 100, "provider": "linkup", "result_count": 3, "source_summary_count": 0, "domain_diversity": 1.0, "extract_recommended": False},
+            {"id": "q1", "mode": "research", "status": "ok", "failure_flags": ["slow"], "latency_ms": 22000, "provider": "research", "result_count": 4, "source_summary_count": 2, "domain_diversity": 1.0, "extract_recommended": False},
+        ]
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "eval.jsonl"
+            report = Path(td) / "report.md"
+            golden_eval.write_jsonl(rows, out)
+            golden_eval.write_markdown_report(rows, report)
+
+            lines = out.read_text().splitlines()
+            self.assertEqual(len(lines), 2)
+            self.assertEqual(json.loads(lines[0])["id"], "q1")
+            text = report.read_text()
+            self.assertIn("# web-search-plus Golden Query Evaluation", text)
+            self.assertIn("normal", text)
+            self.assertIn("research", text)
+
+    def test_run_case_builds_expected_commands(self):
+        calls = []
+
+        def fake_run(cmd, capture_output, text, timeout, env):
+            calls.append(cmd)
+            class Result:
+                returncode = 0
+                stdout = json.dumps({"provider": "linkup", "results": [{"url": "https://example.com"}], "quality_report": {}})
+                stderr = ""
+            return Result()
+
+        with mock.patch("scripts.golden_eval.subprocess.run", side_effect=fake_run):
+            rows = golden_eval.run_case(
+                case={"id": "q1", "category": "hifi_product", "query": "turntables"},
+                script_path=Path("search.py"),
+                modes=["normal", "research"],
+                max_results=3,
+                research_extract_count=1,
+                timeout_seconds=10,
+                env={},
+            )
+
+        self.assertEqual(len(rows), 2)
+        self.assertIn("--quality-report", calls[0])
+        self.assertNotIn("--mode", calls[0])
+        self.assertIn("--mode", calls[1])
+        self.assertIn("research", calls[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quality_research.py
+++ b/tests/test_quality_research.py
@@ -145,6 +145,62 @@ class ResearchModeTests(unittest.TestCase):
         ])
         self.assertEqual(result["source_summaries"][0]["content"], "content for https://example.com/a")
 
+    def test_research_mode_keeps_search_results_when_extraction_fails(self):
+        def execute(provider):
+            return {"provider": provider, "results": [
+                {"url": "https://source.test/a", "title": "A", "description": "Alpha"},
+            ]}
+
+        def extract(urls):
+            raise RuntimeError("extract provider timed out")
+
+        result = search.run_research_mode(
+            query="grounded answer please",
+            research_providers=["linkup"],
+            execute_search=execute,
+            extract_urls=extract,
+            max_results=3,
+            max_extract_urls=1,
+        )
+
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["source_summaries"], [])
+        self.assertEqual(result["routing"]["extraction_provider"], None)
+        self.assertEqual(result["routing"]["extraction_error"], "extract provider timed out")
+        self.assertEqual(result["metadata"]["extracted_url_count"], 0)
+
+    def test_research_mode_respects_time_budget_between_providers_and_skips_extract(self):
+        ticks = iter([0.0, 0.0, 6.0, 6.0])
+        calls = []
+
+        def now():
+            return next(ticks)
+
+        def execute(provider):
+            calls.append(provider)
+            return {"provider": provider, "results": [
+                {"url": f"https://{provider}.test/a", "title": provider, "description": "Result"},
+            ]}
+
+        def extract(urls):
+            raise AssertionError("extract should be skipped once budget is exhausted")
+
+        result = search.run_research_mode(
+            query="time boxed research",
+            research_providers=["linkup", "tavily"],
+            execute_search=execute,
+            extract_urls=extract,
+            max_results=5,
+            max_extract_urls=1,
+            time_budget_seconds=5,
+            now_fn=now,
+        )
+
+        self.assertEqual(calls, ["linkup"])
+        self.assertEqual(result["routing"]["provider_errors"], [{"provider": "tavily", "error": "skipped: research time budget exhausted"}])
+        self.assertEqual(result["routing"]["extraction_error"], "skipped: research time budget exhausted")
+        self.assertEqual(result["metadata"]["extracted_url_count"], 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_quality_research.py
+++ b/tests/test_quality_research.py
@@ -1,0 +1,150 @@
+import unittest
+
+import search
+
+
+class QualityReportTests(unittest.TestCase):
+    def test_quality_report_scores_domain_diversity_and_extract_need(self):
+        result = {
+            "results": [
+                {"url": "https://example.com/a", "title": "A", "description": "short"},
+                {"url": "https://example.com/b", "title": "B", "description": "tiny"},
+                {"url": "https://news.example.org/c", "title": "C", "description": "useful enough snippet for source triage"},
+            ],
+            "metadata": {"dedup_count": 2},
+        }
+        routing = {
+            "provider": "tavily",
+            "confidence": 0.32,
+            "confidence_level": "low",
+            "reason": "low confidence test",
+            "scores": {"tavily": 4.0, "exa": 3.7},
+        }
+
+        report = search.build_quality_report(
+            query="explain some obscure topic",
+            result=result,
+            routing_info=routing,
+            providers_considered=["tavily", "exa", "linkup"],
+            eligible_providers=["tavily", "exa"],
+            cooldown_skips=[{"provider": "linkup", "cooldown_remaining_seconds": 42}],
+            errors=[{"provider": "brave", "error": "missing key"}],
+        )
+
+        self.assertEqual(report["selected_provider"], "tavily")
+        self.assertEqual(report["duplicate_count"], 2)
+        self.assertEqual(report["domain_count"], 2)
+        self.assertAlmostEqual(report["domain_diversity"], 2 / 3)
+        self.assertEqual(report["confidence"], "low")
+        self.assertTrue(report["extract_recommended"])
+        self.assertIn("low routing confidence", report["extract_reasons"])
+        self.assertEqual(report["skipped_providers"][0]["provider"], "linkup")
+
+    def test_quality_report_high_confidence_diverse_results_do_not_need_extract(self):
+        result = {
+            "results": [
+                {"url": "https://a.example/1", "description": "clear snippet " * 8},
+                {"url": "https://b.example/2", "description": "clear snippet " * 8},
+                {"url": "https://c.example/3", "description": "clear snippet " * 8},
+            ],
+            "metadata": {"dedup_count": 0},
+        }
+        routing = {"provider": "brave", "confidence_level": "high", "confidence": 0.91, "reason": "clear"}
+
+        report = search.build_quality_report(
+            query="weather graz today",
+            result=result,
+            routing_info=routing,
+            providers_considered=["brave"],
+            eligible_providers=["brave"],
+            cooldown_skips=[],
+            errors=[],
+        )
+
+        self.assertFalse(report["extract_recommended"])
+        self.assertEqual(report["extract_reasons"], [])
+
+    def test_quality_report_for_forced_provider_does_not_treat_missing_confidence_as_low(self):
+        result = {
+            "results": [
+                {"url": "https://a.example/1", "description": "clear snippet " * 8},
+                {"url": "https://b.example/2", "description": "clear snippet " * 8},
+                {"url": "https://c.example/3", "description": "clear snippet " * 8},
+            ],
+            "metadata": {"dedup_count": 0},
+        }
+        routing = {"auto_routed": False, "provider": "linkup"}
+
+        report = search.build_quality_report(
+            query="best turntables under 1000 euro",
+            result=result,
+            routing_info=routing,
+            providers_considered=["linkup"],
+            eligible_providers=["linkup"],
+            cooldown_skips=[],
+            errors=[],
+        )
+
+        self.assertEqual(report["confidence"], "unknown")
+        self.assertFalse(report["extract_recommended"])
+        self.assertNotIn("low routing confidence", report["extract_reasons"])
+
+
+class ResearchModeTests(unittest.TestCase):
+    def test_select_research_providers_prefers_primary_plus_source_providers(self):
+        selected = search.select_research_providers(
+            primary_provider="tavily",
+            provider_priority=["tavily", "linkup", "exa", "firecrawl", "brave"],
+            available_providers={"tavily", "linkup", "exa", "brave"},
+            max_providers=3,
+        )
+
+        self.assertEqual(selected, ["tavily", "linkup", "exa"])
+
+    def test_research_mode_merges_dedups_and_extracts_top_sources(self):
+        provider_payloads = {
+            "tavily": {"provider": "tavily", "results": [
+                {"url": "https://example.com/a", "title": "A", "description": "Alpha"},
+                {"url": "https://example.com/dupe", "title": "Dupe", "description": "Duplicate"},
+            ]},
+            "linkup": {"provider": "linkup", "results": [
+                {"url": "https://example.com/dupe", "title": "Dupe 2", "description": "Duplicate again"},
+                {"url": "https://other.test/b", "title": "B", "description": "Beta"},
+            ]},
+        }
+        calls = []
+
+        def execute(provider):
+            calls.append(provider)
+            return provider_payloads[provider]
+
+        def extract(urls):
+            return {"provider": "linkup", "results": [{"url": u, "content": f"content for {u}"} for u in urls]}
+
+        result = search.run_research_mode(
+            query="compare alpha beta",
+            research_providers=["tavily", "linkup"],
+            execute_search=execute,
+            extract_urls=extract,
+            max_results=5,
+            max_extract_urls=2,
+        )
+
+        self.assertEqual(calls, ["tavily", "linkup"])
+        self.assertEqual(result["mode"], "research")
+        self.assertEqual(result["routing"]["providers_queried"], ["tavily", "linkup"])
+        self.assertEqual(result["metadata"]["dedup_count"], 1)
+        self.assertEqual([r["url"] for r in result["results"]], [
+            "https://example.com/a",
+            "https://example.com/dupe",
+            "https://other.test/b",
+        ])
+        self.assertEqual([s["url"] for s in result["source_summaries"]], [
+            "https://example.com/a",
+            "https://example.com/dupe",
+        ])
+        self.assertEqual(result["source_summaries"][0]["content"], "content for https://example.com/a")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add opt-in `quality_report` diagnostics for routed search results
- Add opt-in `mode="research"` for multi-provider search + top-source extraction
- Add golden-query evaluator for live provider smoke/regression runs
- Harden research mode so extraction failures and exhausted time budgets degrade to partial results instead of killing the response

## Validation
- `ruff check .`
- `python3 -m pytest tests/ -q` → 47 passed
- `python3 -m py_compile search.py __init__.py scripts/golden_eval.py`
- CLI smoke: `python3 search.py --help | grep -E 'quality-report|mode|research-time-budget'`
- Privacy scan found only public Tailscale release-note golden-query text; no secrets/private host/chat data

## Notes
Research mode remains opt-in. Default fast search behavior is unchanged.