### PR TITLE
Release v2.0.0 with Routing v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,20 @@
 # Changelog
 
-## [Unreleased]
+## [v2.0.0] — 2026-05-15
 
-### 🔧 Changed
-- Docs now list SerpBase and Querit last in general provider lists because both default to `auto_allow=false`.
-- Auto-routing now uses the vNext-lite provider policy from the 25-query qualitative benchmark: You.com, Serper, Exa, Firecrawl, Tavily, and Linkup form the default search pool, while Brave, SerpBase, Querit, native Perplexity, and Kilo Perplexity default to explicit/guarded use.
-- Added class-aware routing boosts for multilingual current queries, AT/local shopping, GitHub/docs, package/API docs, arXiv/academic queries, Reddit/community searches, CVE/security advisories, official/regulatory queries, finance/IR, weather/local factual lookups, and answer/synthesis prompts.
+### 🚀 Major: Routing v2
+- Replaced naive provider-priority auto-routing with benchmarked, class-aware Routing v2 based on the 25-query provider matrix plus Hermi/Andy qualitative review.
+- You.com, Serper, Exa, Firecrawl, Tavily, and Linkup now form the conservative default search pool.
+- Brave, SerpBase, Querit, native Perplexity, and Kilo Perplexity default to explicit/guarded use via `auto_allow=false`; existing configs inherit these guarded defaults unless users explicitly opt providers back in.
+- Added class-aware routing boosts for multilingual current queries, AT/local shopping, GitHub/docs, package/API docs, arXiv/academic queries, Reddit/community searches, CVE/security advisories, official/regulatory queries, finance/IR, weather/local factual lookups, OSS discovery, and answer/synthesis prompts.
 - Search auto-routing now flags answer/synthesis prompts with `answer_mode_recommended` instead of selecting slow answer-only providers such as Kilo Perplexity.
+- Routing diagnostics now expose `language_hint`, `routing_class`, and `routing_policy`.
+
+### 📚 Docs
+- Updated README, User Guide, FAQ, and Architecture docs for Routing v2 defaults, guarded providers, setup presets, and migration behavior.
 
 ### 🧪 Tests
-- Added routing-vNext-lite regression coverage for default auto-allow gates, multilingual Japanese/Arabic routing to You.com, arXiv routing to Exa, Reddit/site queries away from Exa, CVE/security routing away from Firecrawl, and answer-mode recommendations.
+- Added Routing v2 regression coverage for default auto-allow gates, legacy auto-allow migration, multilingual Japanese/Arabic routing to You.com, arXiv routing to Exa, Reddit/site queries away from Exa, Reddit-company finance queries, CVE/security routing away from Firecrawl, answer-mode recommendations, and sports-table false positives.
 
 ## [v1.10.0] — 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### 🔧 Changed
 - Docs now list SerpBase and Querit last in general provider lists because both default to `auto_allow=false`.
+- Auto-routing now uses the vNext-lite provider policy from the 25-query qualitative benchmark: You.com, Serper, Exa, Firecrawl, Tavily, and Linkup form the default search pool, while Brave, SerpBase, Querit, native Perplexity, and Kilo Perplexity default to explicit/guarded use.
+- Added class-aware routing boosts for multilingual current queries, AT/local shopping, GitHub/docs, package/API docs, arXiv/academic queries, Reddit/community searches, CVE/security advisories, official/regulatory queries, finance/IR, weather/local factual lookups, and answer/synthesis prompts.
+- Search auto-routing now flags answer/synthesis prompts with `answer_mode_recommended` instead of selecting slow answer-only providers such as Kilo Perplexity.
+
+### 🧪 Tests
+- Added routing-vNext-lite regression coverage for default auto-allow gates, multilingual Japanese/Arabic routing to You.com, arXiv routing to Exa, Reddit/site queries away from Exa, CVE/security routing away from Firecrawl, and answer-mode recommendations.
 
 ## [v1.10.0] — 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [v2.0.0] — 2026-05-15
 
 ### 🚀 Major: Routing v2
-- Replaced naive provider-priority auto-routing with benchmarked, class-aware Routing v2 based on the 25-query provider matrix plus Hermi/Andy qualitative review.
+- Replaced naive provider-priority auto-routing with benchmarked, class-aware Routing v2 based on the 25-query provider matrix and qualitative provider review.
 - You.com, Serper, Exa, Firecrawl, Tavily, and Linkup now form the conservative default search pool.
 - Brave, SerpBase, Querit, native Perplexity, and Kilo Perplexity default to explicit/guarded use via `auto_allow=false`; existing configs inherit these guarded defaults unless users explicitly opt providers back in.
 - Added class-aware routing boosts for multilingual current queries, AT/local shopping, GitHub/docs, package/API docs, arXiv/academic queries, Reddit/community searches, CVE/security advisories, official/regulatory queries, finance/IR, weather/local factual lookups, OSS discovery, and answer/synthesis prompts.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <img alt="Hermes Plugin" src="https://img.shields.io/badge/Hermes-plugin-a78bfa.svg">
 </p>
 
-**Web search, extraction, and optional cited answers for Hermes — bring any one of 12 provider options and the plugin unlocks the tools your keys can actually support.** `web_extract_plus(provider="auto")` defaults to Firecrawl-first extraction for robust scraping; Linkup remains the cheap/citation-friendly answer-extraction path when available.
+**Web search, extraction, and optional cited answers for Hermes — now with Routing v2: benchmarked, class-aware auto-routing across the providers your keys can actually support.** `web_extract_plus(provider="auto")` defaults to Firecrawl-first extraction for robust scraping; Linkup remains the cheap/citation-friendly answer-extraction path when available.
 
 `web-search-plus` adds three Hermes tools:
 
@@ -34,7 +34,7 @@ Most web-search tools fail in one of two boring ways: they hard-code a single pr
 
 - **No global required key.** Configure one search-capable provider and search/answers work.
 - **Extraction is additive.** Add Linkup, Firecrawl, Tavily, Exa, or You.com for fuller cited answers and URL extraction.
-- **Fallbacks are explicit.** Provider failures go on cooldown; missing extraction keys produce snippet-backed answers with warnings instead of fake confidence.
+- **Routing v2 is conservative.** You.com, Serper, Exa, Firecrawl, Tavily, and Linkup form the default search pool; Brave, SerpBase, Querit, and Perplexity/Kilo stay explicit/guarded unless opted in.
 - **Costs stay bounded.** Research and answer modes cap provider work and keep partial results when extraction fails.
 
 ---
@@ -52,9 +52,9 @@ python ~/.hermes/plugins/web-search-plus/setup.py setup
 # Bare setup prompts every supported provider; press Enter to skip what you do not have.
 # Fast starter preset if you want the short path:
 # python ~/.hermes/plugins/web-search-plus/setup.py setup --preset starter
-# TAVILY_API_KEY=...   # search/research
+# YOU_API_KEY=...      # fast Routing v2 core provider
+# SERPER_API_KEY=...   # reliable Google-like fallback
 # LINKUP_API_KEY=...   # extraction + fuller cited answers
-# BRAVE_API_KEY=...    # broad independent web search
 
 # 3) Restart/reload Hermes so plugin tools are registered
 # CLI: exit and start `hermes` again, or use /reset in-session
@@ -90,15 +90,15 @@ python ~/.hermes/plugins/web-search-plus/setup.py status
 python ~/.hermes/plugins/web-search-plus/setup.py list
 python ~/.hermes/plugins/web-search-plus/setup.py setup
 python ~/.hermes/plugins/web-search-plus/setup.py setup --preset starter --open
-python ~/.hermes/plugins/web-search-plus/setup.py setup brave linkup --env-path ~/.hermes/.env
+python ~/.hermes/plugins/web-search-plus/setup.py setup you linkup --env-path ~/.hermes/.env
 ```
 
 Presets:
 
 - default / `all` — prompt every supported provider; Enter skips missing keys.
-- `starter` — Tavily + Linkup + Brave; best first-run setup.
-- `lean` — Tavily + Linkup; cheapest useful search + extraction pairing.
-- `search` — Tavily + Brave + Serper; broad search coverage.
+- `starter` — You.com + Serper + Linkup; best Routing v2 first-run setup.
+- `lean` — You.com + Linkup; small fast search + extraction pairing.
+- `search` — You.com + Serper + Exa + Firecrawl + Tavily + Linkup; full default Routing v2 pool.
 - `extract` — Firecrawl + Linkup + Exa + Tavily; extraction-heavy setup.
 - `all` — prompt for every supported provider.
 
@@ -114,14 +114,14 @@ python ~/.hermes/plugins/web-search-plus/setup.py status --json
 python ~/.hermes/plugins/web-search-plus/setup.py config show --json
 
 # Prefer one fixed provider instead of auto-routing
-python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default you
 
 # Turn auto-routing back on
 python ~/.hermes/plugins/web-search-plus/setup.py config set-routing on
 
 # Tune auto-routing order and fallback
-python ~/.hermes/plugins/web-search-plus/setup.py config set-priority tavily,linkup,brave,serper
-python ~/.hermes/plugins/web-search-plus/setup.py config set-fallback tavily
+python ~/.hermes/plugins/web-search-plus/setup.py config set-priority you,serper,exa,firecrawl,tavily,linkup
+python ~/.hermes/plugins/web-search-plus/setup.py config set-fallback serper
 python ~/.hermes/plugins/web-search-plus/setup.py config disable perplexity
 python ~/.hermes/plugins/web-search-plus/setup.py config enable perplexity
 python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase off
@@ -129,7 +129,7 @@ python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase
 python ~/.hermes/plugins/web-search-plus/setup.py config set-threshold 0.45
 
 # Preview changes without touching disk
-python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave --dry-run
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default you --dry-run
 ```
 
 Notes:
@@ -137,7 +137,7 @@ Notes:
 - `set-default <provider>` disables auto-routing and makes `--provider auto` resolve to that provider.
 - `set-routing on` restores query-based routing while keeping the saved default for later.
 - `set-priority` accepts comma-separated provider names, normalizes case/whitespace, and ignores duplicates with a warning.
-- `set-auto-allow <provider> off` keeps a configured provider available for explicit calls while preventing auto-routing/fallback from selecting it. SerpBase and Querit default to `off` here.
+- `set-auto-allow <provider> off` keeps a configured provider available for explicit calls while preventing auto-routing/fallback from selecting it. Brave, SerpBase, Querit, Perplexity, and Kilo Perplexity default to `off` here.
 - `setup.py --config-path /path/to/config.json` points the helper at a custom config; `WEB_SEARCH_PLUS_CONFIG=/path/to/config.json` points `search.py` at the same file.
 - `config reset --yes` backs up the existing file before writing fresh defaults.
 
@@ -149,12 +149,12 @@ Notes:
 |---|---|---|
 | Search | `web_search_plus`, snippet-backed `web_answer_plus` | Brave, Serper, Tavily, Exa, Linkup, Firecrawl, Perplexity, Kilo Perplexity, You.com, SearXNG, SerpBase, or Querit |
 | Extraction | `web_extract_plus`, fuller `web_answer_plus` citations | Linkup, Firecrawl, Tavily, Exa, or You.com |
-| Best starter | Search + extraction + broad fallback | Tavily + Linkup + optional Brave |
+| Best starter | Search + extraction + reliable fallback | You.com + Serper + Linkup |
 
 `setup.py status --plain` reports this directly:
 
 ```text
-web-search-plus is configured. Providers: Linkup, Brave Search
+web-search-plus is configured. Providers: You.com, Serper, Linkup
 Capabilities: search=yes, extraction=yes, answer=yes
 ```
 
@@ -228,8 +228,8 @@ Use this when the agent needs search results and routing metadata.
 web_search_plus(query="Graz weather today")
 # → auto-routed current-info search
 
-web_search_plus(query="Singapore CPI latest", provider="brave")
-# → force Brave Search
+web_search_plus(query="Singapore CPI latest", provider="you")
+# → force You.com search
 
 web_search_plus(query="alternatives to Notion", provider="exa")
 # → semantic discovery
@@ -287,20 +287,20 @@ Parameters:
 
 | Provider | Search | Extract | Best for |
 |---|---:|---:|---|
-| Brave | ✅ | — | General-purpose independent web index |
-| Serper | ✅ | — | Google-like SERP, news, shopping, local facts |
+| You.com | ✅ | ✅ | Fast Routing v2 core for current, multilingual, LLM-ready search |
+| Serper | ✅ | — | Reliable Google-like fallback for facts, shopping, local, and news |
+| Exa | ✅ | ✅ | Semantic discovery, docs, GitHub, academic/arXiv |
+| Firecrawl | ✅ | ✅ | Source-first web search with scrape-ready result content |
 | Tavily | ✅ | ✅ | Long-form research and content-heavy queries |
-| Exa | ✅ | ✅ | Semantic discovery and similarity search |
 | Linkup | ✅ | ✅ | Source-backed grounding, citations, RAG-ready retrieval |
-| Firecrawl | ✅ | ✅ | Web search with scrape-ready result content |
-| Perplexity | ✅ | — | Native Perplexity direct answer-style search |
-| Kilo Perplexity | ✅ | — | Perplexity through Kilo gateway (`kilo-perplexity`) |
-| You.com | ✅ | ✅ | LLM-ready real-time snippets and content |
+| Perplexity | ✅ | — | Native direct-answer style search; explicit/answer-mode guarded by default (`auto_allow=false`) |
+| Kilo Perplexity | ✅ | — | Perplexity through Kilo gateway; explicit/answer-mode guarded by default (`auto_allow=false`) |
+| Brave | ✅ | — | Independent web index; explicit/guarded by default (`auto_allow=false`) |
 | SearXNG | ✅ | — | Privacy-focused self-hosted metasearch |
 | SerpBase | ✅ | — | Cheap Google-like SERP fallback; explicit/fallback-only by default (`auto_allow=false`) |
 | Querit | ✅ | — | Multilingual and real-time queries; explicit/fallback-only by default (`auto_allow=false`) |
 
-Auto-routing is rule-based on query signals such as recency, product intent, research language, and semantic-discovery patterns. Brave and Serper share generic web-search intents; when they tie, deterministic per-query tie-breaking keeps the same query reproducible while distributing ties across both providers. SerpBase and Querit are intentionally listed last because both default to `auto_allow=false`: configure their keys to call them explicitly, or opt them into automatic routing with `setup.py config set-auto-allow <provider> on`.
+Routing v2 is benchmarked and class-aware. It detects language/script hints and query classes such as multilingual current news, AT shopping/local, docs/API, GitHub, academic/arXiv, Reddit/community, CVE/security, official/regulatory, finance/IR, weather/local, OSS discovery, and answer/synthesis. You.com, Serper, Exa, Firecrawl, Tavily, and Linkup are the conservative default auto-search pool. Brave, SerpBase, Querit, Perplexity, and Kilo Perplexity default to `auto_allow=false`: configure their keys to call them explicitly, or opt them into automatic routing with `setup.py config set-auto-allow <provider> on`.
 
 ---
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v1.9.3
+web-search-plus — Hermes Plugin v2.0.0
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "1.10.0"
+__version__ = "2.0.0"
 
 import argparse
 import getpass
@@ -56,7 +56,7 @@ _PROVIDER_CATALOG = [
         "provider": "tavily",
         "env": "TAVILY_API_KEY",
         "display_name": "Tavily",
-        "description": "Recommended starter for research/news-style search.",
+        "description": "Research/tutorial provider in the Routing v2 default pool.",
         "free_tier": "1,000 free searches/month",
         "signup_url": "https://tavily.com",
         "capabilities": ["search", "extract", "research"],
@@ -76,11 +76,11 @@ _PROVIDER_CATALOG = [
         "provider": "brave",
         "env": "BRAVE_API_KEY",
         "display_name": "Brave Search",
-        "description": "Independent general web index; useful for fresh and local web results.",
+        "description": "Independent general web index; explicit/guarded by default after Routing v2 reliability testing.",
         "free_tier": "$5 free monthly credits",
         "signup_url": "https://api.search.brave.com/app/keys",
         "capabilities": ["search", "news", "local"],
-        "recommended": True,
+        "recommended": False,
     },
     {
         "provider": "exa",
@@ -157,11 +157,11 @@ _PROVIDER_CATALOG = [
         "provider": "you",
         "env": "YOU_API_KEY",
         "display_name": "You.com",
-        "description": "LLM-ready real-time snippets and extraction when available.",
+        "description": "Fast Routing v2 core provider for current, multilingual, and LLM-ready search.",
         "free_tier": "Limited/API key required",
         "signup_url": "https://api.you.com",
         "capabilities": ["search", "extract"],
-        "recommended": False,
+        "recommended": True,
     },
     {
         "provider": "searxng",
@@ -269,8 +269,8 @@ def _get_hermes_env_path() -> Path:
 
 
 _SETUP_PROVIDER_NAMES = {item["provider"] for item in _PROVIDER_CATALOG}
-_DEFAULT_PROVIDER_PRIORITY = ["tavily", "linkup", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"]
-_DEFAULT_AUTO_ALLOW = {"serpbase": False, "querit": False}
+_DEFAULT_PROVIDER_PRIORITY = ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"]
+_DEFAULT_AUTO_ALLOW = {"serpbase": False, "querit": False, "brave": False, "kilo-perplexity": False, "perplexity": False}
 _ROUTING_PROVIDER_NAMES = set(_DEFAULT_PROVIDER_PRIORITY)
 
 
@@ -558,7 +558,7 @@ def _render_status_dashboard(status: Optional[Dict[str, Any]] = None, *, color: 
     if status["search_configured"] and not status["extract_configured"]:
         lines.append("│ Tip: add Linkup for cleaner citations and web_extract_plus.")
     elif not status["search_configured"]:
-        lines.append("│ Starter: Tavily + Linkup + Brave is the best first setup.")
+        lines.append("│ Starter: You + Serper + Linkup is the best first setup.")
     lines.extend([
         "╰─ Next commands",
         "   python ~/.hermes/plugins/web-search-plus/setup.py setup",
@@ -591,11 +591,11 @@ def _providers_for_preset(preset: str) -> List[Dict[str, Any]]:
     """Return provider catalog entries for a named setup preset."""
     preset = preset.lower().strip()
     if preset == "starter":
-        names = {"tavily", "linkup", "brave"}
+        names = {"you", "serper", "linkup"}
     elif preset == "lean":
-        names = {"tavily", "linkup"}
+        names = {"you", "linkup"}
     elif preset == "search":
-        names = {"tavily", "brave", "serper"}
+        names = {"you", "serper", "exa", "firecrawl", "tavily", "linkup"}
     elif preset == "extract":
         names = {"linkup", "firecrawl", "tavily"}
     elif preset == "all":
@@ -663,8 +663,8 @@ def _unconfigured_session_hint(
 def _web_search_plus_cli_setup(parser: argparse.ArgumentParser) -> None:
     parser.description = "Configure web-search-plus provider keys with a tiny, secret-safe wizard."
     parser.epilog = (
-        "Default setup prompts every provider. Presets: starter=Tavily+Linkup+Brave, lean=Tavily+Linkup, "
-        "search=Tavily+Brave+Serper, extract=Linkup+Firecrawl+Tavily."
+        "Default setup prompts every provider. Presets: starter=You+Serper+Linkup, lean=You+Linkup, "
+        "search=You+Serper+Exa+Firecrawl+Tavily+Linkup, extract=Linkup+Firecrawl+Tavily."
     )
     subs = parser.add_subparsers(dest="web_search_plus_command")
     status = subs.add_parser("status", help="Show a setup dashboard without printing secrets")

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -84,7 +84,7 @@ High-level flow:
 
 1. Analyze query text for signals: current-info intent, product/local intent, research language, direct-answer intent, semantic-discovery intent, privacy intent, complexity, recency, language/script hints, and benchmark-derived query classes.
 2. Score known providers for those signals.
-3. Apply conservative vNext-lite boosts and penalties for classes such as multilingual current queries, AT/local shopping, GitHub/docs, package/API docs, arXiv/academic, Reddit/community, CVE/security, official/regulatory, finance/IR, weather/local factual, and answer/synthesis.
+3. Apply conservative Routing v2 boosts and penalties for classes such as multilingual current queries, AT/local shopping, GitHub/docs, package/API docs, arXiv/academic, Reddit/community, CVE/security, official/regulatory, finance/IR, weather/local factual, and answer/synthesis.
 4. Remove providers that do not have a key or required local config.
 5. Remove providers listed in `disabled_providers`.
 6. Remove providers with `auto_allow=false` from automatic routing.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,9 +40,9 @@ Each provider adapter normalizes provider-specific request and response details 
 
 Provider capability classes:
 
-- Search-only: Brave, Serper, Perplexity, Kilo Perplexity, SearXNG, SerpBase, Querit. SerpBase and Querit are listed last because they default to `auto_allow=false` and are explicit/fallback-only unless users opt in.
-- Search and extraction: Tavily, Exa, Linkup, Firecrawl, You.com.
-- Answer-style search: Perplexity and Kilo Perplexity return direct-answer style search results, but are still exposed through the search interface.
+- Search-only: Brave, Serper, Perplexity, Kilo Perplexity, SearXNG, SerpBase, Querit. Brave, Perplexity/Kilo Perplexity, SerpBase, and Querit default to `auto_allow=false` and are explicit/guarded unless users opt in.
+- Search and extraction: You.com, Firecrawl, Tavily, Exa, Linkup.
+- Answer-style search: Perplexity and Kilo Perplexity return direct-answer style search results, but default auto-routing treats them as answer/research-mode providers rather than fast search providers.
 
 Provider pricing, freshness, ranking, localization, and vertical support are controlled by the providers. The plugin normalizes responses; it does not make providers equivalent.
 
@@ -60,9 +60,15 @@ Default routing config includes:
   "auto_routing": {
     "enabled": true,
     "fallback_provider": "serper",
-    "provider_priority": ["tavily", "linkup", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"],
+    "provider_priority": ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"],
     "disabled_providers": [],
-    "auto_allow": {"serpbase": false, "querit": false},
+    "auto_allow": {
+      "serpbase": false,
+      "querit": false,
+      "brave": false,
+      "kilo-perplexity": false,
+      "perplexity": false
+    },
     "confidence_threshold": 0.3
   }
 }
@@ -76,15 +82,16 @@ Routing is rule-based. It is not ML and it is not magic.
 
 High-level flow:
 
-1. Analyze query text for signals: current-info intent, product/local intent, research language, direct-answer intent, semantic-discovery intent, privacy intent, complexity, and recency.
+1. Analyze query text for signals: current-info intent, product/local intent, research language, direct-answer intent, semantic-discovery intent, privacy intent, complexity, recency, language/script hints, and benchmark-derived query classes.
 2. Score known providers for those signals.
-3. Remove providers that do not have a key or required local config.
-4. Remove providers listed in `disabled_providers`.
-5. Remove providers with `auto_allow=false` from automatic routing.
-6. Choose the highest-scoring remaining provider.
-7. Break ties deterministically using query text and `provider_priority`.
-8. Execute the provider call with retry/cooldown handling.
-9. Return quality diagnostics if requested.
+3. Apply conservative vNext-lite boosts and penalties for classes such as multilingual current queries, AT/local shopping, GitHub/docs, package/API docs, arXiv/academic, Reddit/community, CVE/security, official/regulatory, finance/IR, weather/local factual, and answer/synthesis.
+4. Remove providers that do not have a key or required local config.
+5. Remove providers listed in `disabled_providers`.
+6. Remove providers with `auto_allow=false` from automatic routing.
+7. Choose the highest-scoring remaining provider.
+8. Break ties deterministically using query text and `provider_priority`.
+9. Execute the provider call with retry/cooldown handling.
+10. Return quality diagnostics if requested.
 
 When no provider is eligible, the router reports `no_available_providers` and falls back to the configured fallback provider path. If that provider has no key, the call fails visibly instead of inventing results.
 
@@ -97,7 +104,10 @@ Example:
 ```json
 "auto_allow": {
   "serpbase": false,
-  "querit": false
+  "querit": false,
+  "brave": false,
+  "kilo-perplexity": false,
+  "perplexity": false
 }
 ```
 
@@ -120,7 +130,7 @@ Opt out:
 python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase off
 ```
 
-The gate exists for providers where silent automatic use could surprise users because of pricing, maturity, coverage, terms, or result style. SerpBase is documented as an explicit-opt-in provider, not as a broken or disabled provider.
+The gate exists for providers where silent automatic use could surprise users because of pricing, maturity, reliability, coverage, terms, latency, or result style. Guarded providers are documented as explicit-opt-in providers, not as broken or disabled providers.
 
 ## Fallback and failure semantics
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -33,13 +33,13 @@ For the exact flow, see [Architecture](ARCHITECTURE.md#routing-engine).
 Per call:
 
 ```python
-web_search_plus(query="Hermes Agent docs", provider="brave")
+web_search_plus(query="Hermes Agent docs", provider="you")
 ```
 
 Persistently:
 
 ```bash
-python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default you
 ```
 
 Re-enable auto-routing later:
@@ -78,7 +78,7 @@ python ~/.hermes/plugins/web-search-plus/setup.py status
 Also verify that the key was written to the environment file Hermes actually uses. The setup helper supports explicit targeting:
 
 ```bash
-python ~/.hermes/plugins/web-search-plus/setup.py setup brave --env-path ~/.hermes/.env
+python ~/.hermes/plugins/web-search-plus/setup.py setup you --env-path ~/.hermes/.env
 ```
 
 ## How do I cap spend?
@@ -112,8 +112,8 @@ Different SERP APIs can have different freshness, ranking, localization, persona
 Yes. Configure one search-capable provider and pin it if you want predictable behavior:
 
 ```bash
-python ~/.hermes/plugins/web-search-plus/setup.py setup brave
-python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave
+python ~/.hermes/plugins/web-search-plus/setup.py setup you
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default you
 ```
 
 Extraction requires an extraction-capable provider such as Linkup, Firecrawl, Tavily, Exa, or You.com.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -20,9 +20,9 @@ Turn it back off with:
 python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase off
 ```
 
-## Which provider gets picked when multiple providers are configured?
+## Which provider gets picked by Routing v2 when multiple providers are configured?
 
-If routing is enabled, the query analyzer scores providers by query signals such as current-info intent, product/local intent, research language, direct-answer intent, semantic-discovery intent, privacy intent, language/script hints, and class-specific benchmark rules. The router then filters out unavailable, disabled, or `auto_allow=false` providers and chooses the best eligible provider. Ties are deterministic per query.
+If Routing v2 is enabled, the query analyzer scores providers by query signals such as current-info intent, product/local intent, research language, direct-answer intent, semantic-discovery intent, privacy intent, language/script hints, and class-specific benchmark rules. The router then filters out unavailable, disabled, or `auto_allow=false` providers and chooses the best eligible provider. Ties are deterministic per query.
 
 The default auto-search pool is conservative: You.com, Serper, Exa, Firecrawl, Tavily, and Linkup. Brave, SerpBase, Querit, native Perplexity, and Kilo Perplexity default to explicit/guarded use; Kilo Perplexity is intended for answer/research mode rather than fast search auto-routing.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -22,7 +22,9 @@ python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase
 
 ## Which provider gets picked when multiple providers are configured?
 
-If routing is enabled, the query analyzer scores providers by query signals such as current-info intent, product/local intent, research language, direct-answer intent, semantic-discovery intent, and privacy intent. The router then filters out unavailable, disabled, or `auto_allow=false` providers and chooses the best eligible provider. Ties are deterministic per query.
+If routing is enabled, the query analyzer scores providers by query signals such as current-info intent, product/local intent, research language, direct-answer intent, semantic-discovery intent, privacy intent, language/script hints, and class-specific benchmark rules. The router then filters out unavailable, disabled, or `auto_allow=false` providers and chooses the best eligible provider. Ties are deterministic per query.
+
+The default auto-search pool is conservative: You.com, Serper, Exa, Firecrawl, Tavily, and Linkup. Brave, SerpBase, Querit, native Perplexity, and Kilo Perplexity default to explicit/guarded use; Kilo Perplexity is intended for answer/research mode rather than fast search auto-routing.
 
 For the exact flow, see [Architecture](ARCHITECTURE.md#routing-engine).
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -143,18 +143,18 @@ Example pattern:
 
 Read that as: SerpBase has a key but is explicit-only, Brave is temporarily cooled down, and Serper won among eligible providers. If you want SerpBase to participate in automatic routing, opt in with `set-auto-allow serpbase on`; if you want Brave retried immediately, wait for cooldown or clear local provider health state in your cache directory.
 
-## Explicit opt-in providers: SerpBase and Querit
+## Explicit opt-in providers: guarded providers
 
 Some providers can be configured for explicit use without being selected automatically. That is what `auto_allow` controls.
 
-SerpBase and Querit default to `auto_allow=false`. Setting their keys makes explicit calls work:
+Brave, SerpBase, Querit, native Perplexity, and Kilo Perplexity default to `auto_allow=false`. Setting their keys makes explicit calls work:
 
 ```python
 web_search_plus(query="best DAC reviews", provider="serpbase")
 web_search_plus(query="aktuelle KI-News Deutschland", provider="querit")
 ```
 
-That does not make either provider eligible for automatic routing or fallback until you opt in:
+That does not make any guarded provider eligible for automatic routing or fallback until you opt in:
 
 ```bash
 python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase on
@@ -185,7 +185,7 @@ web_search_plus(query="turntable reviews under 1000", mode="research", research_
 
 Important parameters:
 
-- `provider`: `auto`, or a concrete provider such as `brave`, `serper`, `tavily`, `linkup`, `exa`, `perplexity`, `kilo-perplexity`, `you`, `searxng`, `serpbase`, or `querit`. SerpBase and Querit are listed last because they default to `auto_allow=false`.
+- `provider`: `auto`, or a concrete provider such as `you`, `serper`, `exa`, `firecrawl`, `tavily`, `linkup`, `brave`, `perplexity`, `kilo-perplexity`, `searxng`, `serpbase`, or `querit`. Brave, Perplexity/Kilo Perplexity, SerpBase, and Querit are available for explicit calls but default to `auto_allow=false`.
 - `count`: result count, from 1 to 20.
 - `time_range`: `day`, `week`, `month`, or `year` where supported.
 - `include_domains` / `exclude_domains`: provider-dependent domain filters.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -64,6 +64,16 @@ Presets:
 
 Search-capable providers include You.com, Serper, Exa, Firecrawl, Tavily, Linkup, Brave, Perplexity, Kilo Perplexity, SearXNG, SerpBase, and Querit. Extraction-capable providers are Linkup, Firecrawl, Tavily, Exa, and You.com.
 
+### Migration note for v2.0.0
+
+Routing v2 changes the default `provider="auto"` behavior. Existing configs keep explicit user choices, but missing `auto_allow` entries inherit the new guarded defaults: Brave, SerpBase, Querit, native Perplexity, and Kilo Perplexity stay explicit-only until you opt them into automatic routing.
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config show --json
+python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase on
+python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase off
+```
+
 ## Routing preferences
 
 Secrets and behavior are intentionally separate:
@@ -131,6 +141,8 @@ Example pattern:
   "routing": {
     "provider": "serper",
     "reason": "moderate_confidence_match",
+    "routing_policy": "routing-v2",
+    "routing_class": "shopping_at",
     "auto_allow_excluded": ["serpbase"]
   },
   "quality_report": {

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -51,18 +51,18 @@ Useful commands:
 python ~/.hermes/plugins/web-search-plus/setup.py list
 python ~/.hermes/plugins/web-search-plus/setup.py status --json
 python ~/.hermes/plugins/web-search-plus/setup.py setup --preset starter
-python ~/.hermes/plugins/web-search-plus/setup.py setup brave linkup --env-path ~/.hermes/.env
+python ~/.hermes/plugins/web-search-plus/setup.py setup you linkup --env-path ~/.hermes/.env
 ```
 
 Presets:
 
-- `starter`: Tavily + Linkup + Brave. Best default for new users.
-- `lean`: Tavily + Linkup. Cheap useful search plus extraction.
-- `search`: Tavily + Brave + Serper. Broad search coverage.
+- `starter`: You.com + Serper + Linkup. Best Routing v2 first-run setup.
+- `lean`: You.com + Linkup. Small fast search plus extraction.
+- `search`: You.com + Serper + Exa + Firecrawl + Tavily + Linkup. Full default Routing v2 pool.
 - `extract`: Firecrawl + Linkup + Exa + Tavily. Extraction-heavy setup.
 - `all`: prompt for every supported provider.
 
-Search-capable providers include Brave, Serper, Tavily, Exa, Linkup, Firecrawl, Perplexity, Kilo Perplexity, You.com, SearXNG, SerpBase, and Querit. Extraction-capable providers are Linkup, Firecrawl, Tavily, Exa, and You.com.
+Search-capable providers include You.com, Serper, Exa, Firecrawl, Tavily, Linkup, Brave, Perplexity, Kilo Perplexity, SearXNG, SerpBase, and Querit. Extraction-capable providers are Linkup, Firecrawl, Tavily, Exa, and You.com.
 
 ## Routing preferences
 
@@ -82,7 +82,7 @@ python ~/.hermes/plugins/web-search-plus/setup.py config show --json
 Pin a fixed provider:
 
 ```bash
-python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default you
 ```
 
 Turn query-based auto-routing back on:
@@ -94,8 +94,8 @@ python ~/.hermes/plugins/web-search-plus/setup.py config set-routing on
 Tune automatic routing and fallback:
 
 ```bash
-python ~/.hermes/plugins/web-search-plus/setup.py config set-priority tavily,linkup,exa,firecrawl,perplexity,kilo-perplexity,brave,serper,you,searxng
-python ~/.hermes/plugins/web-search-plus/setup.py config set-fallback tavily
+python ~/.hermes/plugins/web-search-plus/setup.py config set-priority you,serper,exa,firecrawl,tavily,linkup
+python ~/.hermes/plugins/web-search-plus/setup.py config set-fallback serper
 python ~/.hermes/plugins/web-search-plus/setup.py config disable perplexity
 python ~/.hermes/plugins/web-search-plus/setup.py config enable perplexity
 python ~/.hermes/plugins/web-search-plus/setup.py config set-threshold 0.45
@@ -104,7 +104,7 @@ python ~/.hermes/plugins/web-search-plus/setup.py config set-threshold 0.45
 Preview config changes without writing:
 
 ```bash
-python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave --dry-run
+python ~/.hermes/plugins/web-search-plus/setup.py config set-default you --dry-run
 ```
 
 ### Routing debug walkthrough
@@ -141,7 +141,7 @@ Example pattern:
 }
 ```
 
-Read that as: SerpBase has a key but is explicit-only, Brave is temporarily cooled down, and Serper won among eligible providers. If you want SerpBase to participate in automatic routing, opt in with `set-auto-allow serpbase on`; if you want Brave retried immediately, wait for cooldown or clear local provider health state in your cache directory.
+Read that as: guarded providers can have keys but remain explicit-only for `provider="auto"`, and the router selected the best eligible provider. If you want SerpBase, Brave, Querit, Perplexity, or Kilo Perplexity to participate in automatic routing, opt in with `set-auto-allow <provider> on`; if a provider is cooled down, wait or clear local provider health state in your cache directory.
 
 ## Explicit opt-in providers: guarded providers
 

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "1.10.0"
+version: "2.0.0"
 description: "Multi-provider web search, URL extraction, cited answers, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []
@@ -27,26 +27,26 @@ onboarding:
   status_command: "python ~/.hermes/plugins/web-search-plus/setup.py status"
   routing_status_command: "python ~/.hermes/plugins/web-search-plus/setup.py config show"
   routing_config_commands:
-    fixed_provider: "python ~/.hermes/plugins/web-search-plus/setup.py config set-default brave"
+    fixed_provider: "python ~/.hermes/plugins/web-search-plus/setup.py config set-default you"
     auto_routing: "python ~/.hermes/plugins/web-search-plus/setup.py config set-routing on"
-    priority: "python ~/.hermes/plugins/web-search-plus/setup.py config set-priority tavily,linkup,brave,serper"
-    fallback: "python ~/.hermes/plugins/web-search-plus/setup.py config set-fallback tavily"
+    priority: "python ~/.hermes/plugins/web-search-plus/setup.py config set-priority you,serper,exa,firecrawl,tavily,linkup"
+    fallback: "python ~/.hermes/plugins/web-search-plus/setup.py config set-fallback serper"
     disable_provider: "python ~/.hermes/plugins/web-search-plus/setup.py config disable perplexity"
-    block_auto_provider: "python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase off"
+    block_auto_provider: "python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow brave off"
     reset: "python ~/.hermes/plugins/web-search-plus/setup.py config reset --yes"
   config_file: "~/.hermes/plugins/config.json"
   env_override: "WEB_SEARCH_PLUS_CONFIG"
   note: "No single provider key is globally required. Add at least one search-capable provider for web_search_plus/web_answer_plus; add Linkup or another extraction-capable provider for web_extract_plus and fuller cited answers. Setup keys live in .env; routing preferences live in config.json and can choose fixed-provider mode or tuned auto-routing without relying on unreleased Hermes core plugin-CLI support."
   recommended_env:
-    - name: TAVILY_API_KEY
-      description: "Tavily — recommended starter for search/research (1k free/month)"
-      url: "https://tavily.com"
+    - name: YOU_API_KEY
+      description: "You.com — fast Routing v2 core provider"
+      url: "https://api.you.com"
+      secret: true
+    - name: SERPER_API_KEY
+      description: "Serper — reliable Google-like fallback for search/news/shopping/local"
+      url: "https://serper.dev/api-key"
       secret: true
     - name: LINKUP_API_KEY
       description: "Linkup — cheap extraction and citations (€5 free monthly credits)"
       url: "https://www.linkup.so"
-      secret: true
-    - name: BRAVE_API_KEY
-      description: "Brave Search — independent general web index ($5 free monthly credits)"
-      url: "https://api.search.brave.com/app/keys"
       secret: true

--- a/search.py
+++ b/search.py
@@ -291,9 +291,15 @@ DEFAULT_CONFIG = {
         "fallback_provider": "serper",
         # Low-trust / experimental providers can stay configured for explicit use
         # without being selected automatically.
-        "provider_priority": ["tavily", "linkup", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"],
+        "provider_priority": ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"],
         "disabled_providers": [],
-        "auto_allow": {"serpbase": False, "querit": False},
+        "auto_allow": {
+            "serpbase": False,
+            "querit": False,
+            "brave": False,
+            "kilo-perplexity": False,
+            "perplexity": False,
+        },
         "confidence_threshold": 0.3,  # Below this, note low confidence
     },
     "serper": {
@@ -419,7 +425,7 @@ def _validate_runtime_config(config: Dict[str, Any]) -> Dict[str, Any]:
         raw_allow = auto.get("auto_allow") or {}
         if not isinstance(raw_allow, dict):
             raise ValueError("auto_allow must be an object mapping provider names to booleans")
-        normalized_allow = {}
+        normalized_allow = dict(DEFAULT_CONFIG["auto_routing"].get("auto_allow", {}))
         for raw_provider, allowed in raw_allow.items():
             provider = _normalize_routing_provider_config(str(raw_provider))
             normalized_allow[provider] = bool(allowed)
@@ -1275,6 +1281,12 @@ class QueryAnalyzer:
             (r'\b(202[4-9]|2030)\b', 2.0),
             (r'\b(breaking|live|just|now)\b', 3.0),
             (r'\blast (hour|day|week|month)\b', 2.5),
+            # Common non-English freshness markers from the 25-query routing benchmark.
+            (r'\b(hoy|aujourd|heute|aktuell)\b', 2.5),
+            (r'[今日最新]', 2.5),
+            (r'(сегодня|новости)', 2.5),
+            (r'(اليوم|أخبار)', 2.5),
+            (r'(最新|今天)', 2.5),
         ]
         
         total = 0.0
@@ -1283,6 +1295,122 @@ class QueryAnalyzer:
                 total += weight
         
         return total > 2.0, total
+
+    def _detect_language_hint(self, query: str) -> str:
+        """Best-effort language/script hint for routing; not user-facing translation."""
+        q = query.lower()
+        if re.search(r'[\u0600-\u06ff]', query):
+            return "ar"
+        if re.search(r'[\u0400-\u04ff]', query):
+            return "ru"
+        if re.search(r'[\u3040-\u30ff]', query) or re.search(r'(東京|ニュース|今日|企業|発表)', query):
+            return "ja"
+        if re.search(r'[\u4e00-\u9fff]', query):
+            return "zh"
+        if re.search(r'\b(noticias|españa|hoy|regulación|inteligencia artificial)\b', q):
+            return "es"
+        if re.search(r'\b(actualités|france|aujourd|ouverts?|dimanche|récents?|avis)\b', q):
+            return "fr"
+        if re.search(r'\b(der|die|das|und|oder|nicht|ist|sind|aktuelle?n?|preis|kaufen|öffnungszeiten|österreich)\b', q):
+            return "de"
+        return "en"
+
+    def _detect_routing_class(self, query: str, language_hint: str) -> str:
+        """Coarse class labels from the qualitative 25-query benchmark."""
+        q = query.lower()
+        # Answer/synthesis must win before docs/GitHub keywords like "Python" or "Node.js".
+        if re.search(r'\b(difference|differences|unterschiede|vergleich|compare|comparison|was sind|what are)\b', q):
+            return "answer_synthesis"
+        if re.search(r'\b(nvidia|earnings|gross margin|investor relations|guidance|10-[qk]|eps|revenue)\b', q):
+            return "finance_ir"
+        if re.search(r'\bsite:\s*reddit\.com\b|\br/\w+|\breddit\s+(thread|post|community|users?|discussion|comments?)\b', q):
+            return "reddit_community"
+        if re.search(r'\b(cve|mitigation|advisory|security advisory|openssh)\b', q):
+            return "cve_security"
+        if re.search(r'\barxiv\b|\bpaper(s)?\b|\bscaling laws\b|\brandomi[sz]ed trial\b|\bprimary sources?\b', q):
+            return "academic_arxiv"
+        if re.search(r'\bgithub\b|\brepo(sitory)?\b|\bplugin docs\b', q):
+            return "github_docs"
+        if re.search(r'\b(python|pydantic|node\.js|api docs?|documentation|docs|changelog|release notes?|taskgroup|basemodel)\b', q):
+            return "docs_api"
+        if re.search(r'\b(eu ai act|european commission|official|regulation|regulatory|obligations?)\b', q):
+            return "official_regulatory"
+        if (
+            re.search(r'\b(geizhals|preis|prices?|buy|kaufen|österreich|austria|shop|händler|deal|angebot)\b', q)
+            and re.search(r'\b(sony|denon|iphone|samsung|bose|kef|marantz|yamaha|lg|asus|laptop|tv|headphones?|speaker|receiver|avc|wh-|[a-z]{1,5}[-\s]?\d{3,}[a-z0-9-]*)\b', q)
+        ):
+            return "shopping_at"
+        if re.search(r'\b(graz|öffnungszeiten|adresse|restaurants?|vegan|hifi team)\b', q):
+            return "local_at"
+        if re.search(r'\b(bundesliga|standings?|fixtures?|tabelle|punkte|spieltag|matchday|lineups?|scores?|sturm|salzburg|lask)\b|\b(league|liga|standings?|points?)\s+table\b', q):
+            return "sports_current"
+        if re.search(r'\b(wetter|weather|forecast|regen|rain)\b', q):
+            return "weather_local"
+        if re.search(r'\b(alternatives? to|open source|self hosted|competitors?|similar to)\b', q):
+            return "oss_discovery"
+        if language_hint not in {"en", "de"}:
+            return "multilingual_current"
+        return "general"
+
+    def _apply_vnext_routing_boosts(
+        self,
+        query: str,
+        provider_scores: Dict[str, float],
+        language_hint: str,
+        routing_class: str,
+        recency_score: float,
+    ) -> bool:
+        """Apply conservative class-aware boosts from the qualitative routing benchmark.
+
+        Returns whether this should be handled as answer/research mode by callers that
+        support synthesis providers. Search auto-routing still avoids slow answer-only
+        providers unless explicitly selected.
+        """
+        def boost(provider: str, value: float) -> None:
+            provider_scores[provider] = provider_scores.get(provider, 0.0) + value
+
+        answer_mode = False
+
+        # Script/language-aware current queries: You performed best as the safe fast default,
+        # with Exa/Firecrawl/Linkup useful by script. Keep this modest so strong class rules win.
+        if language_hint not in {"en", "de"}:
+            if language_hint == "zh":
+                boost("exa", 7.0); boost("you", 6.0); boost("firecrawl", 4.0); boost("linkup", 3.0); boost("serper", 2.5)
+            elif language_hint == "ar":
+                boost("you", 8.0); boost("linkup", 5.0); boost("serper", 4.0); boost("firecrawl", 2.0)
+            else:
+                boost("you", 8.0); boost("exa", 5.0); boost("firecrawl", 4.0); boost("linkup", 3.0); boost("tavily", 2.0)
+            boost("you", min(recency_score, 3.0))
+
+        if routing_class == "shopping_at":
+            boost("serper", 8.0); boost("firecrawl", 6.0); boost("linkup", 4.0); boost("you", 2.0); boost("exa", -2.0)
+        elif routing_class == "local_at":
+            boost("firecrawl", 8.0); boost("serper", 6.0); boost("linkup", 4.0); boost("you", 2.0)
+        elif routing_class == "official_regulatory":
+            boost("exa", 8.0); boost("firecrawl", 6.0); boost("serper", 5.0); boost("you", 3.0)
+        elif routing_class == "sports_current":
+            boost("you", 8.0); boost("serper", 6.0); boost("linkup", 5.0); boost("tavily", 2.0)
+        elif routing_class == "github_docs":
+            boost("exa", 10.0); boost("you", 6.0); boost("firecrawl", 5.0); boost("serper", 4.0)
+        elif routing_class == "docs_api":
+            boost("serper", 6.0); boost("exa", 5.0); boost("you", 4.0); boost("firecrawl", 3.0); boost("tavily", 3.0)
+        elif routing_class == "academic_arxiv":
+            boost("exa", 12.0); boost("serper", 3.0); boost("linkup", 2.0); boost("you", 1.5)
+        elif routing_class == "oss_discovery":
+            boost("exa", 8.0); boost("firecrawl", 5.0); boost("tavily", 4.0); boost("you", 3.0)
+        elif routing_class == "reddit_community":
+            boost("serper", 10.0); boost("firecrawl", 8.0); boost("tavily", 6.0); boost("exa", -20.0)
+        elif routing_class == "cve_security":
+            boost("serper", 10.0); boost("exa", 8.0); boost("linkup", 5.0); boost("you", 2.0); boost("firecrawl", -20.0)
+        elif routing_class == "finance_ir":
+            boost("exa", 7.0); boost("you", 6.0); boost("firecrawl", 5.0); boost("serper", 4.0)
+        elif routing_class == "weather_local":
+            boost("serper", 8.0); boost("firecrawl", 6.0); boost("you", 2.0)
+        elif routing_class == "answer_synthesis":
+            answer_mode = True
+            boost("you", 16.0); boost("tavily", 4.0); boost("linkup", 3.0); boost("exa", 2.0)
+
+        return answer_mode
     
     def analyze(self, query: str) -> Dict[str, Any]:
         """
@@ -1351,8 +1479,10 @@ class QueryAnalyzer:
                 "weight": complexity["complexity_score"]
             })
         
-        # Check recency intent
+        # Check recency intent and benchmark-derived language/class hints
         is_recency, recency_score = self._detect_recency_intent(query)
+        language_hint = self._detect_language_hint(query)
+        routing_class = self._detect_routing_class(query, language_hint)
         
         # Map intents to providers with final scores
         provider_scores = {
@@ -1369,6 +1499,13 @@ class QueryAnalyzer:
             "searxng": privacy_score,  # SearXNG for privacy/multi-source queries
             "firecrawl": discovery_score + (research_score * 0.35) + (recency_score * 0.25),
         }
+        answer_mode_recommended = self._apply_vnext_routing_boosts(
+            query,
+            provider_scores,
+            language_hint,
+            routing_class,
+            recency_score,
+        )
         
         # Build match details per provider
         provider_matches = {
@@ -1394,6 +1531,9 @@ class QueryAnalyzer:
             "complexity": complexity,
             "recency_focused": is_recency,
             "recency_score": recency_score,
+            "language_hint": language_hint,
+            "routing_class": routing_class,
+            "answer_mode_recommended": answer_mode_recommended,
             "linkup_source_score": linkup_source_score,
             "exa_deep_score": exa_deep_score,
             "exa_deep_reasoning_score": exa_deep_reasoning_score,
@@ -1431,13 +1571,14 @@ class QueryAnalyzer:
                 "top_signals": [],
                 "analysis": analysis,
                 "auto_allow_excluded": auto_excluded,
+                "answer_mode_recommended": analysis.get("answer_mode_recommended", False),
             }
         
         # Find the winner
         max_score = max(available.values())
         
         # Handle ties using deterministic per-query distribution
-        priority = self.auto_config.get("provider_priority", ["tavily", "linkup", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"])
+        priority = self.auto_config.get("provider_priority", ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"])
         winners = [p for p, s in available.items() if s == max_score]
         
         if len(winners) > 1:
@@ -1508,11 +1649,14 @@ class QueryAnalyzer:
             ],
             "below_threshold": confidence < threshold,
             "auto_allow_excluded": auto_excluded,
+            "answer_mode_recommended": analysis.get("answer_mode_recommended", False),
             "analysis_summary": {
                 "query_length": len(query.split()),
                 "is_complex": analysis["complexity"]["is_complex"],
                 "has_url": analysis["detected_url"] is not None,
                 "recency_focused": analysis["recency_focused"],
+                "language_hint": analysis.get("language_hint", "en"),
+                "routing_class": analysis.get("routing_class", "general"),
             }
         }
 
@@ -1565,6 +1709,7 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             "reason": routing["reason"],
             "exa_depth": routing.get("exa_depth", "normal"),
             "auto_allow_excluded": routing.get("auto_allow_excluded", []),
+            "answer_mode_recommended": routing.get("answer_mode_recommended", False),
         },
         "scores": routing["scores"],
         "top_signals": routing["top_signals"],
@@ -1588,6 +1733,8 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             "complexity_score": round(analysis["complexity"]["complexity_score"], 2),
             "has_url": analysis["detected_url"],
             "recency_focused": analysis["recency_focused"],
+            "language_hint": analysis.get("language_hint", "en"),
+            "routing_class": analysis.get("routing_class", "general"),
         },
         "all_matches": {
             provider: [

--- a/search.py
+++ b/search.py
@@ -1372,46 +1372,50 @@ class QueryAnalyzer:
         def boost(provider: str, value: float) -> None:
             provider_scores[provider] = provider_scores.get(provider, 0.0) + value
 
+        def boost_many(items: List[Tuple[str, float]]) -> None:
+            for provider, value in items:
+                boost(provider, value)
+
         answer_mode = False
 
         # Script/language-aware current queries: You performed best as the safe fast default,
         # with Exa/Firecrawl/Linkup useful by script. Keep this modest so strong class rules win.
         if language_hint not in {"en", "de"}:
             if language_hint == "zh":
-                boost("exa", 7.0); boost("you", 6.0); boost("firecrawl", 4.0); boost("linkup", 3.0); boost("serper", 2.5)
+                boost_many([("exa", 7.0), ("you", 6.0), ("firecrawl", 4.0), ("linkup", 3.0), ("serper", 2.5)])
             elif language_hint == "ar":
-                boost("you", 8.0); boost("linkup", 5.0); boost("serper", 4.0); boost("firecrawl", 2.0)
+                boost_many([("you", 8.0), ("linkup", 5.0), ("serper", 4.0), ("firecrawl", 2.0)])
             else:
-                boost("you", 8.0); boost("exa", 5.0); boost("firecrawl", 4.0); boost("linkup", 3.0); boost("tavily", 2.0)
+                boost_many([("you", 8.0), ("exa", 5.0), ("firecrawl", 4.0), ("linkup", 3.0), ("tavily", 2.0)])
             boost("you", min(recency_score, 3.0))
 
         if routing_class == "shopping_at":
-            boost("serper", 8.0); boost("firecrawl", 6.0); boost("linkup", 4.0); boost("you", 2.0); boost("exa", -2.0)
+            boost_many([("serper", 8.0), ("firecrawl", 6.0), ("linkup", 4.0), ("you", 2.0), ("exa", -2.0)])
         elif routing_class == "local_at":
-            boost("firecrawl", 8.0); boost("serper", 6.0); boost("linkup", 4.0); boost("you", 2.0)
+            boost_many([("firecrawl", 8.0), ("serper", 6.0), ("linkup", 4.0), ("you", 2.0)])
         elif routing_class == "official_regulatory":
-            boost("exa", 8.0); boost("firecrawl", 6.0); boost("serper", 5.0); boost("you", 3.0)
+            boost_many([("exa", 8.0), ("firecrawl", 6.0), ("serper", 5.0), ("you", 3.0)])
         elif routing_class == "sports_current":
-            boost("you", 8.0); boost("serper", 6.0); boost("linkup", 5.0); boost("tavily", 2.0)
+            boost_many([("you", 8.0), ("serper", 6.0), ("linkup", 5.0), ("tavily", 2.0)])
         elif routing_class == "github_docs":
-            boost("exa", 10.0); boost("you", 6.0); boost("firecrawl", 5.0); boost("serper", 4.0)
+            boost_many([("exa", 10.0), ("you", 6.0), ("firecrawl", 5.0), ("serper", 4.0)])
         elif routing_class == "docs_api":
-            boost("serper", 6.0); boost("exa", 5.0); boost("you", 4.0); boost("firecrawl", 3.0); boost("tavily", 3.0)
+            boost_many([("serper", 6.0), ("exa", 5.0), ("you", 4.0), ("firecrawl", 3.0), ("tavily", 3.0)])
         elif routing_class == "academic_arxiv":
-            boost("exa", 12.0); boost("serper", 3.0); boost("linkup", 2.0); boost("you", 1.5)
+            boost_many([("exa", 12.0), ("serper", 3.0), ("linkup", 2.0), ("you", 1.5)])
         elif routing_class == "oss_discovery":
-            boost("exa", 8.0); boost("firecrawl", 5.0); boost("tavily", 4.0); boost("you", 3.0)
+            boost_many([("exa", 8.0), ("firecrawl", 5.0), ("tavily", 4.0), ("you", 3.0)])
         elif routing_class == "reddit_community":
-            boost("serper", 10.0); boost("firecrawl", 8.0); boost("tavily", 6.0); boost("exa", -20.0)
+            boost_many([("serper", 10.0), ("firecrawl", 8.0), ("tavily", 6.0), ("exa", -20.0)])
         elif routing_class == "cve_security":
-            boost("serper", 10.0); boost("exa", 8.0); boost("linkup", 5.0); boost("you", 2.0); boost("firecrawl", -20.0)
+            boost_many([("serper", 10.0), ("exa", 8.0), ("linkup", 5.0), ("you", 2.0), ("firecrawl", -20.0)])
         elif routing_class == "finance_ir":
-            boost("exa", 7.0); boost("you", 6.0); boost("firecrawl", 5.0); boost("serper", 4.0)
+            boost_many([("exa", 7.0), ("you", 6.0), ("firecrawl", 5.0), ("serper", 4.0)])
         elif routing_class == "weather_local":
-            boost("serper", 8.0); boost("firecrawl", 6.0); boost("you", 2.0)
+            boost_many([("serper", 8.0), ("firecrawl", 6.0), ("you", 2.0)])
         elif routing_class == "answer_synthesis":
             answer_mode = True
-            boost("you", 16.0); boost("tavily", 4.0); boost("linkup", 3.0); boost("exa", 2.0)
+            boost_many([("you", 16.0), ("tavily", 4.0), ("linkup", 3.0), ("exa", 2.0)])
 
         return answer_mode
     

--- a/search.py
+++ b/search.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 1.9.3
-Supports search providers: Serper (Google), Brave Search, Tavily, Querit,
-Linkup, Exa, Firecrawl, Perplexity, Kilo Perplexity, You.com, SearXNG.
+Version: 2.0.0
+Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
+Brave Search, SerpBase, Querit, Perplexity, Kilo Perplexity, SearXNG.
 Supports extract providers: Firecrawl, Linkup, Tavily, Exa, You.com.
 
 Smart Routing uses multi-signal analysis:
+  - Routing v2 language/script and query-class detection
   - Query intent classification (shopping, research, discovery)
   - Linguistic pattern detection (how much vs how does)
   - Product/brand recognition
@@ -15,12 +16,12 @@ Smart Routing uses multi-signal analysis:
 
 Usage:
     python3 search.py --query "..."                    # Auto-route based on query
-    python3 search.py --provider [serper|serpbase|brave|tavily|linkup|querit|exa|firecrawl|perplexity|kilo-perplexity|you|searxng|auto] --query "..." [options]
+    python3 search.py --provider [you|serper|exa|firecrawl|tavily|linkup|brave|serpbase|querit|perplexity|kilo-perplexity|searxng|auto] --query "..." [options]
 
 Examples:
-    python3 search.py -q "iPhone 16 Pro price"              # → Serper (shopping intent)
-    python3 search.py -q "how does quantum entanglement work"  # → Tavily (research intent)
-    python3 search.py -q "startups similar to Notion"       # → Exa (discovery intent)
+    python3 search.py -q "東京 AI ニュース 今日"              # → You.com (multilingual current)
+    python3 search.py -q "arXiv 2024 LLM scaling laws"      # → Exa (academic discovery)
+    python3 search.py -q "latest OpenSSH CVE mitigation"    # → Serper (security/current)
 """
 
 import argparse
@@ -39,6 +40,8 @@ from typing import Optional, List, Dict, Any, Tuple
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode, urlparse, parse_qsl, urlunparse
+
+ROUTING_POLICY = "routing-v2"
 
 
 # =============================================================================
@@ -1567,6 +1570,7 @@ class QueryAnalyzer:
                 "confidence": 0.0,
                 "confidence_level": "low",
                 "reason": "no_available_providers",
+                "routing_policy": ROUTING_POLICY,
                 "scores": scores,
                 "top_signals": [],
                 "analysis": analysis,
@@ -1640,6 +1644,7 @@ class QueryAnalyzer:
             "confidence": confidence,
             "confidence_level": "high" if confidence >= 0.7 else "medium" if confidence >= 0.4 else "low",
             "reason": reason,
+            "routing_policy": ROUTING_POLICY,
             "exa_depth": exa_depth,
             "scores": {p: round(s, 2) for p, s in available.items()},
             "winning_score": round(max_score, 2),
@@ -1707,6 +1712,7 @@ def explain_routing(query: str, config: Dict[str, Any]) -> Dict[str, Any]:
             "confidence": routing["confidence"],
             "confidence_level": routing["confidence_level"],
             "reason": routing["reason"],
+            "routing_policy": routing.get("routing_policy", ROUTING_POLICY),
             "exa_depth": routing.get("exa_depth", "normal"),
             "auto_allow_excluded": routing.get("auto_allow_excluded", []),
             "answer_mode_recommended": routing.get("answer_mode_recommended", False),
@@ -1969,6 +1975,10 @@ def build_quality_report(
         "query": query,
         "selected_provider": routing_info.get("provider") or result.get("provider"),
         "routing_reason": routing_info.get("reason"),
+        "routing_policy": routing_info.get("routing_policy", ROUTING_POLICY),
+        "routing_class": routing_info.get("analysis_summary", {}).get("routing_class"),
+        "language_hint": routing_info.get("analysis_summary", {}).get("language_hint"),
+        "answer_mode_recommended": routing_info.get("answer_mode_recommended", False),
         "confidence": confidence_level,
         "confidence_score": routing_info.get("confidence"),
         "providers_considered": providers_considered,
@@ -4096,9 +4106,12 @@ Full docs: See README.md and SKILL.md
                 "confidence": routing["confidence"],
                 "confidence_level": routing["confidence_level"],
                 "reason": routing["reason"],
+                "routing_policy": routing.get("routing_policy", ROUTING_POLICY),
                 "top_signals": routing["top_signals"],
                 "scores": routing["scores"],
                 "auto_allow_excluded": routing.get("auto_allow_excluded", []),
+                "answer_mode_recommended": routing.get("answer_mode_recommended", False),
+                "analysis_summary": routing.get("analysis_summary", {}),
             }
         else:
             provider = "exa"
@@ -4108,10 +4121,11 @@ Full docs: See README.md and SKILL.md
                 "confidence": 1.0,
                 "confidence_level": "high",
                 "reason": "similar_url_specified",
+                "routing_policy": ROUTING_POLICY,
             }
     else:
         provider = args.provider or "serper"
-        routing_info = {"auto_routed": False, "provider": provider}
+        routing_info = {"auto_routed": False, "provider": provider, "routing_policy": ROUTING_POLICY}
     
     # Build provider fallback list
     auto_config = config.get("auto_routing", {})

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -180,8 +180,8 @@ def test_setup_presets_choose_expected_providers():
     extract = {item["provider"] for item in wsp._providers_for_preset("extract")}
     all_providers = {item["provider"] for item in wsp._providers_for_preset("all")}
 
-    assert starter == {"tavily", "linkup", "brave"}
-    assert lean == {"tavily", "linkup"}
+    assert starter == {"you", "serper", "linkup"}
+    assert lean == {"you", "linkup"}
     assert extract == {"linkup", "firecrawl", "tavily"}
     assert all_providers == {item["provider"] for item in wsp._get_provider_catalog()}
 
@@ -209,7 +209,7 @@ def test_setup_dry_run_prints_plan_without_prompting(monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "Setup plan:" in out
-    assert "Tavily" in out
+    assert "You.com" in out
     assert "Linkup" in out
     assert "Dry run only" in out
 
@@ -217,7 +217,7 @@ def test_setup_dry_run_prints_plan_without_prompting(monkeypatch, capsys):
 def test_setup_dry_run_uses_target_env_path_for_dashboard(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("BRAVE_API_KEY", "live-env-should-not-count")
     env_path = tmp_path / ".env"
-    env_path.write_text("TAVILY_API_KEY=x\n")
+    env_path.write_text("YOU_API_KEY=x\n")
     parser = wsp.argparse.ArgumentParser()
     wsp._web_search_plus_cli_setup(parser)
     args = parser.parse_args(["setup", "--preset", "starter", "--dry-run", "--env-path", str(env_path)])
@@ -226,7 +226,7 @@ def test_setup_dry_run_uses_target_env_path_for_dashboard(tmp_path, monkeypatch,
 
     out = capsys.readouterr().out
     assert "Providers: 1/12 configured" in out
-    assert "Active: Tavily" in out
+    assert "Active: You.com" in out
     assert "Brave Search" not in out.split("Setup plan:", 1)[0]
 
 
@@ -362,9 +362,12 @@ def test_config_set_auto_allow_updates_provider_gate(tmp_path):
 def test_default_behavior_config_blocks_low_trust_auto_providers():
     config = wsp._default_behavior_config()
 
-    assert config["auto_routing"]["provider_priority"][-2:] == ["serpbase", "querit"]
+    assert config["auto_routing"]["provider_priority"][:6] == ["you", "serper", "exa", "firecrawl", "tavily", "linkup"]
     assert config["auto_routing"]["auto_allow"]["serpbase"] is False
     assert config["auto_routing"]["auto_allow"]["querit"] is False
+    assert config["auto_routing"]["auto_allow"]["brave"] is False
+    assert config["auto_routing"]["auto_allow"]["kilo-perplexity"] is False
+    assert config["auto_routing"]["auto_allow"]["perplexity"] is False
 
 
 def test_setup_dry_run_can_auto_deny_provider(tmp_path, capsys):
@@ -380,7 +383,7 @@ def test_setup_dry_run_can_auto_deny_provider(tmp_path, capsys):
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "auto-allow false: querit, serpbase" in out
+    assert "auto-allow false: brave, kilo-perplexity, perplexity, querit, serpbase" in out
     assert not env_path.exists()
     assert not config_path.exists()
 

--- a/tests/test_routing_v2.py
+++ b/tests/test_routing_v2.py
@@ -61,6 +61,7 @@ def test_multilingual_current_japanese_routes_to_you_not_brave_or_serper():
     routing = _route("東京 AI ニュース 今日 2026 企業 発表")
 
     assert routing["provider"] == "you"
+    assert routing["routing_policy"] == "routing-v2"
     assert routing["analysis_summary"]["language_hint"] == "ja"
     assert "brave" in routing["auto_allow_excluded"]
 

--- a/tests/test_routing_vnext_lite.py
+++ b/tests/test_routing_vnext_lite.py
@@ -1,0 +1,104 @@
+import importlib.util
+from pathlib import Path
+from unittest import mock
+
+SEARCH_PATH = Path(__file__).resolve().parents[1] / "search.py"
+search_spec = importlib.util.spec_from_file_location("wsp_search_routing_vnext_under_test", SEARCH_PATH)
+search = importlib.util.module_from_spec(search_spec)
+assert search_spec.loader is not None
+search_spec.loader.exec_module(search)
+
+
+def _route(query):
+    config = search._deepcopy_default_config()
+    with mock.patch.object(search, "get_api_key", return_value="test-key"):
+        return search.QueryAnalyzer(config).route(query)
+
+
+def test_default_auto_allow_blocks_unreliable_and_answer_only_providers():
+    config = search._deepcopy_default_config()
+
+    auto_allow = config["auto_routing"]["auto_allow"]
+
+    assert auto_allow["serpbase"] is False
+    assert auto_allow["querit"] is False
+    assert auto_allow["brave"] is False
+    assert auto_allow["kilo-perplexity"] is False
+    assert auto_allow["perplexity"] is False
+
+
+def test_legacy_auto_allow_config_inherits_new_guarded_provider_defaults():
+    config = search._deepcopy_default_config()
+    config["auto_routing"]["auto_allow"] = {"serpbase": False, "querit": False}
+
+    validated = search._validate_runtime_config(config)
+
+    assert validated["auto_routing"]["auto_allow"]["brave"] is False
+    assert validated["auto_routing"]["auto_allow"]["kilo-perplexity"] is False
+    assert validated["auto_routing"]["auto_allow"]["perplexity"] is False
+
+
+def test_answer_synthesis_overrides_docs_keywords():
+    routing = _route("was sind die Unterschiede zwischen Python und Node.js")
+
+    assert routing["analysis_summary"]["routing_class"] == "answer_synthesis"
+    assert routing["answer_mode_recommended"] is True
+
+
+def test_reddit_company_finance_query_is_not_community_query():
+    routing = _route("Reddit IPO earnings revenue investor relations")
+
+    assert routing["analysis_summary"]["routing_class"] == "finance_ir"
+
+
+def test_plain_database_table_query_is_not_sports_current():
+    routing = _route("postgres table partitioning performance documentation")
+
+    assert routing["analysis_summary"]["routing_class"] != "sports_current"
+
+
+def test_multilingual_current_japanese_routes_to_you_not_brave_or_serper():
+    routing = _route("東京 AI ニュース 今日 2026 企業 発表")
+
+    assert routing["provider"] == "you"
+    assert routing["analysis_summary"]["language_hint"] == "ja"
+    assert "brave" in routing["auto_allow_excluded"]
+
+
+def test_multilingual_arabic_routes_to_you_and_blocks_querit():
+    routing = _route("أخبار الذكاء الاصطناعي اليوم 2026 السعودية تنظيم")
+
+    assert routing["provider"] == "you"
+    assert routing["analysis_summary"]["language_hint"] == "ar"
+    assert "querit" in routing["auto_allow_excluded"]
+
+
+def test_arxiv_academic_routes_to_exa():
+    routing = _route("arXiv 2024 LLM scaling laws inference compute paper")
+
+    assert routing["provider"] == "exa"
+    assert routing["analysis_summary"]["routing_class"] == "academic_arxiv"
+
+
+def test_reddit_site_query_routes_away_from_exa():
+    routing = _route("site:reddit.com r/hometheater Denon X4800H user impressions HDMI issues")
+
+    assert routing["provider"] in {"serper", "firecrawl", "tavily"}
+    assert routing["provider"] != "exa"
+    assert routing["analysis_summary"]["routing_class"] == "reddit_community"
+
+
+def test_cve_security_does_not_route_to_firecrawl():
+    routing = _route("latest OpenSSH CVE 2026 mitigation advisory official")
+
+    assert routing["provider"] in {"serper", "exa", "linkup"}
+    assert routing["provider"] != "firecrawl"
+    assert routing["analysis_summary"]["routing_class"] == "cve_security"
+
+
+def test_answer_synthesis_recommends_answer_mode_without_auto_selecting_kilo():
+    routing = _route("Was sind die wichtigsten Unterschiede zwischen Exa Tavily und You.com für Agenten Suche")
+
+    assert routing["provider"] == "you"
+    assert routing["answer_mode_recommended"] is True
+    assert "kilo-perplexity" in routing["auto_allow_excluded"]


### PR DESCRIPTION
## Summary

Release **web-search-plus v2.0.0** with Routing v2: a benchmarked, class-aware auto-routing policy for web search.

## What changed

- Replaces naive provider-priority auto-routing with Routing v2 query classification.
- Adds routing diagnostics for `routing_policy`, `language_hint`, `routing_class`, and `answer_mode_recommended`.
- Sets the conservative default auto-search pool to:
  - You.com
  - Serper
  - Exa
  - Firecrawl
  - Tavily
  - Linkup
- Keeps these providers explicit/guarded by default with `auto_allow=false`:
  - Brave
  - SerpBase
  - Querit
  - Perplexity
  - Kilo Perplexity
- Preserves explicit provider calls and lets existing configs inherit the new guarded defaults.
- Updates onboarding presets, README, User Guide, FAQ, Architecture docs, plugin metadata, and CHANGELOG for v2.0.0.
- Fixes CI Ruff E702 violations in the new Routing v2 boost policy block.

## Why major

`provider="auto"` now behaves materially differently: slow/unstable/answer-oriented providers are no longer silently selected in the hot path, while multilingual/current and class-specific routing gets first-class handling. That is user-visible behavior, so this is a major release, not a patch bump.

## Validation

Local checks on final head `bd2c087`:

- `ruff check .` → OK
- `python3 -m pytest -q` → `139 passed`
- `python3 -m compileall search.py __init__.py tests` → OK
- `git diff --check` → OK
- Version consistency scan → OK (`plugin.yaml`, `__init__.py`, `search.py`, `CHANGELOG.md` all `2.0.0`)
- Secret regex scan → OK
- Private agent-name scan → OK
- Docs/code consistency scan → OK
- Sensitive repo-file scan → OK (`.env`, `provider_health.json`, `.pem`, `.key` absent)
- Stale public terminology scan → OK (no `vNext-lite` / `1.10.1` leftovers)

Routing smoke checks:

- Japanese current/news query → You.com, `routing_class=multilingual_current`
- Arabic current/news query → You.com, `routing_class=multilingual_current`
- arXiv/academic query → Exa, `routing_class=academic_arxiv`
- CVE/security query → Serper, `routing_class=cve_security`
- Answer/synthesis query → You.com + `answer_mode_recommended=true`
- `postgres table partitioning...` → not misclassified as sports

## Privacy / key safety

This PR does not include real provider keys, `.env`, provider health state, local cache contents, or private runtime data. Examples use placeholders only.