### PR TITLE
feat: add lightweight answer locale detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@
 - Provider-key wording is capability-based: no single key is globally required; search keys enable search/answer, extraction-capable keys enable URL extraction and fuller cited answers.
 - Answer defaults stay budget-safe: quick mode uses 3 sources and up to 2 extracts; deep mode uses broader search with extraction hard-capped at 5 URLs.
 - `web_answer_plus` prefers Linkup for extraction, falls back to the normal extraction chain when another extract provider is configured, and degrades to snippet-backed answers with an explicit warning when no extraction provider exists.
-- `web_answer_plus` now has a lightweight in-process locale layer for EN/DE/ES/FR/IT/PT, script hints for non-Latin queries, localized freshness terms, and intent hints without adding external detector dependencies or logging raw queries.
+- `web_answer_plus` now has a lightweight in-process locale layer for EN/DE/ES/FR/IT/PT/NL/PL, script hints for non-Latin queries including Hans/Hant Chinese, localized freshness terms, and intent hints without adding external detector dependencies or logging raw queries.
 
 ### 🧪 Tests
-- Added regression coverage for answer defaults, freshness detection, citation normalization, locale hints, multilingual locale/intent detection, output shapes, quick/deep mode selection, fallback extractor cost metadata, extraction status, cost guards, provider catalog, full-provider default setup, optional presets, setup dashboard rendering, dry-run setup behavior, empty-key tool gating, and onboarding hints.
-- Test suite: 84/84 unit tests passing locally.
+- Added regression coverage for answer defaults, freshness detection, citation normalization, locale hints, multilingual locale/intent detection, Dutch/Polish locale detection, Traditional Chinese script hints, detector input normalization/capping, output shapes, quick/deep mode selection, fallback extractor cost metadata, extraction status, cost guards, provider catalog, full-provider default setup, optional presets, setup dashboard rendering, dry-run setup behavior, empty-key tool gating, and onboarding hints.
+- Test suite: 89/89 unit tests passing locally.
 
 ## [v1.7.1] — 2026-05-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@
 - Provider-key wording is capability-based: no single key is globally required; search keys enable search/answer, extraction-capable keys enable URL extraction and fuller cited answers.
 - Answer defaults stay budget-safe: quick mode uses 3 sources and up to 2 extracts; deep mode uses broader search with extraction hard-capped at 5 URLs.
 - `web_answer_plus` prefers Linkup for extraction, falls back to the normal extraction chain when another extract provider is configured, and degrades to snippet-backed answers with an explicit warning when no extraction provider exists.
+- `web_answer_plus` now has a lightweight in-process locale layer for EN/DE/ES/FR/IT/PT, script hints for non-Latin queries, localized freshness terms, and intent hints without adding external detector dependencies or logging raw queries.
 
 ### 🧪 Tests
-- Added regression coverage for answer defaults, freshness detection, citation normalization, locale hints, output shapes, quick/deep mode selection, fallback extractor cost metadata, extraction status, cost guards, provider catalog, full-provider default setup, optional presets, setup dashboard rendering, dry-run setup behavior, empty-key tool gating, and onboarding hints.
-- Test suite: 80/80 unit tests passing locally.
+- Added regression coverage for answer defaults, freshness detection, citation normalization, locale hints, multilingual locale/intent detection, output shapes, quick/deep mode selection, fallback extractor cost metadata, extraction status, cost guards, provider catalog, full-provider default setup, optional presets, setup dashboard rendering, dry-run setup behavior, empty-key tool gating, and onboarding hints.
+- Test suite: 84/84 unit tests passing locally.
 
 ## [v1.7.1] — 2026-05-06
 

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ Defaults are intentionally conservative:
 
 - `quick` mode asks for 3 sources and extracts up to 2 URLs.
 - `deep` mode asks for 6 sources and uses research mode, with extraction still hard-capped at 5 URLs.
-- `freshness="auto"` applies recency filters only when the query looks current/news/date-sensitive, including common DE/ES/FR/IT/PT news terms.
-- `language="auto"` uses lightweight in-process script/language hints for EN, DE, ES, FR, IT, and PT; unsupported scripts stay conservative and never call an external detector.
+- `freshness="auto"` applies recency filters only when the query looks current/news/date-sensitive, including common DE/ES/FR/IT/PT/NL/PL and Chinese news terms.
+- `language="auto"` uses lightweight in-process script/language hints for EN, DE, ES, FR, IT, PT, NL, and PL, plus coarse script hints for Arab/Cyrl/Jpan/Hans/Hant without external detector calls.
 - Linkup is preferred for extraction; other extraction providers are used through the normal fallback chain.
 - If no extraction provider is configured, answers are snippet-backed and carry an explicit warning.
 
@@ -152,7 +152,7 @@ Parameters:
 | `sources` | integer | quick `3`, deep `6` | Citation-ready sources to return, max 10 |
 | `freshness` | string | `"auto"` | `auto`, `none`, `day`, `week`, `month`, `year` |
 | `output` | string | `"answer"` | `answer`, `brief`, `sources`, or `json` |
-| `language` | string | `"auto"` | Optional language code such as `de`, `en`, `es`, `fr`, `it`, `pt` |
+| `language` | string | `"auto"` | Optional language code such as `de`, `en`, `es`, `fr`, `it`, `pt`, `nl`, `pl` |
 | `country` | string | `"auto"` | Optional country/region code such as `AT`, `DE`, `US` |
 | `max_extracts` | integer | `2` | Advanced cost guard; hard-capped at 5 |
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Defaults are intentionally conservative:
 
 - `quick` mode asks for 3 sources and extracts up to 2 URLs.
 - `deep` mode asks for 6 sources and uses research mode, with extraction still hard-capped at 5 URLs.
-- `freshness="auto"` applies recency filters only when the query looks current/news/date-sensitive.
+- `freshness="auto"` applies recency filters only when the query looks current/news/date-sensitive, including common DE/ES/FR/IT/PT news terms.
+- `language="auto"` uses lightweight in-process script/language hints for EN, DE, ES, FR, IT, and PT; unsupported scripts stay conservative and never call an external detector.
 - Linkup is preferred for extraction; other extraction providers are used through the normal fallback chain.
 - If no extraction provider is configured, answers are snippet-backed and carry an explicit warning.
 
@@ -151,7 +152,7 @@ Parameters:
 | `sources` | integer | quick `3`, deep `6` | Citation-ready sources to return, max 10 |
 | `freshness` | string | `"auto"` | `auto`, `none`, `day`, `week`, `month`, `year` |
 | `output` | string | `"answer"` | `answer`, `brief`, `sources`, or `json` |
-| `language` | string | `"auto"` | Optional language code such as `de`, `en`, `es`, `fr` |
+| `language` | string | `"auto"` | Optional language code such as `de`, `en`, `es`, `fr`, `it`, `pt` |
 | `country` | string | `"auto"` | Optional country/region code such as `AT`, `DE`, `US` |
 | `max_extracts` | integer | `2` | Advanced cost guard; hard-capped at 5 |
 

--- a/__init__.py
+++ b/__init__.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 import threading
 import time
+import unicodedata
 import webbrowser
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
@@ -718,10 +719,22 @@ def _format_extract_results(data: dict) -> str:
     return "\n".join(lines).strip()
 
 
+_ANSWER_DETECTOR_MAX_CHARS = 1000
+_ANSWER_LATIN_CONFIDENCE_THRESHOLD = 2
+_ANSWER_TRADITIONAL_CHINESE_MARKERS = "臺灣體評價氣訊網龍門開關學國買賣與專業"
+
 _ANSWER_LANGUAGE_PROFILES = {
     "de": {
         "terms": ["der", "die", "das", "und", "für", "was", "wie", "preis", "günstig", "vergleich", "österreich", "deutschland", "schweiz", "nachrichten", "definieren"],
         "diacritics": "äöüß",
+    },
+    "nl": {
+        "terms": ["de", "het", "een", "wat", "hoe", "zijn", "voor", "prijs", "prijzen", "goedkoop", "vergelijk", "beste", "nederland", "belgië", "nieuws", "laatste", "deze week"],
+        "diacritics": "ëïéèá",
+    },
+    "pl": {
+        "terms": ["co", "jak", "dla", "cena", "najlepsza", "najlepsze", "tani", "porównanie", "polska", "polsce", "wiadomości", "najnowsze", "tygodniu"],
+        "diacritics": "ąćęłńóśźż",
     },
     "es": {
         "terms": ["el", "la", "los", "las", "qué", "que", "cómo", "como", "tiempo", "precio", "barato", "comparación", "alternativas", "españa", "méxico", "noticias"],
@@ -746,13 +759,18 @@ _ANSWER_LANGUAGE_PROFILES = {
 }
 
 _ANSWER_INTENT_TERMS = {
-    "weather": ["weather", "forecast", "wetter", "tiempo", "météo", "meteo", "tempo"],
-    "news": ["news", "latest", "updates", "nachrichten", "neueste", "noticias", "nouvelles", "notizie", "notícias"],
-    "define": ["define", "definition", "what is", "was ist", "definieren", "definición", "définition", "definizione", "definição"],
-    "shopping": ["price", "cheap", "buy", "review", "preis", "günstig", "vergleich", "precio", "barato", "preço", "preços", "pas cher", "prezzo"],
-    "time": ["time in", "uhrzeit", "hora en", "heure à", "ora a"],
-    "calc": ["calculate", "berechne", "calcular", "calculer", "calcola"],
+    "weather": ["weather", "forecast", "wetter", "tiempo", "météo", "meteo", "tempo", "pogoda", "weer"],
+    "news": ["news", "latest", "updates", "nachrichten", "neueste", "noticias", "nouvelles", "notizie", "notícias", "nieuws", "laatste", "wiadomości", "najnowsze", "最新", "消息"],
+    "define": ["define", "definition", "what is", "was ist", "definieren", "definición", "définition", "definizione", "definição", "definitie", "definicja"],
+    "shopping": ["price", "cheap", "buy", "review", "preis", "günstig", "vergleich", "precio", "barato", "preço", "preços", "pas cher", "prezzo", "prijs", "prijzen", "goedkoop", "cena", "tani", "評測", "評價"],
+    "time": ["time in", "uhrzeit", "hora en", "heure à", "ora a", "tijd in", "czas w"],
+    "calc": ["calculate", "berechne", "calcular", "calculer", "calcola", "bereken", "oblicz"],
 }
+
+
+def _normalize_answer_detector_input(query: str) -> str:
+    """Normalize and cap detector input before regex work."""
+    return unicodedata.normalize("NFKC", query or "")[:_ANSWER_DETECTOR_MAX_CHARS]
 
 
 def _detect_answer_script(query: str) -> str:
@@ -764,12 +782,12 @@ def _detect_answer_script(query: str) -> str:
     if re.search(r"[\u3040-\u30ff]", query):
         return "Jpan"
     if re.search(r"[\u4e00-\u9fff]", query):
-        return "Hans"
+        return "Hant" if any(marker in query for marker in _ANSWER_TRADITIONAL_CHINESE_MARKERS) else "Hans"
     return "Latn"
 
 
 def _detect_answer_intent(query: str) -> str:
-    q = query.lower()[:1000]
+    q = _normalize_answer_detector_input(query).lower()
     for intent, terms in _ANSWER_INTENT_TERMS.items():
         if any(term in q for term in terms):
             return intent
@@ -782,13 +800,14 @@ def _detect_answer_freshness(query: str, requested: str = "auto") -> Dict[str, s
     if requested != "auto":
         return {"requested": requested, "applied": "none" if requested == "none" else requested, "reason": "explicit freshness requested"}
 
-    q = query.lower()[:1000]
-    day_terms = ["today", "right now", "breaking", "heute", "gerade", "aktuell", "now", "hoje", "hoy", "oggi", "aujourd'hui"]
+    q = _normalize_answer_detector_input(query).lower()
+    day_terms = ["today", "right now", "breaking", "heute", "gerade", "aktuell", "hoje", "hoy", "oggi", "aujourd'hui", "vandaag", "dzisiaj", "今日"]
     week_terms = [
         "latest", "this week", "past week", "recent", "news", "updates", "neueste", "diese woche", "nachrichten",
         "noticias", "esta semana", "últimas", "dernières", "cette semaine", "nouvelles", "ultime", "questa settimana", "notizie", "notícias",
+        "laatste", "nieuws", "deze week", "najnowsze", "wiadomości", "tym tygodniu", "最新", "消息",
     ]
-    month_terms = ["this month", "past month", "dieser monat", "letzter monat", "este mes", "ce mois", "questo mese", "este mês"]
+    month_terms = ["this month", "past month", "dieser monat", "letzter monat", "este mes", "ce mois", "questo mese", "este mês", "deze maand", "ten miesiąc"]
     if any(term in q for term in day_terms):
         return {"requested": requested, "applied": "day", "reason": "query looked time-sensitive"}
     if any(term in q for term in week_terms) or re.search(r"\b20[2-9][0-9]\b", q):
@@ -800,7 +819,7 @@ def _detect_answer_freshness(query: str, requested: str = "auto") -> Dict[str, s
 
 def _detect_answer_locale(query: str, language: str = "auto", country: str = "auto") -> Dict[str, str]:
     """Small locale detector for web_answer_plus. Deliberately conservative."""
-    sample = query[:1000]
+    sample = _normalize_answer_detector_input(query)
     q = sample.lower()
     script = _detect_answer_script(sample)
     detected_language = None if language == "auto" else language.lower()
@@ -814,7 +833,7 @@ def _detect_answer_locale(query: str, language: str = "auto", country: str = "au
             detected_language, confidence = "ru", "medium"
         elif script == "Jpan":
             detected_language, confidence = "ja", "medium"
-        elif script == "Hans":
+        elif script in {"Hans", "Hant"}:
             detected_language, confidence = "zh", "medium"
 
     if not detected_language and script == "Latn":
@@ -824,7 +843,7 @@ def _detect_answer_locale(query: str, language: str = "auto", country: str = "au
             accent_score = sum(2 for char in profile["diacritics"] if char in q)
             scores[code] = term_score + accent_score
         best_language, best_score = max(scores.items(), key=lambda item: item[1])
-        if best_score >= 2 or (best_language != "en" and best_score >= 1 and any(ch in q for ch in _ANSWER_LANGUAGE_PROFILES[best_language]["diacritics"])):
+        if best_score >= _ANSWER_LATIN_CONFIDENCE_THRESHOLD or (best_language != "en" and best_score >= 1 and any(ch in q for ch in _ANSWER_LANGUAGE_PROFILES[best_language]["diacritics"])):
             detected_language = best_language
             confidence = "high" if best_score >= 4 else "medium"
         else:
@@ -843,6 +862,9 @@ def _detect_answer_locale(query: str, language: str = "auto", country: str = "au
             "IT": ["italia", "italy", "roma", "milano"],
             "BR": ["brasil", "brazil", "são paulo"],
             "PT": ["portugal", "lisboa"],
+            "NL": ["nederland", "netherlands", "amsterdam"],
+            "PL": ["polska", "polsce", "poland", "warszawa"],
+            "TW": ["台灣", "臺灣", "taiwan"],
             "JP": ["日本", "japan"],
         }
         for code, terms in country_signals.items():
@@ -850,7 +872,7 @@ def _detect_answer_locale(query: str, language: str = "auto", country: str = "au
                 detected_country = code
                 break
     if not detected_country:
-        detected_country = {"de": "DE", "fr": "FR", "es": "ES", "it": "IT", "pt": "BR", "ja": "JP"}.get(detected_language, "US") if script == "Latn" else "US"
+        detected_country = {"de": "DE", "fr": "FR", "es": "ES", "it": "IT", "pt": "BR", "nl": "NL", "pl": "PL", "ja": "JP", "zh": "CN"}.get(detected_language, "US") if script == "Latn" else "US"
 
     return {
         "language": detected_language,

--- a/__init__.py
+++ b/__init__.py
@@ -718,16 +718,77 @@ def _format_extract_results(data: dict) -> str:
     return "\n".join(lines).strip()
 
 
+_ANSWER_LANGUAGE_PROFILES = {
+    "de": {
+        "terms": ["der", "die", "das", "und", "für", "was", "wie", "preis", "günstig", "vergleich", "österreich", "deutschland", "schweiz", "nachrichten", "definieren"],
+        "diacritics": "äöüß",
+    },
+    "es": {
+        "terms": ["el", "la", "los", "las", "qué", "que", "cómo", "como", "tiempo", "precio", "barato", "comparación", "alternativas", "españa", "méxico", "noticias"],
+        "diacritics": "áéíóúñ¿¡",
+    },
+    "fr": {
+        "terms": ["le", "la", "les", "des", "quelle", "quel", "meilleur", "meilleurs", "pas cher", "comparaison", "avis", "france", "définition", "nouvelles"],
+        "diacritics": "àâçéèêëîïôùûüÿœ",
+    },
+    "it": {
+        "terms": ["il", "lo", "gli", "le", "che", "prezzo", "migliori", "confronto", "italia", "notizie", "questa settimana", "definizione"],
+        "diacritics": "àèéìòù",
+    },
+    "pt": {
+        "terms": ["o", "a", "os", "as", "qual", "preço", "preços", "melhores", "comparação", "brasil", "portugal", "notícias", "hoje"],
+        "diacritics": "áâãàçéêíóôõú",
+    },
+    "en": {
+        "terms": ["the", "what", "how", "best", "price", "cheap", "compare", "review", "news", "latest", "define", "weather"],
+        "diacritics": "",
+    },
+}
+
+_ANSWER_INTENT_TERMS = {
+    "weather": ["weather", "forecast", "wetter", "tiempo", "météo", "meteo", "tempo"],
+    "news": ["news", "latest", "updates", "nachrichten", "neueste", "noticias", "nouvelles", "notizie", "notícias"],
+    "define": ["define", "definition", "what is", "was ist", "definieren", "definición", "définition", "definizione", "definição"],
+    "shopping": ["price", "cheap", "buy", "review", "preis", "günstig", "vergleich", "precio", "barato", "preço", "preços", "pas cher", "prezzo"],
+    "time": ["time in", "uhrzeit", "hora en", "heure à", "ora a"],
+    "calc": ["calculate", "berechne", "calcular", "calculer", "calcola"],
+}
+
+
+def _detect_answer_script(query: str) -> str:
+    """Return a coarse script label without external calls or full language guessing."""
+    if re.search(r"[\u0600-\u06ff]", query):
+        return "Arab"
+    if re.search(r"[\u0400-\u04ff]", query):
+        return "Cyrl"
+    if re.search(r"[\u3040-\u30ff]", query):
+        return "Jpan"
+    if re.search(r"[\u4e00-\u9fff]", query):
+        return "Hans"
+    return "Latn"
+
+
+def _detect_answer_intent(query: str) -> str:
+    q = query.lower()[:1000]
+    for intent, terms in _ANSWER_INTENT_TERMS.items():
+        if any(term in q for term in terms):
+            return intent
+    return "general"
+
+
 def _detect_answer_freshness(query: str, requested: str = "auto") -> Dict[str, str]:
     """Resolve answer freshness from an explicit value or lightweight query signals."""
     requested = requested or "auto"
     if requested != "auto":
         return {"requested": requested, "applied": "none" if requested == "none" else requested, "reason": "explicit freshness requested"}
 
-    q = query.lower()
-    day_terms = ["today", "right now", "breaking", "heute", "gerade", "aktuell", "now"]
-    week_terms = ["latest", "this week", "past week", "recent", "news", "updates", "neueste", "diese woche", "nachrichten"]
-    month_terms = ["this month", "past month", "dieser monat", "letzter monat"]
+    q = query.lower()[:1000]
+    day_terms = ["today", "right now", "breaking", "heute", "gerade", "aktuell", "now", "hoje", "hoy", "oggi", "aujourd'hui"]
+    week_terms = [
+        "latest", "this week", "past week", "recent", "news", "updates", "neueste", "diese woche", "nachrichten",
+        "noticias", "esta semana", "últimas", "dernières", "cette semaine", "nouvelles", "ultime", "questa settimana", "notizie", "notícias",
+    ]
+    month_terms = ["this month", "past month", "dieser monat", "letzter monat", "este mes", "ce mois", "questo mese", "este mês"]
     if any(term in q for term in day_terms):
         return {"requested": requested, "applied": "day", "reason": "query looked time-sensitive"}
     if any(term in q for term in week_terms) or re.search(r"\b20[2-9][0-9]\b", q):
@@ -739,35 +800,38 @@ def _detect_answer_freshness(query: str, requested: str = "auto") -> Dict[str, s
 
 def _detect_answer_locale(query: str, language: str = "auto", country: str = "auto") -> Dict[str, str]:
     """Small locale detector for web_answer_plus. Deliberately conservative."""
-    q = query.lower()
-    detected_language = None if language == "auto" else language
+    sample = query[:1000]
+    q = sample.lower()
+    script = _detect_answer_script(sample)
+    detected_language = None if language == "auto" else language.lower()
     detected_country = None if country == "auto" else country.upper()
     confidence = "explicit" if detected_language else "low"
 
     if not detected_language:
-        language_signals = [
-            ("fr", ["meilleur", "meilleurs", "pas cher", "comparaison", "avis", "france"]),
-            ("es", ["precio", "barato", "comparación", "alternativas", "españa", "méxico"]),
-            ("it", ["prezzo", "migliori", "confronto", "italia"]),
-            ("pt", ["preço", "melhores", "comparação", "brasil", "portugal"]),
-            ("de", ["preis", "günstig", "vergleich", "österreich", "deutschland", "schweiz"]),
-        ]
-        for code, terms in language_signals:
-            if any(term in q for term in terms):
-                detected_language = code
-                confidence = "medium"
-                break
-    if not detected_language:
-        if re.search(r"[\u3040-\u30ff]", query):
-            detected_language, confidence = "ja", "medium"
-        elif re.search(r"[\u4e00-\u9fff]", query):
-            detected_language, confidence = "zh", "medium"
-        elif re.search(r"[\u0600-\u06ff]", query):
+        if script == "Arab":
             detected_language, confidence = "ar", "medium"
-        elif re.search(r"[\u0400-\u04ff]", query):
+        elif script == "Cyrl":
             detected_language, confidence = "ru", "medium"
+        elif script == "Jpan":
+            detected_language, confidence = "ja", "medium"
+        elif script == "Hans":
+            detected_language, confidence = "zh", "medium"
+
+    if not detected_language and script == "Latn":
+        scores = {}
+        for code, profile in _ANSWER_LANGUAGE_PROFILES.items():
+            term_score = sum(1 for term in profile["terms"] if re.search(rf"(?<!\w){re.escape(term)}(?!\w)", q))
+            accent_score = sum(2 for char in profile["diacritics"] if char in q)
+            scores[code] = term_score + accent_score
+        best_language, best_score = max(scores.items(), key=lambda item: item[1])
+        if best_score >= 2 or (best_language != "en" and best_score >= 1 and any(ch in q for ch in _ANSWER_LANGUAGE_PROFILES[best_language]["diacritics"])):
+            detected_language = best_language
+            confidence = "high" if best_score >= 4 else "medium"
         else:
             detected_language, confidence = "en", "low"
+
+    if not detected_language:
+        detected_language = "en"
 
     if not detected_country:
         country_signals = {
@@ -776,8 +840,9 @@ def _detect_answer_locale(query: str, language: str = "auto", country: str = "au
             "FR": ["france", "paris"],
             "ES": ["españa", "spain", "madrid"],
             "MX": ["méxico", "mexico"],
-            "IT": ["italia", "italy"],
-            "BR": ["brasil", "brazil"],
+            "IT": ["italia", "italy", "roma", "milano"],
+            "BR": ["brasil", "brazil", "são paulo"],
+            "PT": ["portugal", "lisboa"],
             "JP": ["日本", "japan"],
         }
         for code, terms in country_signals.items():
@@ -785,9 +850,15 @@ def _detect_answer_locale(query: str, language: str = "auto", country: str = "au
                 detected_country = code
                 break
     if not detected_country:
-        detected_country = {"de": "DE", "fr": "FR", "es": "ES", "it": "IT", "pt": "BR", "ja": "JP"}.get(detected_language, "US")
+        detected_country = {"de": "DE", "fr": "FR", "es": "ES", "it": "IT", "pt": "BR", "ja": "JP"}.get(detected_language, "US") if script == "Latn" else "US"
 
-    return {"language": detected_language, "country": detected_country, "language_confidence": confidence}
+    return {
+        "language": detected_language,
+        "country": detected_country,
+        "language_confidence": confidence,
+        "script": script,
+        "intent_hint": _detect_answer_intent(sample),
+    }
 
 
 def _source_type_for_url(url: str) -> str:

--- a/tests/test_answer_plus.py
+++ b/tests/test_answer_plus.py
@@ -42,6 +42,8 @@ KNOWN_LOCALE_QUERIES = [
     ("quelle est la définition de DAC audio", "fr", "FR", "define"),
     ("ultime notizie hi-fi questa settimana Italia", "it", "IT", "news"),
     ("melhores preços de amplificadores no Brasil", "pt", "BR", "shopping"),
+    ("wat is de beste prijs voor luidsprekers in Nederland", "nl", "NL", "shopping"),
+    ("najlepsza cena wzmacniacza w Polsce", "pl", "PL", "shopping"),
 ]
 
 
@@ -75,11 +77,53 @@ def test_detect_locale_identifies_unsupported_scripts_without_guessing_country()
     assert locale["intent_hint"] == "general"
 
 
+def test_detect_locale_distinguishes_traditional_chinese_script():
+    locale = wsp._detect_answer_locale("最新 DAC 評測 台灣", "auto", "auto")
+
+    assert locale["language"] == "zh"
+    assert locale["country"] == "TW"
+    assert locale["script"] == "Hant"
+    assert locale["intent_hint"] == "news"
+
+
+def test_detect_locale_does_not_treat_shared_tai_character_as_traditional():
+    locale = wsp._detect_answer_locale("台风预警 最新消息", "auto", "auto")
+
+    assert locale["language"] == "zh"
+    assert locale["script"] == "Hans"
+
+
+def test_detect_locale_handles_empty_punctuation_and_idempotence():
+    for query in ["", "   ", "?! -- ..."]:
+        locale = wsp._detect_answer_locale(query, "auto", "auto")
+        assert locale["language"] == "en"
+        assert locale["country"] == "US"
+        assert locale["script"] == "Latn"
+        assert locale["language_confidence"] == "low"
+
+    query = "wat zijn de laatste prijzen in Nederland"
+    assert wsp._detect_answer_locale(query, "auto", "auto") == wsp._detect_answer_locale(query, "auto", "auto")
+
+
+def test_detect_locale_caps_input_before_matching_tail_terms():
+    late_polish_marker = "x" * 1000 + " Polska cena"
+    early_polish_marker = "Polska cena " + "x" * 1000
+
+    assert wsp._detect_answer_locale(late_polish_marker, "auto", "auto")["language"] == "en"
+    assert wsp._detect_answer_locale(early_polish_marker, "auto", "auto")["language"] == "pl"
+
+
 def test_detect_freshness_understands_romance_news_terms():
     assert wsp._detect_answer_freshness("noticias de esta semana sobre DACs", "auto")["applied"] == "week"
     assert wsp._detect_answer_freshness("dernières nouvelles hi-fi cette semaine", "auto")["applied"] == "week"
     assert wsp._detect_answer_freshness("ultime notizie hi-fi questa settimana", "auto")["applied"] == "week"
     assert wsp._detect_answer_freshness("notícias de hoje sobre amplificadores", "auto")["applied"] == "day"
+
+
+def test_detect_freshness_understands_dutch_polish_and_traditional_chinese_terms():
+    assert wsp._detect_answer_freshness("laatste nieuws over DACs deze week", "auto")["applied"] == "week"
+    assert wsp._detect_answer_freshness("najnowsze wiadomości o wzmacniaczach w tym tygodniu", "auto")["applied"] == "week"
+    assert wsp._detect_answer_freshness("今日 DAC 最新消息", "auto")["applied"] == "day"
 
 
 def test_normalize_answer_sources_creates_citation_ready_records():

--- a/tests/test_answer_plus.py
+++ b/tests/test_answer_plus.py
@@ -33,6 +33,53 @@ def test_detect_locale_handles_common_non_english_eu_queries():
     assert locale["language"] == "fr"
     assert locale["country"] == "FR"
     assert locale["language_confidence"] in {"medium", "high"}
+    assert locale["script"] == "Latn"
+
+
+KNOWN_LOCALE_QUERIES = [
+    ("qué tiempo hace mañana en Madrid", "es", "ES", "weather"),
+    ("der preisvergleich für lautsprecher in Österreich", "de", "AT", "shopping"),
+    ("quelle est la définition de DAC audio", "fr", "FR", "define"),
+    ("ultime notizie hi-fi questa settimana Italia", "it", "IT", "news"),
+    ("melhores preços de amplificadores no Brasil", "pt", "BR", "shopping"),
+]
+
+
+def test_detect_locale_covers_core_latin_languages_and_intents():
+    for query, language, country, intent in KNOWN_LOCALE_QUERIES:
+        locale = wsp._detect_answer_locale(query, "auto", "auto")
+
+        assert locale["language"] == language
+        assert locale["country"] == country
+        assert locale["script"] == "Latn"
+        assert locale["language_confidence"] in {"medium", "high"}
+        assert locale["intent_hint"] == intent
+
+
+def test_detect_locale_falls_back_to_english_on_ambiguous_latin_text():
+    locale = wsp._detect_answer_locale("apollo nova studio reference", "auto", "auto")
+
+    assert locale["language"] == "en"
+    assert locale["country"] == "US"
+    assert locale["script"] == "Latn"
+    assert locale["language_confidence"] == "low"
+    assert locale["intent_hint"] == "general"
+
+
+def test_detect_locale_identifies_unsupported_scripts_without_guessing_country():
+    locale = wsp._detect_answer_locale("ما هو أفضل مضخم صوت", "auto", "auto")
+
+    assert locale["language"] == "ar"
+    assert locale["country"] == "US"
+    assert locale["script"] == "Arab"
+    assert locale["intent_hint"] == "general"
+
+
+def test_detect_freshness_understands_romance_news_terms():
+    assert wsp._detect_answer_freshness("noticias de esta semana sobre DACs", "auto")["applied"] == "week"
+    assert wsp._detect_answer_freshness("dernières nouvelles hi-fi cette semaine", "auto")["applied"] == "week"
+    assert wsp._detect_answer_freshness("ultime notizie hi-fi questa settimana", "auto")["applied"] == "week"
+    assert wsp._detect_answer_freshness("notícias de hoje sobre amplificadores", "auto")["applied"] == "day"
 
 
 def test_normalize_answer_sources_creates_citation_ready_records():


### PR DESCRIPTION
## Summary
- Adds a lightweight in-process locale layer for `web_answer_plus`
- Covers EN/DE/ES/FR/IT/PT/NL/PL with conservative marker/diacritic heuristics
- Adds coarse script hints for Arab/Cyrl/Jpan/Hans/Hant without external detector dependencies
- Adds localized intent/freshness hints for the supported language layer
- Normalizes/caps detector input before matching, and keeps answer behavior additive/no routing-v2 changes

## Scope guardrails
- No routing-v2/default-on changes
- No ML/language-detector dependency
- No benchmark or accuracy claims
- No raw query logging / telemetry additions
- No provider-selection changes

## Test plan
- `PYTHONPATH=$PWD python -m pytest tests -q` → 89 passed
- `python -m compileall -q __init__.py search.py setup.py scripts tests`
- `git diff --check`
- Locale smoke: NL/PL/Hant/Hans/shared-台/empty cases OK
- Changed-file privacy scan OK

## Andy review
- Initial scope: add NL/PL + Hant, keep it data-only and defer routing-v2/ML/benchmarks
- Final review: ✅ green light — ship it

## Stack
Stacked on PR #13 (`feat/web-answer-plus-mvp-local`). This PR should land after #13.
