### PR TITLE
Add SerpBase provider with explicit auto-allow gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@
 - Added onboarding/config support for `auto_allow`, including `setup.py config set-auto-allow <provider> on|off` so experimental or fallback providers can remain explicit-only.
 
 ### 🔧 Changed
-- SerpBase defaults to `auto_allow=false`: configured keys unlock explicit calls, but auto-routing/fallback will not select it unless users opt in.
+- SerpBase defaults to `auto_allow=false`: configured keys unlock explicit calls, but auto-routing/fallback will not select it unless users opt in. See [Architecture: Auto-allow gate](docs/ARCHITECTURE.md#auto-allow-gate).
 - README provider, API-key, and routing docs now cover SerpBase activation and auto-allow behavior.
+- Added detailed user documentation, FAQ, and architecture/trust-boundary docs under `docs/`.
 
 ### 🧪 Tests
 - Added regression coverage for SerpBase response normalization, explicit provider calls, missing-key handling, onboarding metadata, and auto-routing exclusion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### ✨ Added
+- Added SerpBase as a search provider using `SERPBASE_API_KEY`, available via `provider="serpbase"`.
+- Added onboarding/config support for `auto_allow`, including `setup.py config set-auto-allow <provider> on|off` so experimental or fallback providers can remain explicit-only.
+
+### 🔧 Changed
+- SerpBase defaults to `auto_allow=false`: configured keys unlock explicit calls, but auto-routing/fallback will not select it unless users opt in.
+- README provider, API-key, and routing docs now cover SerpBase activation and auto-allow behavior.
+
+### 🧪 Tests
+- Added regression coverage for SerpBase response normalization, explicit provider calls, missing-key handling, onboarding metadata, and auto-routing exclusion.
+
 ## [v1.9.3] — 2026-05-14
 
 ### 🐛 Fixed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img alt="Hermes Plugin" src="https://img.shields.io/badge/Hermes-plugin-a78bfa.svg">
 </p>
 
-**Web search, extraction, and optional cited answers for Hermes — bring any one of 10 provider options and the plugin unlocks the tools your keys can actually support.** `web_extract_plus(provider="auto")` defaults to Firecrawl-first extraction for robust scraping; Linkup remains the cheap/citation-friendly answer-extraction path when available.
+**Web search, extraction, and optional cited answers for Hermes — bring any one of 12 provider options and the plugin unlocks the tools your keys can actually support.** `web_extract_plus(provider="auto")` defaults to Firecrawl-first extraction for robust scraping; Linkup remains the cheap/citation-friendly answer-extraction path when available.
 
 `web-search-plus` adds three Hermes tools:
 
@@ -116,6 +116,8 @@ python ~/.hermes/plugins/web-search-plus/setup.py config set-priority tavily,lin
 python ~/.hermes/plugins/web-search-plus/setup.py config set-fallback tavily
 python ~/.hermes/plugins/web-search-plus/setup.py config disable perplexity
 python ~/.hermes/plugins/web-search-plus/setup.py config enable perplexity
+python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase off
+python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase on
 python ~/.hermes/plugins/web-search-plus/setup.py config set-threshold 0.45
 
 # Preview changes without touching disk
@@ -127,6 +129,7 @@ Notes:
 - `set-default <provider>` disables auto-routing and makes `--provider auto` resolve to that provider.
 - `set-routing on` restores query-based routing while keeping the saved default for later.
 - `set-priority` accepts comma-separated provider names, normalizes case/whitespace, and ignores duplicates with a warning.
+- `set-auto-allow <provider> off` keeps a configured provider available for explicit calls while preventing auto-routing/fallback from selecting it. SerpBase and Querit default to `off` here.
 - `setup.py --config-path /path/to/config.json` points the helper at a custom config; `WEB_SEARCH_PLUS_CONFIG=/path/to/config.json` points `search.py` at the same file.
 - `config reset --yes` backs up the existing file before writing fresh defaults.
 
@@ -136,7 +139,7 @@ Notes:
 
 | Capability | Unlocks | Configure at least one of |
 |---|---|---|
-| Search | `web_search_plus`, snippet-backed `web_answer_plus` | Brave, Serper, Tavily, Exa, Querit, Linkup, Firecrawl, Perplexity, You.com, or SearXNG |
+| Search | `web_search_plus`, snippet-backed `web_answer_plus` | Brave, Serper, SerpBase, Tavily, Exa, Querit, Linkup, Firecrawl, Perplexity, Kilo Perplexity, You.com, or SearXNG |
 | Extraction | `web_extract_plus`, fuller `web_answer_plus` citations | Linkup, Firecrawl, Tavily, Exa, or You.com |
 | Best starter | Search + extraction + broad fallback | Tavily + Linkup + optional Brave |
 
@@ -235,7 +238,7 @@ Parameters:
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `query` | string | **required** | Search query |
-| `provider` | string | `"auto"` | `auto`, `serper`, `brave`, `tavily`, `exa`, `querit`, `linkup`, `firecrawl`, `perplexity`, `kilo-perplexity`, `you`, `searxng` |
+| `provider` | string | `"auto"` | `auto`, `serper`, `serpbase`, `brave`, `tavily`, `exa`, `querit`, `linkup`, `firecrawl`, `perplexity`, `kilo-perplexity`, `you`, `searxng` |
 | `depth` | string | `"normal"` | Exa only: `normal`, `deep`, `deep-reasoning` |
 | `count` | integer | `5` | Results, 1–20 |
 | `time_range` | string | — | `day`, `week`, `month`, `year` |
@@ -278,6 +281,7 @@ Parameters:
 |---|---:|---:|---|
 | Brave | ✅ | — | General-purpose independent web index |
 | Serper | ✅ | — | Google-like SERP, news, shopping, local facts |
+| SerpBase | ✅ | — | Cheap Google-like SERP fallback; explicit/fallback-only by default |
 | Tavily | ✅ | ✅ | Long-form research and content-heavy queries |
 | Exa | ✅ | ✅ | Semantic discovery and similarity search |
 | Querit | ✅ | — | Multilingual and real-time queries |
@@ -288,7 +292,7 @@ Parameters:
 | You.com | ✅ | ✅ | LLM-ready real-time snippets and content |
 | SearXNG | ✅ | — | Privacy-focused self-hosted metasearch |
 
-Auto-routing is rule-based on query signals such as recency, product intent, research language, and semantic-discovery patterns. Brave and Serper share generic web-search intents; when they tie, deterministic per-query tie-breaking keeps the same query reproducible while distributing ties across both providers.
+Auto-routing is rule-based on query signals such as recency, product intent, research language, and semantic-discovery patterns. Brave and Serper share generic web-search intents; when they tie, deterministic per-query tie-breaking keeps the same query reproducible while distributing ties across both providers. SerpBase is intentionally `auto_allow=false` by default: configure `SERPBASE_API_KEY` to call `provider="serpbase"` explicitly, or opt it into automatic routing with `setup.py config set-auto-allow serpbase on`.
 
 ---
 
@@ -299,6 +303,7 @@ All provider keys are optional at install time. Configure only what you use:
 ```bash
 # Search-capable providers
 SERPER_API_KEY=***        # https://serper.dev
+SERPBASE_API_KEY=***      # https://www.serpbase.dev — explicit/fallback-only Google-like SERP search
 BRAVE_API_KEY=***         # https://brave.com/search/api/
 TAVILY_API_KEY=***        # https://tavily.com — search + extraction
 EXA_API_KEY=***           # https://exa.ai — search + extraction

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ Notes:
 
 ---
 
+## Documentation
+
+- [User Guide](docs/USER_GUIDE.md) — detailed setup, provider tuning, routing, extraction, answer beta, reliability, and cost controls.
+- [FAQ](docs/FAQ.md) — common setup, SerpBase auto-allow, provider selection, cache, quota, and troubleshooting questions.
+- [Architecture](docs/ARCHITECTURE.md) — plugin boundary, routing engine, auto-allow gate, cache/cooldown state, data flow, and provider-extension notes.
+
+---
+
 ## CLI setup
 
 The setup wizard is intentionally nicer than “paste keys and pray”:

--- a/__init__.py
+++ b/__init__.py
@@ -116,10 +116,11 @@ _PROVIDER_CATALOG = [
         "provider": "serpbase",
         "env": "SERPBASE_API_KEY",
         "display_name": "SerpBase",
-        "description": "Cheap Google-like SERP fallback; explicit/fallback-only by default.",
+        "description": "Cheap Google-like SERP fallback; WSP exposes search only, explicit/fallback-only by default.",
         "free_tier": "100 free searches, paid packs available",
         "signup_url": "https://www.serpbase.dev",
-        "capabilities": ["search", "news", "shopping", "local"],
+        "capabilities": ["search"],
+        "upstream_capabilities": ["images", "news", "videos", "maps_search", "maps_detail"],
         "recommended": False,
     },
     {

--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,7 @@ _SEARCH_SCRIPT = Path(__file__).parent / "search.py"
 _TOOLSET_NAME = "web-search-plus"
 _PROVIDER_ENV_KEYS = [
     "SERPER_API_KEY",
+    "SERPBASE_API_KEY",
     "BRAVE_API_KEY",
     "TAVILY_API_KEY",
     "EXA_API_KEY",
@@ -108,6 +109,16 @@ _PROVIDER_CATALOG = [
         "description": "Google-like SERP results for facts, shopping, local and news queries.",
         "free_tier": "2,500 one-time credits",
         "signup_url": "https://serper.dev/api-key",
+        "capabilities": ["search", "news", "shopping", "local"],
+        "recommended": False,
+    },
+    {
+        "provider": "serpbase",
+        "env": "SERPBASE_API_KEY",
+        "display_name": "SerpBase",
+        "description": "Cheap Google-like SERP fallback; explicit/fallback-only by default.",
+        "free_tier": "100 free searches, paid packs available",
+        "signup_url": "https://www.serpbase.dev",
         "capabilities": ["search", "news", "shopping", "local"],
         "recommended": False,
     },
@@ -257,8 +268,9 @@ def _get_hermes_env_path() -> Path:
 
 
 _SETUP_PROVIDER_NAMES = {item["provider"] for item in _PROVIDER_CATALOG}
-_DEFAULT_PROVIDER_PRIORITY = ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng"]
-_ROUTING_PROVIDER_NAMES = set(_DEFAULT_PROVIDER_PRIORITY) | {"kilo-perplexity"}
+_DEFAULT_PROVIDER_PRIORITY = ["tavily", "linkup", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"]
+_DEFAULT_AUTO_ALLOW = {"serpbase": False, "querit": False}
+_ROUTING_PROVIDER_NAMES = set(_DEFAULT_PROVIDER_PRIORITY)
 
 
 def _get_plugin_config_path() -> Path:
@@ -278,6 +290,7 @@ def _default_behavior_config() -> Dict[str, Any]:
             "fallback_provider": "serper",
             "provider_priority": list(_DEFAULT_PROVIDER_PRIORITY),
             "disabled_providers": [],
+            "auto_allow": dict(_DEFAULT_AUTO_ALLOW),
             "confidence_threshold": 0.3,
         },
     }
@@ -347,6 +360,14 @@ def _merge_behavior_config(user_config: Mapping[str, Any]) -> Dict[str, Any]:
             auto["disabled_providers"] = _normalize_provider_csv(disabled, routing=True) if disabled.strip() else []
         else:
             auto["disabled_providers"] = _normalize_provider_csv(",".join(str(p) for p in disabled), routing=True) if disabled else []
+    if "auto_allow" in auto_user:
+        raw_allow = auto_user.get("auto_allow") or {}
+        if not isinstance(raw_allow, Mapping):
+            raise SystemExit("auto_allow must be an object mapping provider names to booleans")
+        normalized_allow = dict(_DEFAULT_AUTO_ALLOW)
+        for raw_provider, allowed in raw_allow.items():
+            normalized_allow[_normalize_routing_provider(str(raw_provider))] = bool(allowed)
+        auto["auto_allow"] = normalized_allow
     if "confidence_threshold" in auto_user:
         threshold = float(auto_user["confidence_threshold"])
         if threshold < 0.0 or threshold > 1.0:
@@ -429,6 +450,9 @@ def _routing_summary(config: Mapping[str, Any]) -> str:
         f"  fallback provider: {auto.get('fallback_provider', 'serper')}",
         "  priority: " + ", ".join(auto.get("provider_priority", _DEFAULT_PROVIDER_PRIORITY)),
         "  disabled: " + (", ".join(auto.get("disabled_providers", [])) or "none"),
+        "  auto-allow false: " + (
+            ", ".join(p for p, allowed in sorted((auto.get("auto_allow") or {}).items()) if allowed is False) or "none"
+        ),
         f"  confidence threshold: {auto.get('confidence_threshold', 0.3)}",
     ]
     return "\n".join(lines)
@@ -660,6 +684,8 @@ def _web_search_plus_cli_setup(parser: argparse.ArgumentParser) -> None:
     setup.add_argument("--default-provider", help="Provider to use when routing is fixed/off")
     setup.add_argument("--provider-priority", help="Comma-separated auto-routing priority")
     setup.add_argument("--disable-providers", help="Comma-separated providers to exclude from auto-routing")
+    setup.add_argument("--auto-allow", help="Comma-separated providers allowed in auto-routing")
+    setup.add_argument("--auto-deny", help="Comma-separated providers blocked from auto-routing but still usable explicitly")
     setup.add_argument("--fallback-provider", help="Fallback provider when no route is available")
     setup.add_argument("--confidence-threshold", type=float, help="Auto-routing confidence threshold 0.0-1.0")
 
@@ -695,6 +721,11 @@ def _web_search_plus_cli_setup(parser: argparse.ArgumentParser) -> None:
     enable.add_argument("provider")
     enable.add_argument("--config-path")
     enable.add_argument("--dry-run", action="store_true")
+    allow_auto = config_subs.add_parser("set-auto-allow", help="Allow or block a provider from automatic routing/fallback")
+    allow_auto.add_argument("provider")
+    allow_auto.add_argument("mode", choices=["on", "off", "true", "false", "yes", "no"])
+    allow_auto.add_argument("--config-path")
+    allow_auto.add_argument("--dry-run", action="store_true")
     threshold = config_subs.add_parser("set-threshold", help="Set routing confidence threshold")
     threshold.add_argument("value", type=float)
     threshold.add_argument("--config-path")
@@ -718,6 +749,14 @@ def _apply_setup_routing_args(config: Dict[str, Any], args: Any) -> Dict[str, An
         auto["provider_priority"] = _normalize_provider_csv(getattr(args, "provider_priority"), routing=True)
     if getattr(args, "disable_providers", None):
         auto["disabled_providers"] = _normalize_provider_csv(getattr(args, "disable_providers"), routing=True)
+    auto_allow = dict(auto.get("auto_allow") or _DEFAULT_AUTO_ALLOW)
+    if getattr(args, "auto_allow", None):
+        for provider in _normalize_provider_csv(getattr(args, "auto_allow"), routing=True):
+            auto_allow[provider] = True
+    if getattr(args, "auto_deny", None):
+        for provider in _normalize_provider_csv(getattr(args, "auto_deny"), routing=True):
+            auto_allow[provider] = False
+    auto["auto_allow"] = auto_allow
     if getattr(args, "fallback_provider", None):
         auto["fallback_provider"] = _normalize_routing_provider(getattr(args, "fallback_provider"))
     if getattr(args, "confidence_threshold", None) is not None:
@@ -763,6 +802,12 @@ def _handle_config_command(args: Any) -> None:
     elif subcommand == "enable":
         provider = _normalize_routing_provider(getattr(args, "provider"))
         config["auto_routing"]["disabled_providers"] = [p for p in config["auto_routing"].get("disabled_providers", []) if p != provider]
+    elif subcommand == "set-auto-allow":
+        provider = _normalize_routing_provider(getattr(args, "provider"))
+        mode = str(getattr(args, "mode")).lower()
+        auto_allow = dict(config["auto_routing"].get("auto_allow") or _DEFAULT_AUTO_ALLOW)
+        auto_allow[provider] = mode in {"on", "true", "yes"}
+        config["auto_routing"]["auto_allow"] = auto_allow
     elif subcommand == "set-threshold":
         value = float(getattr(args, "value"))
         if value < 0.0 or value > 1.0:
@@ -1448,12 +1493,12 @@ def register(ctx: Any) -> None:
             "Multi-provider web search with intelligent auto-routing. "
             "Automatically selects the best provider based on query intent: "
             "Serper for shopping/news/facts, Tavily for research/analysis, "
-            "Exa for semantic discovery, Querit for multilingual/real-time, "
+            "Exa for semantic discovery, "
             "Brave for general web search, "
             "Linkup for source-backed grounding/citations, "
             "Firecrawl for web search plus optional scrape-ready results, "
             "Perplexity for direct answers, You.com for real-time snippets, "
-            "and SearXNG for privacy-focused/self-hosted search. "
+            "SearXNG for privacy-focused/self-hosted search, and SerpBase/Querit only when explicitly enabled or forced. "
             "Set depth='deep' for Exa multi-source synthesis, 'deep-reasoning' for complex cross-document analysis. "
             "Override with provider param if needed."
         ),
@@ -1466,7 +1511,7 @@ def register(ctx: Any) -> None:
                 },
                 "provider": {
                     "type": "string",
-                    "enum": ["auto", "serper", "brave", "tavily", "exa", "querit", "linkup", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng"],
+                    "enum": ["auto", "serper", "serpbase", "brave", "tavily", "exa", "querit", "linkup", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng"],
                     "description": "Search provider. Use 'auto' for intelligent routing (default). Brave and Serper share generic web-search intents and ties are distributed deterministically per query.",
                     "default": "auto",
                 },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,245 @@
+# web-search-plus Architecture
+
+This document explains the runtime shape of `web-search-plus`: what runs locally, what leaves the machine, how routing works, and where the safety/cost boundaries are. It is deliberately plain. Fancy diagrams are nice; lying less is nicer.
+
+## System boundary
+
+`web-search-plus` is a Hermes Agent plugin. Hermes calls the plugin tools, and the plugin calls configured provider APIs.
+
+```text
+Hermes Agent
+  → plugin tool schema and handler in __init__.py
+  → provider/routing engine in search.py
+  → configured external provider APIs
+  → normalized result returned to Hermes
+```
+
+The plugin does not run a separate hosted backend. It does not add an analytics service. It does not make searches private from the provider you configured. Queries and URLs sent to external providers leave the machine by definition.
+
+## Main files
+
+- `plugin.yaml`: plugin manifest, optional environment variables, onboarding commands, and tool declarations.
+- `__init__.py`: Hermes plugin entrypoint, tool schemas, setup/onboarding helpers, and wrapper functions exposed to Hermes.
+- `search.py`: provider adapters, routing, caching, cooldowns, extraction, answer support, and CLI.
+- `setup.py`: thin standalone CLI entrypoint that loads setup helpers from `__init__.py`.
+- `tests/`: unit and regression coverage for providers, onboarding, routing, extraction, answer behavior, and docs-sensitive configuration.
+
+## Tool surface
+
+The plugin exposes three tools:
+
+- `web_search_plus`: routed or forced-provider search.
+- `web_extract_plus`: URL extraction through extraction-capable providers.
+- `web_answer_plus`: beta synthesis layer that searches, selects sources, optionally extracts content, and returns an answer shape with warnings and source metadata.
+
+`web_answer_plus` is not a replacement for `web_search_plus`. It exists for explicit answer/synthesis requests.
+
+## Provider abstraction
+
+Each provider adapter normalizes provider-specific request and response details into a common result shape. Providers declare capabilities in docs and onboarding metadata, but provider APIs are still heterogeneous.
+
+Provider capability classes:
+
+- Search-only: Brave, Serper, SerpBase, Querit, Perplexity, Kilo Perplexity, SearXNG.
+- Search and extraction: Tavily, Exa, Linkup, Firecrawl, You.com.
+- Answer-style search: Perplexity and Kilo Perplexity return direct-answer style search results, but are still exposed through the search interface.
+
+Provider pricing, freshness, ranking, localization, and vertical support are controlled by the providers. The plugin normalizes responses; it does not make providers equivalent.
+
+## Configuration model
+
+There are two config layers:
+
+- Secrets: provider keys in `.env`.
+- Behavior: routing config in `config.json`.
+
+Default routing config includes:
+
+```json
+{
+  "auto_routing": {
+    "enabled": true,
+    "fallback_provider": "serper",
+    "provider_priority": ["tavily", "linkup", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"],
+    "disabled_providers": [],
+    "auto_allow": {"serpbase": false, "querit": false},
+    "confidence_threshold": 0.3
+  }
+}
+```
+
+Secrets and routing are separate so users can configure a provider key without automatically letting that provider receive automatic traffic.
+
+## Routing engine
+
+Routing is rule-based. It is not ML and it is not magic.
+
+High-level flow:
+
+1. Analyze query text for signals: current-info intent, product/local intent, research language, direct-answer intent, semantic-discovery intent, privacy intent, complexity, and recency.
+2. Score known providers for those signals.
+3. Remove providers that do not have a key or required local config.
+4. Remove providers listed in `disabled_providers`.
+5. Remove providers with `auto_allow=false` from automatic routing.
+6. Choose the highest-scoring remaining provider.
+7. Break ties deterministically using query text and `provider_priority`.
+8. Execute the provider call with retry/cooldown handling.
+9. Return quality diagnostics if requested.
+
+When no provider is eligible, the router reports `no_available_providers` and falls back to the configured fallback provider path. If that provider has no key, the call fails visibly instead of inventing results.
+
+## Auto-allow gate
+
+`auto_allow` controls automatic routing and fallback eligibility. It does not control explicit provider calls.
+
+Example:
+
+```json
+"auto_allow": {
+  "serpbase": false,
+  "querit": false
+}
+```
+
+With this config:
+
+- `provider="serpbase"` can work when `SERPBASE_API_KEY` is present.
+- `provider="auto"` will not select SerpBase.
+- fallback lists will not silently choose SerpBase.
+- `quality_report` can surface SerpBase under `auto_allow_excluded`.
+
+Opt in:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase on
+```
+
+Opt out:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase off
+```
+
+The gate exists for providers where silent automatic use could surprise users because of pricing, maturity, coverage, terms, or result style. SerpBase is documented as an explicit-opt-in provider, not as a broken or disabled provider.
+
+## Fallback and failure semantics
+
+The plugin favors partial truth over fake certainty.
+
+- Provider calls use shared transient-error retry behavior.
+- Transient HTTP codes include `429` and `503`.
+- Retry backoff is short and bounded.
+- Repeated provider failures update provider health state and cooldown.
+- Cooldowns step through 1 minute, 5 minutes, 25 minutes, and 1 hour.
+- Cooldown state is local and stored in `provider_health.json` under the cache directory.
+- Research mode keeps partial provider results when later extraction or provider calls fail.
+- Answer mode returns warnings for missing extraction, empty extraction, budget exhaustion, and source limitations.
+
+A provider outage should produce skipped-provider metadata or a structured error, not a confident hallucination.
+
+## Caching
+
+Search results are cached locally by query, provider, result count, and relevant parameters.
+
+- Default TTL: 1 hour.
+- Cache key: SHA-256 hash prefix over normalized query/provider/max-results/params payload.
+- Cache directory: `WSP_CACHE_DIR` if set; otherwise the plugin cache directory.
+- CLI bypass: `--no-cache`.
+- Cache write failures are non-fatal and reported to stderr.
+- Corrupted or expired cache entries are removed on read.
+
+The cache stores result payloads. Do not put the cache directory in version control.
+
+## Cost and budget model
+
+The plugin has cost guards, not provider billing control.
+
+- `count` limits requested search result count.
+- Research mode has a best-effort `research_time_budget` checked between provider and extraction steps.
+- `web_answer_plus` limits extraction with `max_extracts`, hard-capped at 5.
+- Extraction provider order is bounded and explicit.
+- `disabled_providers`, `set-default`, and `auto_allow` let users control which providers can receive traffic.
+
+The plugin does not know every provider account's exact current price, quota, or billing state. Provider dashboards remain the source of truth.
+
+## Observability and debugging
+
+Use quality reports for routing diagnostics:
+
+```python
+web_search_plus(query="best bookshelf speakers under 1000", quality_report=True)
+```
+
+CLI equivalent:
+
+```bash
+python3 search.py --query "best bookshelf speakers under 1000" --provider auto --quality-report --compact
+```
+
+Useful fields include:
+
+- selected provider
+- provider scores
+- confidence and reason
+- skipped providers
+- cooldown remaining seconds
+- provider errors
+- `auto_allow_excluded`
+- extraction recommendation
+
+Setup/status diagnostics:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py status --json
+python ~/.hermes/plugins/web-search-plus/setup.py config show --json
+```
+
+## Data flow and trust boundary
+
+Data sent to providers depends on the tool:
+
+- `web_search_plus`: sends the query and provider-specific search parameters.
+- `web_extract_plus`: sends URLs and extraction options.
+- `web_answer_plus`: sends queries to search providers, may send selected URLs to extraction providers, then returns synthesized output to Hermes.
+
+The plugin does not promise “no data leaves your machine.” A more accurate statement is: data only goes to providers you configure or explicitly select, plus local cache/state files written by the plugin.
+
+## Extending with a new provider
+
+A provider addition should include:
+
+- provider adapter function in `search.py`
+- API key mapping in runtime and onboarding code
+- provider metadata in setup/list/status output
+- routing score/match behavior if it participates in auto-routing
+- explicit default `auto_allow` decision
+- docs in README, User Guide, FAQ, and Architecture when behavior is user-visible
+- tests for response normalization, missing-key behavior, routing eligibility, onboarding metadata, and CLI/provider choices
+
+Default stance: new or surprising providers should start explicit-only until their cost and quality characteristics are boring enough for automatic fallback.
+
+## Non-goals
+
+`web-search-plus` is not:
+
+- a paywall bypass tool
+- an auth-walled content extractor
+- a guarantee of Google/Bing parity
+- an unlimited scraping service
+- an SLA-backed hosted search backend
+- a privacy shield from external providers
+- a legal/medical/financial citation verifier
+- a replacement for live provider billing dashboards
+
+## Safe claims to make
+
+Use precise wording:
+
+- “multi-provider search and extraction”
+- “capability-based provider setup”
+- “best-effort routing diagnostics”
+- “explicit opt-in for automatic use of gated providers”
+- “bounded research and answer extraction fanout”
+- “local cache and cooldown state”
+
+Avoid claims like “always best,” “private,” “real-time guaranteed,” “unlimited,” or “verified citations.” Those are marketing confetti. Pretty, useless, and gets everywhere.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,178 @@
+# web-search-plus FAQ
+
+## Why did SerpBase not get used after I set `SERPBASE_API_KEY`?
+
+Because SerpBase is explicit-opt-in for automatic routing. The key enables direct calls:
+
+```python
+web_search_plus(query="best DAC reviews", provider="serpbase")
+```
+
+To let `provider="auto"` or fallback select SerpBase, opt in:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase on
+```
+
+Turn it back off with:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase off
+```
+
+## Which provider gets picked when multiple providers are configured?
+
+If routing is enabled, the query analyzer scores providers by query signals such as current-info intent, product/local intent, research language, direct-answer intent, semantic-discovery intent, and privacy intent. The router then filters out unavailable, disabled, or `auto_allow=false` providers and chooses the best eligible provider. Ties are deterministic per query.
+
+For the exact flow, see [Architecture](ARCHITECTURE.md#routing-engine).
+
+## How do I force one provider?
+
+Per call:
+
+```python
+web_search_plus(query="Hermes Agent docs", provider="brave")
+```
+
+Persistently:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave
+```
+
+Re-enable auto-routing later:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-routing on
+```
+
+## What happens if all providers fail?
+
+The tool returns a structured error or warning metadata instead of fabricating results. In fallback paths, the plugin keeps partial results when it has them. Providers with repeated failures enter cooldown and are skipped temporarily.
+
+Typical causes:
+
+- missing key
+- quota or rate limit
+- provider outage
+- network timeout
+- bad or unsupported query parameters
+
+## Why is my new key not detected?
+
+After editing `.env`, restart or reset Hermes so the process reloads environment variables:
+
+```text
+CLI: restart hermes, or use /reset
+Gateway/Telegram: /restart, then /reset
+```
+
+Then check:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py status
+```
+
+Also verify that the key was written to the environment file Hermes actually uses. The setup helper supports explicit targeting:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py setup brave --env-path ~/.hermes/.env
+```
+
+## How do I cap spend?
+
+Use fewer providers, pin cheaper providers, keep extraction capped, and avoid research mode unless needed.
+
+Useful controls:
+
+- `count` limits search result count.
+- `mode="normal"` avoids multi-provider research fanout.
+- `research_time_budget` limits research-mode wall-clock work between steps.
+- `web_answer_plus(max_extracts=...)` limits extraction count and is hard-capped at 5.
+- `setup.py config set-default <provider>` pins search to one provider.
+- `setup.py config disable <provider>` removes a provider from auto-routing.
+- `setup.py config set-auto-allow <provider> off` keeps a provider explicit-only.
+
+These are plugin-side controls, not a billing guarantee. Providers own their own pricing and rate limits.
+
+## Is `web_answer_plus` production-ready?
+
+It is beta. It is useful for concise cited summaries, but it is not the default path for live facts. Prefer `web_search_plus` for current events, sports, prices, weather, schedules, standings, and source discovery.
+
+Citations are best-effort source references from selected search/extraction results. They are not legal, medical, financial, or academic verification.
+
+## Why do SerpBase results differ from Google?
+
+Different SERP APIs can have different freshness, ranking, localization, personalization, vertical support, and parsing behavior. Treat SerpBase as a Google-like SERP provider, not as a promise of exact Google parity.
+
+## Can I run with only one provider?
+
+Yes. Configure one search-capable provider and pin it if you want predictable behavior:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py setup brave
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave
+```
+
+Extraction requires an extraction-capable provider such as Linkup, Firecrawl, Tavily, Exa, or You.com.
+
+## Can I run fully offline?
+
+No. The plugin calls external provider APIs for search and extraction. You can use a self-hosted SearXNG instance for the search provider, but the plugin still sends the query to that configured instance.
+
+## Does the plugin log or send results anywhere else?
+
+The normal data flow is:
+
+```text
+Hermes tool call → web-search-plus plugin → configured provider API → plugin response → Hermes agent
+```
+
+The plugin writes local cache files and provider health state under the cache directory. It does not add a separate analytics service. Provider APIs still receive the queries or URLs you ask them to process.
+
+## Where is the cache?
+
+By default the cache directory is near the plugin install under the Hermes plugin cache area. Override it with:
+
+```bash
+export WSP_CACHE_DIR=/path/to/cache
+```
+
+Search cache TTL is 1 hour. CLI tests can bypass cache with:
+
+```bash
+python3 search.py --query "Hermes Agent" --provider auto --no-cache
+```
+
+## What do I do about repeated 429 or quota errors?
+
+- Wait for the provider quota window to reset.
+- Disable that provider temporarily:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config disable brave
+```
+
+- Pin a different provider:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default tavily
+```
+
+- Reduce fanout by avoiding `mode="research"`.
+
+Repeated provider failures are cooled down automatically, but provider-side quota exhaustion still needs provider-side quota management.
+
+## How do I debug routing decisions?
+
+Use `quality_report=True` or CLI `--quality-report`:
+
+```python
+web_search_plus(query="best bookshelf speakers under 1000", quality_report=True)
+```
+
+```bash
+python3 search.py --query "best bookshelf speakers under 1000" --provider auto --quality-report --compact
+```
+
+Look for selected provider, provider scores, skipped providers, cooldown skips, and `auto_allow_excluded`.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,0 +1,264 @@
+# web-search-plus User Guide
+
+This guide is the long-form operating manual for `web-search-plus`. If you only need the first install, start with the [README Quick Start](../README.md#quick-start). Come back here when you want to tune providers, routing, fallback, extraction, or answer synthesis without guessing.
+
+## What this plugin does
+
+`web-search-plus` adds three Hermes tools:
+
+- `web_search_plus` for routed multi-provider web search.
+- `web_extract_plus` for clean URL extraction.
+- `web_answer_plus` for optional beta cited-answer synthesis on top of search and extraction.
+
+The plugin is capability-based. You do not need every provider key. One search-capable key is enough for search and snippet-backed answers; one extraction-capable key unlocks URL extraction and fuller cited answers.
+
+## Installation and first-run checks
+
+Install and enable the plugin:
+
+```bash
+hermes plugins install robbyczgw-cla/hermes-web-search-plus --enable
+```
+
+Check status and configure keys:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py status
+python ~/.hermes/plugins/web-search-plus/setup.py setup
+```
+
+Restart or reset Hermes after changing keys so the tool schemas and environment are reloaded:
+
+```text
+CLI: exit and start hermes again, or use /reset in-session
+Gateway/Telegram: /restart, then /reset
+```
+
+Smoke test from the plugin directory:
+
+```bash
+cd ~/.hermes/plugins/web-search-plus
+python3 search.py --query "Hermes Agent latest release" --provider auto --quality-report --compact
+```
+
+## Provider setup
+
+Keys live in the active Hermes environment file, normally `~/.hermes/.env`. The setup helper preserves existing entries and does not print secret values.
+
+Useful commands:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py list
+python ~/.hermes/plugins/web-search-plus/setup.py status --json
+python ~/.hermes/plugins/web-search-plus/setup.py setup --preset starter
+python ~/.hermes/plugins/web-search-plus/setup.py setup brave linkup --env-path ~/.hermes/.env
+```
+
+Presets:
+
+- `starter`: Tavily + Linkup + Brave. Best default for new users.
+- `lean`: Tavily + Linkup. Cheap useful search plus extraction.
+- `search`: Tavily + Brave + Serper. Broad search coverage.
+- `extract`: Firecrawl + Linkup + Exa + Tavily. Extraction-heavy setup.
+- `all`: prompt for every supported provider.
+
+Search-capable providers include Brave, Serper, SerpBase, Tavily, Exa, Querit, Linkup, Firecrawl, Perplexity, Kilo Perplexity, You.com, and SearXNG. Extraction-capable providers are Linkup, Firecrawl, Tavily, Exa, and You.com.
+
+## Routing preferences
+
+Secrets and behavior are intentionally separate:
+
+- Provider keys live in `.env`.
+- Routing behavior lives in `config.json`.
+- `WEB_SEARCH_PLUS_CONFIG=/path/to/config.json` can point runtime search at a custom config.
+- `setup.py --config-path /path/to/config.json` points the setup helper at a custom config.
+
+Inspect routing:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config show --json
+```
+
+Pin a fixed provider:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave
+```
+
+Turn query-based auto-routing back on:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-routing on
+```
+
+Tune automatic routing and fallback:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-priority tavily,linkup,exa,firecrawl,perplexity,kilo-perplexity,brave,serper,you,searxng
+python ~/.hermes/plugins/web-search-plus/setup.py config set-fallback tavily
+python ~/.hermes/plugins/web-search-plus/setup.py config disable perplexity
+python ~/.hermes/plugins/web-search-plus/setup.py config enable perplexity
+python ~/.hermes/plugins/web-search-plus/setup.py config set-threshold 0.45
+```
+
+Preview config changes without writing:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave --dry-run
+```
+
+### Routing debug walkthrough
+
+When a query does not use the provider you expected, ask for routing diagnostics instead of guessing:
+
+```bash
+python3 search.py --query "best bookshelf speakers under 1000 EUR" --provider auto --quality-report --compact --no-cache
+```
+
+In the JSON output, check these fields first:
+
+- `routing.provider`: the selected provider.
+- `routing.reason`: why the router considered the match strong or weak.
+- `scores`: provider scores before final selection.
+- `quality_report.skipped_providers`: providers skipped because of cooldown or errors.
+- `routing.auto_allow_excluded`: configured providers that were blocked from automatic routing by `auto_allow=false`.
+- `quality_report.extraction_recommended`: whether snippets look thin enough that `web_extract_plus` may help.
+
+Example pattern:
+
+```json
+{
+  "routing": {
+    "provider": "serper",
+    "reason": "moderate_confidence_match",
+    "auto_allow_excluded": ["serpbase"]
+  },
+  "quality_report": {
+    "skipped_providers": [
+      {"provider": "brave", "reason": "cooldown", "cooldown_remaining_seconds": 42}
+    ]
+  }
+}
+```
+
+Read that as: SerpBase has a key but is explicit-only, Brave is temporarily cooled down, and Serper won among eligible providers. If you want SerpBase to participate in automatic routing, opt in with `set-auto-allow serpbase on`; if you want Brave retried immediately, wait for cooldown or clear local provider health state in your cache directory.
+
+## Explicit opt-in providers and SerpBase
+
+Some providers can be configured for explicit use without being selected automatically. That is what `auto_allow` controls.
+
+SerpBase defaults to `auto_allow=false`. Setting `SERPBASE_API_KEY` makes explicit calls work:
+
+```python
+web_search_plus(query="best DAC reviews", provider="serpbase")
+```
+
+It does not make SerpBase eligible for automatic routing or fallback until you opt in:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase on
+```
+
+Turn automatic use back off:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase off
+```
+
+This pattern avoids silent cost or coverage surprises. Use it for providers whose pricing, maturity, or result style you want to test before letting `provider="auto"` choose them.
+
+## Using `web_search_plus`
+
+Use `web_search_plus` when you need source discovery, current facts, prices, schedules, weather, sports, or provider diagnostics.
+
+Examples:
+
+```python
+web_search_plus(query="Graz weather today")
+web_search_plus(query="best bookshelf speakers under 1000 EUR", quality_report=True)
+web_search_plus(query="alternatives to Notion", provider="exa")
+web_search_plus(query="turntable reviews under 1000", mode="research", research_time_budget=45)
+```
+
+Important parameters:
+
+- `provider`: `auto`, or a concrete provider such as `brave`, `serper`, `serpbase`, `tavily`, `linkup`, `exa`, `perplexity`, `kilo-perplexity`, `you`, or `searxng`.
+- `count`: result count, from 1 to 20.
+- `time_range`: `day`, `week`, `month`, or `year` where supported.
+- `include_domains` / `exclude_domains`: provider-dependent domain filters.
+- `quality_report`: include routing diagnostics, skipped providers, result quality hints, and extraction recommendation.
+- `mode="research"`: query multiple providers and optionally extract selected URLs within a best-effort wall-clock budget.
+
+## Using `web_extract_plus`
+
+Use `web_extract_plus` when you already have URLs and want page content, not just search snippets.
+
+```python
+web_extract_plus(urls=["https://example.com"], provider="firecrawl")
+web_extract_plus(urls=["https://docs.linkup.so"], provider="linkup", render_js=False)
+```
+
+Auto extraction currently tries Firecrawl, Linkup, Exa, Tavily, and You.com when keys are available. Firecrawl is the robust default scraper; Linkup is the cheap/citation-friendly fallback; Exa is tried before Tavily for research-style pages.
+
+## Using `web_answer_plus` beta
+
+`web_answer_plus` is an answer-synthesis layer. Use it only when the user explicitly asks for a written answer, summary, or cited brief.
+
+Good fits:
+
+- “Summarize these sources.”
+- “Give me a cited brief.”
+- “Compare the positions from a few articles.”
+
+Bad fits:
+
+- weather, prices, sports lineups, schedules, scores, or standings
+- raw source discovery
+- anything latency-sensitive where result lists matter more than prose
+
+Examples:
+
+```python
+web_answer_plus(query="Summarize what changed in Hermes Agent this week", output="brief")
+web_answer_plus(query="Compare DAC amps under 500 EUR in Austria", mode="deep", sources=6, country="AT")
+web_answer_plus(query="OpenAI latest model announcements", freshness="week", output="brief")
+```
+
+Defaults are conservative:
+
+- `quick` uses 3 sources and extracts up to 2 URLs.
+- `deep` uses 6 sources and research mode, with extraction capped at 5 URLs.
+- `freshness="none"` avoids over-triggering recency. Set `freshness="auto"`, `day`, `week`, `month`, or `year` explicitly when recency matters.
+
+## Reliability and cost controls
+
+The plugin is designed to fail visibly rather than invent confidence.
+
+- Search result cache TTL is 1 hour by default.
+- Cache files and provider health state live under `WSP_CACHE_DIR`, or the plugin cache directory if unset.
+- Use `--no-cache` in CLI tests when you need a fresh provider call.
+- Transient provider errors are retried with short backoff.
+- Repeated provider failures put that provider on cooldown, stepping from 1 minute to 5 minutes to 25 minutes to 1 hour.
+- Research mode checks `research_time_budget` between provider calls and extraction steps; it is best-effort, not a provider-side billing limit.
+- `web_answer_plus` caps extraction count with `max_extracts`, hard-capped at 5.
+- Missing extraction keys, empty results, quota failures, and budget exhaustion are returned as warnings or metadata where possible.
+
+The plugin cannot normalize or guarantee provider pricing. Provider APIs own their own billing, rate limits, index freshness, and terms.
+
+## Updating
+
+Update the plugin with Hermes’ plugin workflow or by pulling the installed clone, then restart/reset Hermes:
+
+```bash
+cd ~/.hermes/plugins/web-search-plus
+git pull
+python3 -m pytest -q
+python3 -m compileall -q __init__.py search.py setup.py scripts tests
+```
+
+Check [CHANGELOG.md](../CHANGELOG.md) before upgrading across feature releases.
+
+## More help
+
+- [FAQ](FAQ.md) for common setup and routing problems.
+- [Architecture](ARCHITECTURE.md) for routing, trust boundaries, caching, and provider extension notes.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -5,6 +5,7 @@ author: robbyczgw-cla
 requires_env: []
 optional_env:
   - SERPER_API_KEY
+  - SERPBASE_API_KEY
   - BRAVE_API_KEY
   - TAVILY_API_KEY
   - EXA_API_KEY
@@ -31,6 +32,7 @@ onboarding:
     priority: "python ~/.hermes/plugins/web-search-plus/setup.py config set-priority tavily,linkup,brave,serper"
     fallback: "python ~/.hermes/plugins/web-search-plus/setup.py config set-fallback tavily"
     disable_provider: "python ~/.hermes/plugins/web-search-plus/setup.py config disable perplexity"
+    block_auto_provider: "python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase off"
     reset: "python ~/.hermes/plugins/web-search-plus/setup.py config reset --yes"
   config_file: "~/.hermes/plugins/config.json"
   env_override: "WEB_SEARCH_PLUS_CONFIG"

--- a/search.py
+++ b/search.py
@@ -15,7 +15,7 @@ Smart Routing uses multi-signal analysis:
 
 Usage:
     python3 search.py --query "..."                    # Auto-route based on query
-    python3 search.py --provider [serper|brave|tavily|linkup|querit|exa|firecrawl|perplexity|kilo-perplexity|you|searxng|auto] --query "..." [options]
+    python3 search.py --provider [serper|serpbase|brave|tavily|linkup|querit|exa|firecrawl|perplexity|kilo-perplexity|you|searxng|auto] --query "..." [options]
 
 Examples:
     python3 search.py -q "iPhone 16 Pro price"              # → Serper (shopping intent)
@@ -38,7 +38,7 @@ from pathlib import Path
 from typing import Optional, List, Dict, Any, Tuple
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote, urlencode, urlparse
+from urllib.parse import quote, urlencode, urlparse, parse_qsl, urlunparse
 
 
 # =============================================================================
@@ -289,8 +289,11 @@ DEFAULT_CONFIG = {
     "auto_routing": {
         "enabled": True,
         "fallback_provider": "serper",
-        "provider_priority": ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng"],
+        # Low-trust / experimental providers can stay configured for explicit use
+        # without being selected automatically.
+        "provider_priority": ["tavily", "linkup", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"],
         "disabled_providers": [],
+        "auto_allow": {"serpbase": False, "querit": False},
         "confidence_threshold": 0.3,  # Below this, note low confidence
     },
     "serper": {
@@ -342,6 +345,13 @@ DEFAULT_CONFIG = {
         "country": "us",
         "safesearch": "moderate"
     },
+    "serpbase": {
+        "api_url": "https://api.serpbase.dev/google/search",
+        "country": "us",
+        "language": "en",
+        "page": 1,
+        "timeout": 30,
+    },
     "searxng": {
         "instance_url": None,  # Required - user must set their own instance
         "safesearch": 0,  # 0=off, 1=moderate, 2=strict
@@ -355,7 +365,7 @@ def _deepcopy_default_config() -> Dict[str, Any]:
     return json.loads(json.dumps(DEFAULT_CONFIG))
 
 
-_ROUTING_PROVIDER_NAMES = {"tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng"}
+_ROUTING_PROVIDER_NAMES = {"tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "serpbase", "you", "searxng"}
 
 
 def _normalize_routing_provider_config(provider: str) -> str:
@@ -405,6 +415,17 @@ def _validate_runtime_config(config: Dict[str, Any]) -> Dict[str, Any]:
             auto["disabled_providers"] = _normalize_routing_provider_list_config(disabled)
         else:
             auto["disabled_providers"] = []
+    if "auto_allow" in auto:
+        raw_allow = auto.get("auto_allow") or {}
+        if not isinstance(raw_allow, dict):
+            raise ValueError("auto_allow must be an object mapping provider names to booleans")
+        normalized_allow = {}
+        for raw_provider, allowed in raw_allow.items():
+            provider = _normalize_routing_provider_config(str(raw_provider))
+            normalized_allow[provider] = bool(allowed)
+        auto["auto_allow"] = normalized_allow
+    else:
+        auto["auto_allow"] = dict(DEFAULT_CONFIG["auto_routing"].get("auto_allow", {}))
     if "confidence_threshold" in auto:
         threshold = float(auto["confidence_threshold"])
         if threshold < 0.0 or threshold > 1.0:
@@ -489,6 +510,7 @@ def get_api_key(provider: str, config: Dict[str, Any] = None) -> Optional[str]:
         return os.environ.get("KILOCODE_API_KEY")
     key_map = {
         "serper": "SERPER_API_KEY",
+        "serpbase": "SERPBASE_API_KEY",
         "brave": "BRAVE_API_KEY",
         "tavily": "TAVILY_API_KEY",
         "querit": "QUERIT_API_KEY",
@@ -610,6 +632,7 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
     if not key:
         env_var = {
             "serper": "SERPER_API_KEY",
+            "serpbase": "SERPBASE_API_KEY",
             "brave": "BRAVE_API_KEY",
             "tavily": "TAVILY_API_KEY",
             "querit": "QUERIT_API_KEY",
@@ -623,6 +646,7 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
         
         urls = {
             "serper": "https://serper.dev",
+            "serpbase": "https://www.serpbase.dev",
             "brave": "https://brave.com/search/api/",
             "tavily": "https://tavily.com",
             "querit": "https://querit.ai",
@@ -1333,6 +1357,7 @@ class QueryAnalyzer:
         # Map intents to providers with final scores
         provider_scores = {
             "serper": shopping_score + local_news_score + (recency_score * 0.35),
+            "serpbase": (shopping_score * 0.8) + (local_news_score * 0.8) + (recency_score * 0.25),
             "brave": shopping_score + local_news_score + (recency_score * 0.35),
             "tavily": research_score + (complexity["complexity_score"] if not complexity["is_complex"] else 0) + (0.2 * recency_score),
             "querit": (research_score * 0.65) + (rag_score * 0.35) + (recency_score * 0.45),
@@ -1348,6 +1373,7 @@ class QueryAnalyzer:
         # Build match details per provider
         provider_matches = {
             "serper": shopping_matches + local_news_matches,
+            "serpbase": shopping_matches + local_news_matches,
             "brave": shopping_matches + local_news_matches,
             "tavily": research_matches,
             "querit": research_matches,
@@ -1382,9 +1408,15 @@ class QueryAnalyzer:
         
         # Filter to available providers
         disabled = set(self.auto_config.get("disabled_providers", []))
+        # Filter to configured providers that are eligible for automatic routing.
+        # Providers with auto_allow=false remain available for explicit calls.
+        auto_excluded = [
+            p for p in scores
+            if get_api_key(p, self.config) and p not in disabled and not _provider_auto_allowed(p, self.auto_config)
+        ]
         available = {
             p: s for p, s in scores.items()
-            if p not in disabled and get_api_key(p, self.config)
+            if p not in disabled and _provider_auto_allowed(p, self.auto_config) and get_api_key(p, self.config)
         }
         
         if not available:
@@ -1398,13 +1430,14 @@ class QueryAnalyzer:
                 "scores": scores,
                 "top_signals": [],
                 "analysis": analysis,
+                "auto_allow_excluded": auto_excluded,
             }
         
         # Find the winner
         max_score = max(available.values())
         
         # Handle ties using deterministic per-query distribution
-        priority = self.auto_config.get("provider_priority", ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng"])
+        priority = self.auto_config.get("provider_priority", ["tavily", "linkup", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"])
         winners = [p for p, s in available.items() if s == max_score]
         
         if len(winners) > 1:
@@ -1474,6 +1507,7 @@ class QueryAnalyzer:
                 for s in top_signals
             ],
             "below_threshold": confidence < threshold,
+            "auto_allow_excluded": auto_excluded,
             "analysis_summary": {
                 "query_length": len(query.split()),
                 "is_complex": analysis["complexity"]["is_complex"],
@@ -1530,11 +1564,13 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             "confidence_level": routing["confidence_level"],
             "reason": routing["reason"],
             "exa_depth": routing.get("exa_depth", "normal"),
+            "auto_allow_excluded": routing.get("auto_allow_excluded", []),
         },
         "scores": routing["scores"],
         "top_signals": routing["top_signals"],
         "intent_breakdown": {
             "shopping_signals": len(analysis["provider_matches"]["serper"]),
+            "serpbase_signals": len(analysis["provider_matches"].get("serpbase", [])),
             "brave_signals": len(analysis["provider_matches"]["brave"]),
             "research_signals": len(analysis["provider_matches"]["tavily"]),
             "querit_signals": len(analysis["provider_matches"]["querit"]),
@@ -1562,12 +1598,24 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             if matches
         },
         "available_providers": [
-            p for p in ["serper", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng"]
-            if get_api_key(p, config) and p not in config.get("auto_routing", {}).get("disabled_providers", [])
+            p for p in ["serper", "serpbase", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng"]
+            if get_api_key(p, config) and p not in config.get("auto_routing", {}).get("disabled_providers", []) and _provider_auto_allowed(p, config.get("auto_routing", {}))
         ]
     }
 
 
+
+
+def _provider_auto_allowed(provider: str, auto_config: Dict[str, Any]) -> bool:
+    """Return whether a configured provider may be selected by auto-routing/fallback.
+
+    Explicit provider calls still work; this gate only prevents low-trust or
+    experimental providers from receiving user queries automatically.
+    """
+    auto_allow = auto_config.get("auto_allow", {}) if isinstance(auto_config, dict) else {}
+    if not isinstance(auto_allow, dict):
+        return True
+    return bool(auto_allow.get(provider, True))
 
 
 class ProviderConfigError(Exception):
@@ -2119,6 +2167,101 @@ def search_serper(
         "answer": answer,
         "knowledge_graph": data.get("knowledgeGraph"),
         "related_searches": [r.get("query") for r in data.get("relatedSearches", [])]
+    }
+
+
+# =============================================================================
+# SerpBase (Google SERP API)
+# =============================================================================
+
+def _strip_tracking_params(url: str) -> str:
+    """Remove common SERP tracking params while preserving the canonical target URL."""
+    if not url:
+        return ""
+    parsed = urlparse(url)
+    tracking_prefixes = ("utm_",)
+    tracking_names = {"srsltid", "gclid", "fbclid", "mc_cid", "mc_eid"}
+    query = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key.lower() not in tracking_names and not key.lower().startswith(tracking_prefixes)
+    ]
+    return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+
+
+def _serpbase_related_search_query(item: Any) -> Optional[str]:
+    if isinstance(item, dict):
+        return item.get("query") or item.get("title")
+    if isinstance(item, str):
+        return item
+    return None
+
+
+def search_serpbase(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    country: str = "us",
+    language: str = "en",
+    page: int = 1,
+    api_url: str = "https://api.serpbase.dev/google/search",
+    timeout: int = 30,
+) -> dict:
+    """Search using SerpBase's Google Search endpoint.
+
+    SerpBase returns HTTP 200 for some business failures, so `status == 0` is
+    required before parsing results.
+    """
+    body = {
+        "q": query,
+        "hl": language,
+        "gl": country,
+        "page": page,
+    }
+    headers = {
+        "X-API-Key": api_key,
+        "Content-Type": "application/json",
+    }
+
+    data = make_request(api_url, headers, body, timeout=timeout)
+    status = data.get("status", 0)
+    if status != 0:
+        message = data.get("message") or data.get("error") or data.get("msg") or "business status failure"
+        transient = status in {1029, 1502, 1503, 1504}
+        raise ProviderRequestError(f"SerpBase error {status}: {message}", transient=transient)
+
+    results = []
+    for i, item in enumerate(data.get("organic", [])[:max_results]):
+        results.append({
+            "title": item.get("title", ""),
+            "url": _strip_tracking_params(item.get("link", "") or item.get("url", "")),
+            "snippet": item.get("snippet", ""),
+            "score": round(1.0 - i * 0.1, 2),
+            "rank": item.get("rank") or item.get("position") or i + 1,
+            "display_link": item.get("display_link") or item.get("displayed_link"),
+        })
+
+    related_searches = [
+        value for value in (_serpbase_related_search_query(item) for item in data.get("related_searches", [])) if value
+    ]
+    answer = ""
+    if data.get("answer_box"):
+        answer_box = data.get("answer_box") or {}
+        answer = answer_box.get("answer") or answer_box.get("snippet") or ""
+    elif data.get("knowledge_graph"):
+        kg = data.get("knowledge_graph") or {}
+        answer = kg.get("description") or kg.get("subtitle") or ""
+    elif results:
+        answer = results[0]["snippet"]
+
+    return {
+        "provider": "serpbase",
+        "query": query,
+        "results": results,
+        "answer": answer,
+        "knowledge_graph": data.get("knowledge_graph"),
+        "related_searches": related_searches,
+        "session_id": data.get("session_id"),
     }
 
 
@@ -3492,7 +3635,7 @@ Full docs: See README.md and SKILL.md
     # Common arguments
     parser.add_argument(
         "--provider", "-p", 
-        choices=["serper", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng", "auto"],
+        choices=["serper", "serpbase", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng", "auto"],
         help="Search provider (auto=intelligent routing)"
     )
     parser.add_argument(
@@ -3531,6 +3674,11 @@ Full docs: See README.md and SKILL.md
         "--auto", "-a",
         action="store_true",
         help="Use intelligent auto-routing (default when no provider specified)"
+    )
+    parser.add_argument(
+        "--allow-fallback",
+        action="store_true",
+        help="Allow explicit --provider calls to fall back to other configured providers on failure. Auto-routing already uses fallback."
     )
     parser.add_argument(
         "--explain-routing",
@@ -3803,6 +3951,7 @@ Full docs: See README.md and SKILL.md
                 "reason": routing["reason"],
                 "top_signals": routing["top_signals"],
                 "scores": routing["scores"],
+                "auto_allow_excluded": routing.get("auto_allow_excluded", []),
             }
         else:
             provider = "exa"
@@ -3819,23 +3968,27 @@ Full docs: See README.md and SKILL.md
     
     # Build provider fallback list
     auto_config = config.get("auto_routing", {})
-    provider_priority = auto_config.get("provider_priority", ["tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng"])
+    provider_priority = auto_config.get("provider_priority", ["tavily", "linkup", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"])
     disabled_providers = auto_config.get("disabled_providers", [])
 
     # Start with the selected provider, then try others in priority order.
+    # Explicit provider calls are strict by default: requested provider must be
+    # the actual provider. Use --allow-fallback to opt into legacy fallback.
     # Fixed-provider mode is intentionally strict: if auto-routing is disabled
     # and the saved default was selected via provider=auto, do not silently
     # fall back to other providers. Users who want fallback should keep
     # auto-routing enabled and tune priority/fallback instead.
+    explicit_provider_mode = args.provider not in (None, "auto")
     fixed_provider_mode = (
         auto_config.get("enabled", True) is False
         and provider == config.get("default_provider")
         and (args.provider == "auto" or (args.provider is None and not args.similar_url))
     )
+    strict_provider_mode = fixed_provider_mode or (explicit_provider_mode and not args.allow_fallback)
     providers_to_try = [provider] if provider else []
-    if not fixed_provider_mode:
+    if not strict_provider_mode:
         for p in provider_priority:
-            if p not in providers_to_try and p not in disabled_providers and get_api_key(p, config):
+            if p not in providers_to_try and p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config):
                 providers_to_try.append(p)
 
     # Skip providers currently in cooldown
@@ -3864,6 +4017,18 @@ Full docs: See README.md and SKILL.md
                 search_type=args.search_type,
                 time_range=args.time_range,
                 include_images=args.images,
+            )
+        elif prov == "serpbase":
+            serpbase_config = config.get("serpbase", {})
+            return search_serpbase(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                country=serpbase_config.get("country", args.country),
+                language=serpbase_config.get("language", args.language),
+                page=int(serpbase_config.get("page", 1)),
+                api_url=serpbase_config.get("api_url", "https://api.serpbase.dev/google/search"),
+                timeout=int(serpbase_config.get("timeout", 30)),
             )
         elif prov == "brave":
             brave_config = config.get("brave", {})
@@ -4019,14 +4184,14 @@ Full docs: See README.md and SKILL.md
     if args.mode == "research":
         available_research_providers = {
             p for p in providers_to_try
-            if p not in disabled_providers and get_api_key(p, config) and not provider_in_cooldown(p)[0]
+            if p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config) and not provider_in_cooldown(p)[0]
         }
         if provider and get_api_key(provider, config) and not provider_in_cooldown(provider)[0]:
             available_research_providers.add(provider)
         if args.research_providers:
             research_providers = [
                 p for p in args.research_providers
-                if p not in disabled_providers and get_api_key(p, config) and not provider_in_cooldown(p)[0]
+                if p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config) and not provider_in_cooldown(p)[0]
             ]
         else:
             research_providers = select_research_providers(

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -55,6 +55,17 @@ def test_provider_catalog_has_recommended_starter_metadata():
     assert "search" in by_provider["brave"]["capabilities"]
 
 
+def test_serpbase_catalog_distinguishes_wsp_and_upstream_capabilities():
+    catalog = wsp._get_provider_catalog()
+    by_provider = {item["provider"]: item for item in catalog}
+    serpbase = by_provider["serpbase"]
+
+    assert serpbase["capabilities"] == ["search"]
+    assert "news" not in serpbase["capabilities"]
+    assert "maps_search" in serpbase["upstream_capabilities"]
+    assert "WSP exposes search only" in serpbase["description"]
+
+
 def test_provider_status_detects_capability_tiers_without_requiring_all(monkeypatch):
     env = {"TAVILY_API_KEY": "tvly-test", "LINKUP_API_KEY": ""}
 

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -214,7 +214,7 @@ def test_setup_dry_run_uses_target_env_path_for_dashboard(tmp_path, monkeypatch,
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "Providers: 1/11 configured" in out
+    assert "Providers: 1/12 configured" in out
     assert "Active: Tavily" in out
     assert "Brave Search" not in out.split("Setup plan:", 1)[0]
 
@@ -230,7 +230,7 @@ def test_status_uses_target_env_path_for_dashboard(tmp_path, monkeypatch, capsys
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "Providers: 1/11 configured" in out
+    assert "Providers: 1/12 configured" in out
     assert "Active: Linkup" in out
     assert "Brave Search" not in out
 
@@ -332,6 +332,46 @@ def test_config_disable_and_enable_provider_updates_disabled_list(tmp_path):
 
     data = json.loads(config_path.read_text())
     assert "brave" not in data["auto_routing"]["disabled_providers"]
+
+
+def test_config_set_auto_allow_updates_provider_gate(tmp_path):
+    config_path = tmp_path / "config.json"
+    parser = wsp.argparse.ArgumentParser()
+    wsp._web_search_plus_cli_setup(parser)
+    deny = parser.parse_args(["config", "set-auto-allow", "serpbase", "off", "--config-path", str(config_path)])
+    deny.func(deny)
+    allow = parser.parse_args(["config", "set-auto-allow", "serpbase", "on", "--config-path", str(config_path)])
+    allow.func(allow)
+
+    data = json.loads(config_path.read_text())
+    assert data["auto_routing"]["auto_allow"]["serpbase"] is True
+    assert data["auto_routing"]["auto_allow"]["querit"] is False
+
+
+def test_default_behavior_config_blocks_low_trust_auto_providers():
+    config = wsp._default_behavior_config()
+
+    assert config["auto_routing"]["provider_priority"][-2:] == ["serpbase", "querit"]
+    assert config["auto_routing"]["auto_allow"]["serpbase"] is False
+    assert config["auto_routing"]["auto_allow"]["querit"] is False
+
+
+def test_setup_dry_run_can_auto_deny_provider(tmp_path, capsys):
+    env_path = tmp_path / ".env"
+    config_path = tmp_path / "config.json"
+    parser = wsp.argparse.ArgumentParser()
+    wsp._web_search_plus_cli_setup(parser)
+    args = parser.parse_args([
+        "setup", "--preset", "starter", "--dry-run", "--env-path", str(env_path), "--config-path", str(config_path),
+        "--auto-deny", "serpbase,querit"
+    ])
+
+    args.func(args)
+
+    out = capsys.readouterr().out
+    assert "auto-allow false: querit, serpbase" in out
+    assert not env_path.exists()
+    assert not config_path.exists()
 
 
 def test_config_rejects_unknown_provider_without_writing(tmp_path):

--- a/tests/test_serpbase_provider.py
+++ b/tests/test_serpbase_provider.py
@@ -1,0 +1,146 @@
+import importlib.util
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+SEARCH_PATH = Path(__file__).resolve().parents[1] / "search.py"
+search_spec = importlib.util.spec_from_file_location("wsp_search_serpbase_under_test", SEARCH_PATH)
+search = importlib.util.module_from_spec(search_spec)
+assert search_spec.loader is not None
+search_spec.loader.exec_module(search)
+
+QueryAnalyzer = search.QueryAnalyzer
+get_api_key = search.get_api_key
+validate_api_key = search.validate_api_key
+
+
+class SerpBaseProviderTests(unittest.TestCase):
+    def test_get_api_key_reads_serpbase_env(self):
+        with mock.patch.dict(os.environ, {"SERPBASE_API_KEY": "serpbase-test-key"}, clear=False):
+            self.assertEqual(get_api_key("serpbase", {}), "serpbase-test-key")
+
+    def test_validate_api_key_accepts_serpbase(self):
+        with mock.patch.dict(os.environ, {"SERPBASE_API_KEY": "serpbase-test-key-12345"}, clear=False):
+            self.assertEqual(validate_api_key("serpbase", {}), "serpbase-test-key-12345")
+
+    def test_search_serpbase_parses_organic_results_and_checks_business_status(self):
+        fake_response = {
+            "status": 0,
+            "session_id": "sess_123",
+            "organic": [
+                {
+                    "title": "Example result",
+                    "link": "https://example.com/page?srsltid=tracking&utm_source=x",
+                    "snippet": "Example snippet",
+                    "rank": 1,
+                    "display_link": "example.com",
+                }
+            ],
+            "related_searches": [{"query": "related one"}, "related two"],
+            "knowledge_graph": {"title": "Example KG"},
+        }
+        with mock.patch.object(search, "make_request", return_value=fake_response) as mock_request:
+            result = search.search_serpbase(
+                query="example query",
+                api_key="serpbase-test-key-12345",
+                max_results=5,
+                country="at",
+                language="de",
+            )
+
+        self.assertEqual(result["provider"], "serpbase")
+        self.assertEqual(result["session_id"], "sess_123")
+        self.assertEqual(result["results"][0]["title"], "Example result")
+        self.assertEqual(result["results"][0]["url"], "https://example.com/page")
+        self.assertEqual(result["results"][0]["snippet"], "Example snippet")
+        self.assertEqual(result["related_searches"], ["related one", "related two"])
+
+        url, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(url, "https://api.serpbase.dev/google/search")
+        self.assertEqual(headers["X-API-Key"], "serpbase-test-key-12345")
+        self.assertEqual(body["q"], "example query")
+        self.assertEqual(body["hl"], "de")
+        self.assertEqual(body["gl"], "at")
+        self.assertEqual(body["page"], 1)
+
+    def test_search_serpbase_raises_on_business_error(self):
+        with mock.patch.object(search, "make_request", return_value={"status": 1020, "message": "insufficient credits"}):
+            with self.assertRaises(search.ProviderRequestError) as ctx:
+                search.search_serpbase("query", "serpbase-test-key-12345")
+        self.assertIn("SerpBase error 1020", str(ctx.exception))
+
+    def test_auto_router_excludes_serpbase_and_querit_when_auto_allow_false(self):
+        config = search._deepcopy_default_config()
+        config["auto_routing"]["provider_priority"] = ["serpbase", "querit", "serper"]
+        config["auto_routing"]["auto_allow"] = {"serpbase": False, "querit": False}
+        analyzer = QueryAnalyzer(config)
+        env = {
+            "SERPBASE_API_KEY": "serpbase-test-key-12345",
+            "QUERIT_API_KEY": "querit-test-key-12345",
+            "SERPER_API_KEY": "serper-test-key-12345",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            routing = analyzer.route("latest iphone price today")
+
+        self.assertEqual(routing["provider"], "serper")
+        self.assertNotIn("serpbase", routing["scores"])
+        self.assertNotIn("querit", routing["scores"])
+        self.assertIn("serpbase", routing["auto_allow_excluded"])
+        self.assertIn("querit", routing["auto_allow_excluded"])
+
+    def test_explicit_serpbase_key_still_works_when_auto_allow_false(self):
+        config = search._deepcopy_default_config()
+        config["auto_routing"]["auto_allow"] = {"serpbase": False}
+        with mock.patch.dict(os.environ, {"SERPBASE_API_KEY": "serpbase-test-key-12345"}, clear=False):
+            self.assertEqual(validate_api_key("serpbase", config), "serpbase-test-key-12345")
+
+
+    def test_explain_routing_reports_auto_allow_exclusions(self):
+        config = {
+            "auto_routing": {
+                "provider_priority": ["serpbase", "querit", "serper"],
+                "disabled_providers": [],
+                "auto_allow": {"serpbase": False, "querit": False},
+                "confidence_threshold": 0.3,
+            }
+        }
+        with mock.patch.object(search, "get_api_key", return_value="dummy-key"):
+            explanation = search.explain_routing("best price sony wh-1000xm6 Austria", config)
+        excluded = explanation["routing_decision"]["auto_allow_excluded"]
+        self.assertIn("serpbase", excluded)
+        self.assertIn("querit", excluded)
+        self.assertIn("serpbase_signals", explanation["intent_breakdown"])
+
+    def test_explicit_serpbase_missing_key_hard_fails_without_fallback(self):
+        env = os.environ.copy()
+        env.pop("SERPBASE_API_KEY", None)
+        env["SERPER_API_KEY"] = "serper-test-key-present-but-must-not-be-used"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SEARCH_PATH),
+                "--provider",
+                "serpbase",
+                "--query",
+                "Graz weather today",
+                "--max-results",
+                "1",
+                "--no-cache",
+            ],
+            cwd=str(SEARCH_PATH.parent),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=20,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("Missing API key for serpbase", proc.stderr)
+        self.assertNotIn('"trying_next"', proc.stderr)
+        self.assertNotIn('"provider": "serper"', proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add SerpBase as an explicit search provider using `SERPBASE_API_KEY`
- Keep SerpBase out of automatic routing/fallback by default via `auto_allow=false`
- Document activation, `set-auto-allow`, README provider/API-key coverage, and changelog notes
- Preserve native `perplexity` and `kilo-perplexity` as distinct providers after rebasing on `main`

## Verification
- `python3 -m pytest -q` → 128 passed
- `python3 -m compileall -q __init__.py search.py setup.py scripts tests`
- `git diff --check`
- `python3 setup.py config set-auto-allow serpbase on --dry-run --config-path /tmp/wsp-serpbase-doc-test.json`
- Live SerpBase smoke tested before final docs commit; auto-routing correctly reports SerpBase under `auto_allow_excluded`

## Notes
SerpBase is intentionally explicit/fallback-only by default. Users can call it with `provider="serpbase"`; automatic selection requires `setup.py config set-auto-allow serpbase on`.
