### PR TITLE
fix: split native and kilo perplexity providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### 🐛 Fixed
+- `perplexity` now uses the native Perplexity API endpoint (`https://api.perplexity.ai/chat/completions`), `PERPLEXITY_API_KEY`, and `sonar-pro` model instead of the Kilo gateway defaults.
+- `kilo-perplexity` is preserved as a distinct routing provider using `KILOCODE_API_KEY`, the Kilo gateway endpoint, and `perplexity/sonar-pro`.
+
+### 🧪 Tests
+- Added regression coverage for native Perplexity defaults, distinct Kilo Perplexity routing, separate environment keys, and onboarding/runtime config normalization.
+
 ## [v1.9.2] — 2026-05-10
 
 ### 🔧 Changed

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Parameters:
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `query` | string | **required** | Search query |
-| `provider` | string | `"auto"` | `auto`, `serper`, `brave`, `tavily`, `exa`, `querit`, `linkup`, `firecrawl`, `perplexity`, `you`, `searxng` |
+| `provider` | string | `"auto"` | `auto`, `serper`, `brave`, `tavily`, `exa`, `querit`, `linkup`, `firecrawl`, `perplexity`, `kilo-perplexity`, `you`, `searxng` |
 | `depth` | string | `"normal"` | Exa only: `normal`, `deep`, `deep-reasoning` |
 | `count` | integer | `5` | Results, 1–20 |
 | `time_range` | string | — | `day`, `week`, `month`, `year` |
@@ -283,7 +283,8 @@ Parameters:
 | Querit | ✅ | — | Multilingual and real-time queries |
 | Linkup | ✅ | ✅ | Source-backed grounding, citations, RAG-ready retrieval |
 | Firecrawl | ✅ | ✅ | Web search with scrape-ready result content |
-| Perplexity | ✅ | — | Direct answer-style search |
+| Perplexity | ✅ | — | Native Perplexity direct answer-style search |
+| Kilo Perplexity | ✅ | — | Perplexity through Kilo gateway (`kilo-perplexity`) |
 | You.com | ✅ | ✅ | LLM-ready real-time snippets and content |
 | SearXNG | ✅ | — | Privacy-focused self-hosted metasearch |
 
@@ -308,7 +309,7 @@ PERPLEXITY_API_KEY=***    # https://perplexity.ai/settings/api
 YOU_API_KEY=***           # https://api.you.com — search + extraction
 SEARXNG_INSTANCE_URL=https://your-instance.example.com
 
-# Advanced alternate credential path for the perplexity provider via Kilo Gateway
+# Kilo gateway alternate provider (`provider="kilo-perplexity"`)
 KILOCODE_API_KEY=***
 ```
 

--- a/__init__.py
+++ b/__init__.py
@@ -257,8 +257,8 @@ def _get_hermes_env_path() -> Path:
 
 
 _SETUP_PROVIDER_NAMES = {item["provider"] for item in _PROVIDER_CATALOG}
-_DEFAULT_PROVIDER_PRIORITY = ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"]
-_ROUTING_PROVIDER_NAMES = set(_DEFAULT_PROVIDER_PRIORITY)
+_DEFAULT_PROVIDER_PRIORITY = ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng"]
+_ROUTING_PROVIDER_NAMES = set(_DEFAULT_PROVIDER_PRIORITY) | {"kilo-perplexity"}
 
 
 def _get_plugin_config_path() -> Path:
@@ -296,8 +296,8 @@ def _normalize_provider_name(provider: str) -> str:
 def _normalize_routing_provider(provider: str) -> str:
     """Normalize a provider that search.py can actually route to."""
     normalized = (provider or "").strip().lower()
-    if normalized in {"kilo-perplexity", "kilo_perplexity"}:
-        normalized = "perplexity"
+    if normalized == "kilo_perplexity":
+        normalized = "kilo-perplexity"
     if normalized not in _ROUTING_PROVIDER_NAMES:
         valid = ", ".join(sorted(_ROUTING_PROVIDER_NAMES))
         print(f"Unknown routing provider: {provider}. Valid routing providers: {valid}", file=sys.stderr)
@@ -1466,7 +1466,7 @@ def register(ctx: Any) -> None:
                 },
                 "provider": {
                     "type": "string",
-                    "enum": ["auto", "serper", "brave", "tavily", "exa", "querit", "linkup", "firecrawl", "perplexity", "you", "searxng"],
+                    "enum": ["auto", "serper", "brave", "tavily", "exa", "querit", "linkup", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng"],
                     "description": "Search provider. Use 'auto' for intelligent routing (default). Brave and Serper share generic web-search intents and ties are distributed deterministically per query.",
                     "default": "auto",
                 },

--- a/search.py
+++ b/search.py
@@ -3,7 +3,7 @@
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
 Version: 1.9.2
 Supports search providers: Serper (Google), Brave Search, Tavily, Querit,
-Linkup, Exa, Firecrawl, Perplexity, You.com, SearXNG.
+Linkup, Exa, Firecrawl, Perplexity, Kilo Perplexity, You.com, SearXNG.
 Supports extract providers: Firecrawl, Linkup, Tavily, Exa, You.com.
 
 Smart Routing uses multi-signal analysis:
@@ -15,7 +15,7 @@ Smart Routing uses multi-signal analysis:
 
 Usage:
     python3 search.py --query "..."                    # Auto-route based on query
-    python3 search.py --provider [serper|brave|tavily|linkup|querit|exa|firecrawl|perplexity|you|searxng|auto] --query "..." [options]
+    python3 search.py --provider [serper|brave|tavily|linkup|querit|exa|firecrawl|perplexity|kilo-perplexity|you|searxng|auto] --query "..." [options]
 
 Examples:
     python3 search.py -q "iPhone 16 Pro price"              # → Serper (shopping intent)
@@ -289,7 +289,7 @@ DEFAULT_CONFIG = {
     "auto_routing": {
         "enabled": True,
         "fallback_provider": "serper",
-        "provider_priority": ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"],
+        "provider_priority": ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng"],
         "disabled_providers": [],
         "confidence_threshold": 0.3,  # Below this, note low confidence
     },
@@ -324,6 +324,10 @@ DEFAULT_CONFIG = {
         "verbosity": "standard"
     },
     "perplexity": {
+        "api_url": "https://api.perplexity.ai/chat/completions",
+        "model": "sonar-pro"
+    },
+    "kilo-perplexity": {
         "api_url": "https://api.kilo.ai/api/gateway/chat/completions",
         "model": "perplexity/sonar-pro"
     },
@@ -351,13 +355,13 @@ def _deepcopy_default_config() -> Dict[str, Any]:
     return json.loads(json.dumps(DEFAULT_CONFIG))
 
 
-_ROUTING_PROVIDER_NAMES = {"tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"}
+_ROUTING_PROVIDER_NAMES = {"tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng"}
 
 
 def _normalize_routing_provider_config(provider: str) -> str:
     normalized = (provider or "").strip().lower()
-    if normalized in {"kilo-perplexity", "kilo_perplexity"}:
-        normalized = "perplexity"
+    if normalized == "kilo_perplexity":
+        normalized = "kilo-perplexity"
     if normalized not in _ROUTING_PROVIDER_NAMES:
         raise ValueError(f"unknown routing provider: {provider}")
     return normalized
@@ -480,7 +484,9 @@ def get_api_key(provider: str, config: Dict[str, Any] = None) -> Optional[str]:
     
     # Then check environment
     if provider == "perplexity":
-        return os.environ.get("PERPLEXITY_API_KEY") or os.environ.get("KILOCODE_API_KEY")
+        return os.environ.get("PERPLEXITY_API_KEY")
+    if provider == "kilo-perplexity":
+        return os.environ.get("KILOCODE_API_KEY")
     key_map = {
         "serper": "SERPER_API_KEY",
         "brave": "BRAVE_API_KEY",
@@ -610,7 +616,8 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
             "linkup": "LINKUP_API_KEY",
             "exa": "EXA_API_KEY",
             "you": "YOU_API_KEY",
-            "perplexity": "KILOCODE_API_KEY",
+            "perplexity": "PERPLEXITY_API_KEY",
+            "kilo-perplexity": "KILOCODE_API_KEY",
             "firecrawl": "FIRECRAWL_API_KEY"
         }[provider]
         
@@ -622,7 +629,8 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
             "linkup": "https://app.linkup.so",
             "exa": "https://exa.ai",
             "you": "https://api.you.com",
-            "perplexity": "https://api.kilo.ai",
+            "perplexity": "https://www.perplexity.ai/settings/api",
+            "kilo-perplexity": "https://api.kilo.ai",
             "firecrawl": "https://www.firecrawl.dev/app/api-keys"
         }
         
@@ -1331,6 +1339,7 @@ class QueryAnalyzer:
             "linkup": linkup_source_score + (rag_score * 0.7) + (research_score * 0.45) + (recency_score * 0.35),
             "exa": discovery_score + (1.0 if re.search(r"\b(similar|alternatives?|examples?)\b", query, re.IGNORECASE) else 0.0) + (exa_deep_score * 0.5) + (exa_deep_reasoning_score * 0.5),
             "perplexity": direct_answer_score + (local_news_score * 0.4) + (recency_score * 0.55),
+            "kilo-perplexity": direct_answer_score + (local_news_score * 0.4) + (recency_score * 0.55),
             "you": rag_score + (recency_score * 0.25),  # You.com good for real-time + RAG
             "searxng": privacy_score,  # SearXNG for privacy/multi-source queries
             "firecrawl": discovery_score + (research_score * 0.35) + (recency_score * 0.25),
@@ -1345,6 +1354,7 @@ class QueryAnalyzer:
             "linkup": linkup_source_matches + rag_matches + research_matches,
             "exa": discovery_matches + exa_deep_matches + exa_deep_reasoning_matches,
             "perplexity": direct_answer_matches,
+            "kilo-perplexity": direct_answer_matches,
             "you": rag_matches,
             "searxng": privacy_matches,
             "firecrawl": discovery_matches + research_matches,
@@ -1394,7 +1404,7 @@ class QueryAnalyzer:
         max_score = max(available.values())
         
         # Handle ties using deterministic per-query distribution
-        priority = self.auto_config.get("provider_priority", ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"])
+        priority = self.auto_config.get("provider_priority", ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng"])
         winners = [p for p, s in available.items() if s == max_score]
         
         if len(winners) > 1:
@@ -1552,7 +1562,7 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             if matches
         },
         "available_providers": [
-            p for p in ["serper", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "you", "searxng"]
+            p for p in ["serper", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng"]
             if get_api_key(p, config) and p not in config.get("auto_routing", {}).get("disabled_providers", [])
         ]
     }
@@ -3032,27 +3042,29 @@ def search_exa(
 
 
 # =============================================================================
-# Perplexity via Kilo Gateway (Synthesized Direct Answers)
+# Perplexity-compatible Direct Answers
 # =============================================================================
 
 def search_perplexity(
     query: str,
     api_key: str,
     max_results: int = 5,
-    model: str = "perplexity/sonar-pro",
-    api_url: str = "https://api.kilo.ai/api/gateway/chat/completions",
+    model: str = "sonar-pro",
+    api_url: str = "https://api.perplexity.ai/chat/completions",
     freshness: Optional[str] = None,
+    provider_name: str = "perplexity",
 ) -> dict:
-    """Search/answer using Perplexity Sonar Pro via Kilo Gateway.
+    """Search/answer using the native Perplexity API or a compatible gateway.
 
     Args:
         query: Search query
-        api_key: Kilo Gateway API key
+        api_key: Provider API key
         max_results: Maximum results to return
-        model: Perplexity model to use
-        api_url: Kilo Gateway endpoint
+        model: Perplexity-compatible model to use
+        api_url: Chat completions endpoint
         freshness: Filter by recency — 'day', 'week', 'month', 'year' (maps to
                    Perplexity's search_recency_filter parameter)
+        provider_name: Result provider label (perplexity or kilo-perplexity)
     """
     # Map generic freshness values to Perplexity's search_recency_filter
     recency_map = {"day": "day", "pd": "day", "week": "week", "pw": "week", "month": "month", "pm": "month", "year": "year", "py": "year"}
@@ -3121,7 +3133,7 @@ def search_perplexity(
         })
 
     return {
-        "provider": "perplexity",
+        "provider": provider_name,
         "query": query,
         "results": results,
         "images": [],
@@ -3480,7 +3492,7 @@ Full docs: See README.md and SKILL.md
     # Common arguments
     parser.add_argument(
         "--provider", "-p", 
-        choices=["serper", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "you", "searxng", "auto"],
+        choices=["serper", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng", "auto"],
         help="Search provider (auto=intelligent routing)"
     )
     parser.add_argument(
@@ -3807,7 +3819,7 @@ Full docs: See README.md and SKILL.md
     
     # Build provider fallback list
     auto_config = config.get("auto_routing", {})
-    provider_priority = auto_config.get("provider_priority", ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "brave", "serper", "you", "searxng"])
+    provider_priority = auto_config.get("provider_priority", ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng"])
     disabled_providers = auto_config.get("disabled_providers", [])
 
     # Start with the selected provider, then try others in priority order.
@@ -3938,15 +3950,17 @@ Full docs: See README.md and SKILL.md
                 api_url=firecrawl_config.get("api_url", "https://api.firecrawl.dev/v2/search"),
                 timeout_ms=int(firecrawl_config.get("timeout", 30000)),
             )
-        elif prov == "perplexity":
-            perplexity_config = config.get("perplexity", {})
+        elif prov in {"perplexity", "kilo-perplexity"}:
+            perplexity_config = config.get(prov, {})
+            defaults = DEFAULT_CONFIG.get(prov, {})
             return search_perplexity(
                 query=args.query,
                 api_key=key,
                 max_results=args.max_results,
-                model=perplexity_config.get("model", "perplexity/sonar-pro"),
-                api_url=perplexity_config.get("api_url", "https://api.kilo.ai/api/gateway/chat/completions"),
+                model=perplexity_config.get("model", defaults.get("model", "sonar-pro")),
+                api_url=perplexity_config.get("api_url", defaults.get("api_url", "https://api.perplexity.ai/chat/completions")),
                 freshness=getattr(args, "freshness", None),
+                provider_name=prov,
             )
         elif prov == "you":
             return search_you(

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -498,7 +498,7 @@ def test_no_secret_leaks_across_status_and_config_commands(tmp_path, capsys):
 
 
 
-def test_config_routing_provider_alias_maps_kilo_perplexity_to_perplexity(tmp_path):
+def test_config_routing_provider_alias_maps_kilo_perplexity_to_distinct_provider(tmp_path):
     config_path = tmp_path / "config.json"
     parser = wsp.argparse.ArgumentParser()
     wsp._web_search_plus_cli_setup(parser)
@@ -507,10 +507,10 @@ def test_config_routing_provider_alias_maps_kilo_perplexity_to_perplexity(tmp_pa
     args.func(args)
 
     data = json.loads(config_path.read_text())
-    assert data["default_provider"] == "perplexity"
+    assert data["default_provider"] == "kilo-perplexity"
 
 
-def test_config_routing_provider_alias_maps_kilo_underscore_perplexity_to_perplexity(tmp_path):
+def test_config_routing_provider_alias_maps_kilo_underscore_perplexity_to_distinct_provider(tmp_path):
     config_path = tmp_path / "config.json"
     parser = wsp.argparse.ArgumentParser()
     wsp._web_search_plus_cli_setup(parser)
@@ -519,7 +519,7 @@ def test_config_routing_provider_alias_maps_kilo_underscore_perplexity_to_perple
     args.func(args)
 
     data = json.loads(config_path.read_text())
-    assert data["default_provider"] == "perplexity"
+    assert data["default_provider"] == "kilo-perplexity"
 
 
 def test_config_priority_rejects_non_routing_catalog_provider(tmp_path):
@@ -642,8 +642,8 @@ def test_search_load_config_normalizes_kilo_perplexity_alias(tmp_path, monkeypat
 
     config = search.load_config()
 
-    assert config["default_provider"] == "perplexity"
-    assert config["auto_routing"]["provider_priority"] == ["perplexity"]
+    assert config["default_provider"] == "kilo-perplexity"
+    assert config["auto_routing"]["provider_priority"] == ["kilo-perplexity"]
     assert not list(tmp_path.glob("config.json.broken-*"))
 
 
@@ -654,7 +654,7 @@ def test_search_load_config_normalizes_kilo_underscore_perplexity_alias(tmp_path
 
     config = search.load_config()
 
-    assert config["default_provider"] == "perplexity"
-    assert config["auto_routing"]["provider_priority"] == ["perplexity"]
-    assert config["auto_routing"]["fallback_provider"] == "perplexity"
+    assert config["default_provider"] == "kilo-perplexity"
+    assert config["auto_routing"]["provider_priority"] == ["kilo-perplexity"]
+    assert config["auto_routing"]["fallback_provider"] == "kilo-perplexity"
     assert not list(tmp_path.glob("config.json.broken-*"))

--- a/tests/test_perplexity_provider.py
+++ b/tests/test_perplexity_provider.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+SEARCH_PATH = Path(__file__).resolve().parents[1] / "search.py"
+search_spec = importlib.util.spec_from_file_location("wsp_search_perplexity_under_test", SEARCH_PATH)
+search = importlib.util.module_from_spec(search_spec)
+assert search_spec.loader is not None
+search_spec.loader.exec_module(search)
+
+PLUGIN_PATH = Path(__file__).resolve().parents[1] / "__init__.py"
+plugin_spec = importlib.util.spec_from_file_location("wsp_plugin_perplexity_under_test", PLUGIN_PATH)
+wsp = importlib.util.module_from_spec(plugin_spec)
+assert plugin_spec.loader is not None
+plugin_spec.loader.exec_module(wsp)
+
+
+def test_perplexity_default_uses_native_api_endpoint_and_model(monkeypatch):
+    captured = {}
+
+    def fake_request(api_url, headers, body):
+        captured["api_url"] = api_url
+        captured["headers"] = headers
+        captured["body"] = body
+        return {"choices": [{"message": {"content": "answer"}}], "citations": []}
+
+    monkeypatch.setattr(search, "make_request", fake_request)
+
+    result = search.search_perplexity(query="latest ai news", api_key="pplx-test-key")
+
+    assert result["provider"] == "perplexity"
+    assert captured["api_url"] == "https://api.perplexity.ai/chat/completions"
+    assert captured["body"]["model"] == "sonar-pro"
+    assert captured["headers"]["Authorization"] == "Bearer pplx-test-key"
+
+
+def test_kilo_perplexity_is_distinct_routing_provider_with_kilo_key(monkeypatch, tmp_path, capsys):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"version": 1, "default_provider": "kilo-perplexity", "auto_routing": {"enabled": False}}))
+    monkeypatch.setenv("WEB_SEARCH_PLUS_CONFIG", str(config_path))
+    monkeypatch.delenv("PERPLEXITY_API_KEY", raising=False)
+    monkeypatch.setenv("KILOCODE_API_KEY", "kilo-test-key")
+    monkeypatch.setattr(search, "provider_in_cooldown", lambda _provider: (False, 0))
+    monkeypatch.setattr(search, "execute_provider_with_retry", lambda _provider, fn: fn())
+    monkeypatch.setattr(sys, "argv", ["search.py", "--query", "hello", "--provider", "auto", "--no-cache"])
+
+    captured = {}
+
+    def fake_search_perplexity(**kwargs):
+        captured.update(kwargs)
+        return {"provider": "kilo-perplexity", "query": kwargs["query"], "results": [], "images": []}
+
+    monkeypatch.setattr(search, "search_perplexity", fake_search_perplexity)
+
+    search.main()
+
+    data = json.loads(capsys.readouterr().out)
+    assert data["provider"] == "kilo-perplexity"
+    assert captured["api_key"] == "kilo-test-key"
+    assert captured["model"] == "perplexity/sonar-pro"
+    assert captured["api_url"] == "https://api.kilo.ai/api/gateway/chat/completions"
+
+
+def test_native_perplexity_uses_perplexity_key_not_kilo_key(monkeypatch):
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "pplx-native-key")
+    monkeypatch.setenv("KILOCODE_API_KEY", "kilo-bridge-key")
+
+    assert search.get_api_key("perplexity") == "pplx-native-key"
+    assert search.get_api_key("kilo-perplexity") == "kilo-bridge-key"
+
+
+def test_onboarding_routing_keeps_kilo_perplexity_distinct(tmp_path):
+    config_path = tmp_path / "config.json"
+    parser = wsp.argparse.ArgumentParser()
+    wsp._web_search_plus_cli_setup(parser)
+    args = parser.parse_args(["config", "set-default", "kilo-perplexity", "--config-path", str(config_path)])
+
+    args.func(args)
+
+    data = json.loads(config_path.read_text())
+    assert data["default_provider"] == "kilo-perplexity"


### PR DESCRIPTION
Fixes #16.

This splits native `perplexity` from `kilo-perplexity` instead of aliasing the Kilo gateway to Perplexity:

- `perplexity` now uses `PERPLEXITY_API_KEY`, `https://api.perplexity.ai/chat/completions`, and `sonar-pro`
- `kilo-perplexity` remains available as a distinct provider using `KILOCODE_API_KEY`, the Kilo gateway URL, and `perplexity/sonar-pro`
- routing/config/tool schemas accept `kilo-perplexity` as a distinct provider
- added regression tests for native Perplexity defaults, Kilo routing, separate env keys, and config normalization

Verified:
- `python -m pytest -q` → 116 passed
- `python -m ruff check .` → clean
- `git diff --check` → clean
- smoke test for fixed `kilo-perplexity` routing → ok
- secret-like token scan over the PR diff → clean
