### PR TITLE
feat: add Parallel search and extract provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@
 - Removed `web_answer_plus` from the registered Hermes tool surface and plugin manifest. The plugin now keeps one job: search plus extraction, without a separate answer-synthesis layer.
 - Removed runtime answer-mode metadata (`answer_mode_recommended`) and onboarding answer capability reporting.
 
+### ✨ Added
+- Added Parallel as the 13th search provider and 6th extraction provider using `PARALLEL_API_KEY`. Parallel is available for explicit calls and remains guarded from auto-routing by default via `auto_allow=false`.
+
 ### 🔧 Changed
-- `web_extract_plus(provider="auto")` now uses the benchmark-backed extraction fallback order Tavily → Exa → Linkup → Firecrawl → You.com. Tavily becomes the fast reliable default head; Firecrawl remains the robust scraper safety net rather than the first call.
+- `web_extract_plus(provider="auto")` now uses the benchmark-backed extraction fallback order Tavily → Exa → Linkup → Parallel → Firecrawl → You.com. Tavily becomes the fast reliable default head; Parallel provides a fast excerpt-rich docs fallback; Firecrawl remains the robust scraper safety net rather than the first call.
 
 ### 📚 Docs
 - Updated README, User Guide, FAQ, Architecture, and plugin manifest to describe the two-tool surface: `web_search_plus` and `web_extract_plus`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### 🚀 Major: Routing v2
 - Replaced naive provider-priority auto-routing with benchmarked, class-aware Routing v2 based on the 25-query provider matrix and qualitative provider review.
 - You.com, Serper, Exa, Firecrawl, Tavily, and Linkup now form the conservative default search pool.
-- Brave, SerpBase, Querit, native Perplexity, and Kilo Perplexity default to explicit/guarded use via `auto_allow=false`; existing configs inherit these guarded defaults unless users explicitly opt providers back in.
+- Brave, SerpBase, Querit, Parallel, native Perplexity, and Kilo Perplexity default to explicit/guarded use via `auto_allow=false`; existing configs inherit these guarded defaults unless users explicitly opt providers back in.
 - Added class-aware routing boosts for multilingual current queries, AT/local shopping, GitHub/docs, package/API docs, arXiv/academic queries, Reddit/community searches, CVE/security advisories, official/regulatory queries, finance/IR, weather/local factual lookups, OSS discovery, and answer/synthesis prompts.
 - Search auto-routing now flags answer/synthesis prompts with `answer_mode_recommended` instead of selecting slow answer-only providers such as Kilo Perplexity.
 - Routing diagnostics now expose `language_hint`, `routing_class`, and `routing_policy`.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img alt="Hermes Plugin" src="https://img.shields.io/badge/Hermes-plugin-a78bfa.svg">
 </p>
 
-**Web search and URL extraction for Hermes — now with Routing v2: benchmarked, class-aware auto-routing across the providers your keys can actually support.** `web_extract_plus(provider="auto")` defaults to Tavily-first extraction for fast, reliable fetches; Exa, Linkup, Firecrawl, and You.com remain fallback paths when available.
+**Web search and URL extraction for Hermes — now with Routing v2: benchmarked, class-aware auto-routing across the providers your keys can actually support.** `web_extract_plus(provider="auto")` defaults to Tavily-first extraction for fast, reliable fetches; Exa, Linkup, Firecrawl, Parallel, and You.com remain fallback paths when available.
 
 `web-search-plus` adds two Hermes tools:
 
@@ -27,8 +27,8 @@
 Most web-search tools fail in one of two boring ways: they hard-code a single provider, or they pretend every user has every API key. This plugin is capability-based instead:
 
 - **No global required key.** Configure one search-capable provider and search works.
-- **Extraction is additive.** Add Linkup, Firecrawl, Tavily, Exa, or You.com for URL extraction.
-- **Routing v2 is conservative.** You.com, Serper, Exa, Firecrawl, Tavily, and Linkup form the default search pool; Brave, SerpBase, Querit, and Perplexity/Kilo stay explicit/guarded unless opted in.
+- **Extraction is additive.** Add Linkup, Firecrawl, Tavily, Exa, Parallel, or You.com for URL extraction.
+- **Routing v2 is conservative.** You.com, Serper, Exa, Firecrawl, Tavily, and Linkup form the default search pool; Brave, SerpBase, Querit, Parallel, and Perplexity/Kilo stay explicit/guarded unless opted in.
 - **Costs stay bounded.** Research mode caps provider work and keeps partial results when extraction fails.
 
 ---
@@ -141,8 +141,8 @@ Notes:
 
 | Capability | Unlocks | Configure at least one of |
 |---|---|---|
-| Search | `web_search_plus` | Brave, Serper, Tavily, Exa, Linkup, Firecrawl, Perplexity, Kilo Perplexity, You.com, SearXNG, SerpBase, or Querit |
-| Extraction | `web_extract_plus` | Linkup, Firecrawl, Tavily, Exa, or You.com |
+| Search | `web_search_plus` | Brave, Serper, Tavily, Exa, Linkup, Firecrawl, Parallel, Perplexity, Kilo Perplexity, You.com, SearXNG, SerpBase, or Querit |
+| Extraction | `web_extract_plus` | Linkup, Firecrawl, Tavily, Exa, Parallel, or You.com |
 | Best starter | Search + extraction + reliable fallback | You.com + Serper + Linkup |
 
 `setup.py status --plain` reports this directly:
@@ -182,7 +182,7 @@ Parameters:
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `query` | string | **required** | Search query |
-| `provider` | string | `"auto"` | `auto`, `serper`, `brave`, `tavily`, `exa`, `linkup`, `firecrawl`, `perplexity`, `kilo-perplexity`, `you`, `searxng`, `serpbase`, `querit` |
+| `provider` | string | `"auto"` | `auto`, `serper`, `brave`, `tavily`, `exa`, `linkup`, `firecrawl`, `parallel`, `perplexity`, `kilo-perplexity`, `you`, `searxng`, `serpbase`, `querit` |
 | `depth` | string | `"normal"` | Exa only: `normal`, `deep`, `deep-reasoning` |
 | `count` | integer | `5` | Results, 1–20 |
 | `time_range` | string | — | `day`, `week`, `month`, `year` |
@@ -204,14 +204,14 @@ web_extract_plus(urls=["https://docs.linkup.so"], provider="linkup", render_js=F
 # → Linkup fetch endpoint
 ```
 
-Auto extraction currently tries Tavily, then Exa, Linkup, Firecrawl, and You.com when keys are available. Tavily is the fast reliable default; Exa is the fast docs/academic backup; Linkup stays the clean long-form/RAG fallback; Firecrawl remains the robust scraper safety net; You.com is the final fallback.
+Auto extraction currently tries Tavily, then Exa, Linkup, Parallel, Firecrawl, and You.com when keys are available. Tavily is the fast reliable default; Exa is the fast docs/academic backup; Linkup stays the clean long-form/RAG fallback; Parallel is the excerpt-heavy LLM-ready backup; Firecrawl remains the robust scraper safety net; You.com is the final fallback.
 
 Parameters:
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `urls` | string[] | **required** | URLs to extract |
-| `provider` | string | `"auto"` | `auto`, `firecrawl`, `linkup`, `tavily`, `exa`, `you` |
+| `provider` | string | `"auto"` | `auto`, `firecrawl`, `linkup`, `parallel`, `tavily`, `exa`, `you` |
 | `format` | string | `"markdown"` | `markdown` or `html` |
 | `include_images` | boolean | `false` | Include image metadata when supported |
 | `include_raw_html` | boolean | `false` | Include raw HTML when supported |
@@ -234,9 +234,10 @@ Parameters:
 | Brave | ✅ | — | Independent web index; explicit/guarded by default (`auto_allow=false`) |
 | SearXNG | ✅ | — | Privacy-focused self-hosted metasearch |
 | SerpBase | ✅ | — | Cheap Google-like SERP fallback; explicit/fallback-only by default (`auto_allow=false`) |
+| Parallel | ✅ | ✅ | LLM-ready search and fast extract with long source excerpts; explicit/guarded by default (`auto_allow=false`) |
 | Querit | ✅ | — | Multilingual and real-time queries; explicit/fallback-only by default (`auto_allow=false`) |
 
-Routing v2 is benchmarked and class-aware. It detects language/script hints and query classes such as multilingual current news, AT shopping/local, docs/API, GitHub, academic/arXiv, Reddit/community, CVE/security, official/regulatory, finance/IR, weather/local, OSS discovery, and briefing/synthesis-style searches. You.com, Serper, Exa, Firecrawl, Tavily, and Linkup are the conservative default auto-search pool. Brave, SerpBase, Querit, Perplexity, and Kilo Perplexity default to `auto_allow=false`: configure their keys to call them explicitly, or opt them into automatic routing with `setup.py config set-auto-allow <provider> on`.
+Routing v2 is benchmarked and class-aware. It detects language/script hints and query classes such as multilingual current news, AT shopping/local, docs/API, GitHub, academic/arXiv, Reddit/community, CVE/security, official/regulatory, finance/IR, weather/local, OSS discovery, and briefing/synthesis-style searches. You.com, Serper, Exa, Firecrawl, Tavily, and Linkup are the conservative default auto-search pool. Brave, SerpBase, Querit, Parallel, Perplexity, and Kilo Perplexity default to `auto_allow=false`: configure their keys to call them explicitly, or opt them into automatic routing with `setup.py config set-auto-allow <provider> on`.
 
 ---
 
@@ -256,6 +257,7 @@ PERPLEXITY_API_KEY=***    # https://perplexity.ai/settings/api
 YOU_API_KEY=***           # https://api.you.com — search + extraction
 SEARXNG_INSTANCE_URL=https://your-instance.example.com
 SERPBASE_API_KEY=***      # https://www.serpbase.dev — explicit/fallback-only Google-like SERP search
+PARALLEL_API_KEY=***      # https://platform.parallel.ai — explicit/guarded LLM-ready search + extraction
 QUERIT_API_KEY=***        # https://querit.ai — explicit/fallback-only by default
 
 # Kilo gateway alternate provider (`provider="kilo-perplexity"`)

--- a/__init__.py
+++ b/__init__.py
@@ -35,6 +35,7 @@ _PROVIDER_ENV_KEYS = [
     "PERPLEXITY_API_KEY",
     "KILOCODE_API_KEY",
     "YOU_API_KEY",
+    "PARALLEL_API_KEY",
     "SEARXNG_INSTANCE_URL",
 ]
 _EXTRACT_PROVIDER_ENV_KEYS = [
@@ -43,6 +44,7 @@ _EXTRACT_PROVIDER_ENV_KEYS = [
     "TAVILY_API_KEY",
     "EXA_API_KEY",
     "YOU_API_KEY",
+    "PARALLEL_API_KEY",
 ]
 
 logger = logging.getLogger(__name__)
@@ -126,6 +128,16 @@ _PROVIDER_CATALOG = [
         "free_tier": "1,000 free searches/month",
         "signup_url": "https://querit.com",
         "capabilities": ["search", "multilingual"],
+        "recommended": False,
+    },
+    {
+        "provider": "parallel",
+        "env": "PARALLEL_API_KEY",
+        "display_name": "Parallel",
+        "description": "LLM-ready web search and fast URL extraction with long source excerpts.",
+        "free_tier": "API key required",
+        "signup_url": "https://platform.parallel.ai",
+        "capabilities": ["search", "extract", "citations"],
         "recommended": False,
     },
     {
@@ -261,8 +273,8 @@ def _get_hermes_env_path() -> Path:
 
 
 _SETUP_PROVIDER_NAMES = {item["provider"] for item in _PROVIDER_CATALOG}
-_DEFAULT_PROVIDER_PRIORITY = ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"]
-_DEFAULT_AUTO_ALLOW = {"serpbase": False, "querit": False, "brave": False, "kilo-perplexity": False, "perplexity": False}
+_DEFAULT_PROVIDER_PRIORITY = ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "parallel", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"]
+_DEFAULT_AUTO_ALLOW = {"serpbase": False, "querit": False, "brave": False, "parallel": False, "kilo-perplexity": False, "perplexity": False}
 _ROUTING_PROVIDER_NAMES = set(_DEFAULT_PROVIDER_PRIORITY)
 
 
@@ -328,6 +340,16 @@ def _normalize_provider_csv(value: str, *, routing: bool = True) -> List[str]:
     return providers
 
 
+def _append_missing_default_providers(providers: List[str]) -> List[str]:
+    seen = set(providers)
+    merged = list(providers)
+    for provider in _DEFAULT_PROVIDER_PRIORITY:
+        if provider not in seen:
+            seen.add(provider)
+            merged.append(provider)
+    return merged
+
+
 def _merge_behavior_config(user_config: Mapping[str, Any]) -> Dict[str, Any]:
     config = _default_behavior_config()
     if not isinstance(user_config, Mapping):
@@ -344,9 +366,10 @@ def _merge_behavior_config(user_config: Mapping[str, Any]) -> Dict[str, Any]:
         auto["fallback_provider"] = _normalize_routing_provider(str(auto_user["fallback_provider"]))
     if auto_user.get("provider_priority"):
         if isinstance(auto_user["provider_priority"], str):
-            auto["provider_priority"] = _normalize_provider_csv(auto_user["provider_priority"], routing=True)
+            priority = _normalize_provider_csv(auto_user["provider_priority"], routing=True)
         else:
-            auto["provider_priority"] = _normalize_provider_csv(",".join(str(p) for p in auto_user["provider_priority"]), routing=True)
+            priority = _normalize_provider_csv(",".join(str(p) for p in auto_user["provider_priority"]), routing=True)
+        auto["provider_priority"] = _append_missing_default_providers(priority) if auto.get("enabled", True) is not False else priority
     if "disabled_providers" in auto_user:
         disabled = auto_user.get("disabled_providers") or []
         if isinstance(disabled, str):
@@ -1134,7 +1157,7 @@ def register(ctx: Any) -> None:
                 },
                 "provider": {
                     "type": "string",
-                    "enum": ["auto", "serper", "serpbase", "brave", "tavily", "exa", "querit", "linkup", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng"],
+                    "enum": ["auto", "serper", "serpbase", "brave", "tavily", "exa", "querit", "linkup", "firecrawl", "parallel", "perplexity", "kilo-perplexity", "you", "searxng"],
                     "description": "Search provider. Use 'auto' for intelligent routing (default). Brave and Serper share generic web-search intents and ties are distributed deterministically per query.",
                     "default": "auto",
                 },
@@ -1250,7 +1273,7 @@ def register(ctx: Any) -> None:
             "type": "object",
             "properties": {
                 "urls": {"type": "array", "items": {"type": "string"}, "description": "URLs to extract"},
-                "provider": {"type": "string", "enum": ["auto", "firecrawl", "linkup", "tavily", "exa", "you"], "default": "auto"},
+                "provider": {"type": "string", "enum": ["auto", "firecrawl", "linkup", "parallel", "tavily", "exa", "you"], "default": "auto"},
                 "format": {"type": "string", "enum": ["markdown", "html"], "default": "markdown"},
                 "include_images": {"type": "boolean", "default": False},
                 "include_raw_html": {"type": "boolean", "default": False},

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,12 +57,13 @@ Default routing config includes:
   "auto_routing": {
     "enabled": true,
     "fallback_provider": "serper",
-    "provider_priority": ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"],
+    "provider_priority": ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "parallel", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"],
     "disabled_providers": [],
     "auto_allow": {
       "serpbase": false,
       "querit": false,
       "brave": false,
+      "parallel": false,
       "kilo-perplexity": false,
       "perplexity": false
     },
@@ -101,6 +102,7 @@ Example:
 ```json
 "auto_allow": {
   "serpbase": false,
+  "parallel": false,
   "querit": false,
   "brave": false,
   "kilo-perplexity": false,
@@ -111,9 +113,10 @@ Example:
 With this config:
 
 - `provider="serpbase"` can work when `SERPBASE_API_KEY` is present.
-- `provider="auto"` will not select SerpBase.
-- fallback lists will not silently choose SerpBase.
-- `quality_report` can surface SerpBase under `auto_allow_excluded`.
+- `provider="parallel"` can work when `PARALLEL_API_KEY` is present.
+- `provider="auto"` will not select guarded providers such as SerpBase or Parallel unless opted in.
+- fallback lists will not silently choose guarded providers.
+- `quality_report` can surface guarded providers under `auto_allow_excluded`.
 
 Opt in:
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -24,7 +24,7 @@ python ~/.hermes/plugins/web-search-plus/setup.py config set-auto-allow serpbase
 
 If Routing v2 is enabled, the query analyzer scores providers by query signals such as current-info intent, product/local intent, research language, direct-answer intent, semantic-discovery intent, privacy intent, language/script hints, and class-specific benchmark rules. The router then filters out unavailable, disabled, or `auto_allow=false` providers and chooses the best eligible provider. Ties are deterministic per query.
 
-The default auto-search pool is conservative: You.com, Serper, Exa, Firecrawl, Tavily, and Linkup. Brave, SerpBase, Querit, native Perplexity, and Kilo Perplexity default to explicit/guarded use; Kilo Perplexity is intended for answer/research mode rather than fast search auto-routing.
+The default auto-search pool is conservative: You.com, Serper, Exa, Firecrawl, Tavily, and Linkup. Brave, SerpBase, Querit, Parallel, native Perplexity, and Kilo Perplexity default to explicit/guarded use; Kilo Perplexity is intended for answer/research mode rather than fast search auto-routing.
 
 For the exact flow, see [Architecture](ARCHITECTURE.md#routing-engine).
 
@@ -109,7 +109,7 @@ python ~/.hermes/plugins/web-search-plus/setup.py setup you
 python ~/.hermes/plugins/web-search-plus/setup.py config set-default you
 ```
 
-Extraction requires an extraction-capable provider such as Linkup, Firecrawl, Tavily, Exa, or You.com.
+Extraction requires an extraction-capable provider such as Linkup, Firecrawl, Tavily, Exa, Parallel, or You.com.
 
 ## Can I run fully offline?
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -61,7 +61,7 @@ Presets:
 - `extract`: Firecrawl + Linkup + Exa + Tavily. Extraction-heavy setup.
 - `all`: prompt for every supported provider.
 
-Search-capable providers include You.com, Serper, Exa, Firecrawl, Tavily, Linkup, Brave, Perplexity, Kilo Perplexity, SearXNG, SerpBase, and Querit. Extraction-capable providers are Linkup, Firecrawl, Tavily, Exa, Parallel, and You.com.
+Search-capable providers include You.com, Serper, Exa, Firecrawl, Tavily, Linkup, Parallel, Brave, Perplexity, Kilo Perplexity, SearXNG, SerpBase, and Querit. Extraction-capable providers are Linkup, Firecrawl, Tavily, Exa, Parallel, and You.com.
 
 ### Migration note for v2.0.0
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -61,7 +61,7 @@ Presets:
 - `extract`: Firecrawl + Linkup + Exa + Tavily. Extraction-heavy setup.
 - `all`: prompt for every supported provider.
 
-Search-capable providers include You.com, Serper, Exa, Firecrawl, Tavily, Linkup, Brave, Perplexity, Kilo Perplexity, SearXNG, SerpBase, and Querit. Extraction-capable providers are Linkup, Firecrawl, Tavily, Exa, and You.com.
+Search-capable providers include You.com, Serper, Exa, Firecrawl, Tavily, Linkup, Brave, Perplexity, Kilo Perplexity, SearXNG, SerpBase, and Querit. Extraction-capable providers are Linkup, Firecrawl, Tavily, Exa, Parallel, and You.com.
 
 ### Migration note for v2.0.0
 
@@ -196,7 +196,7 @@ web_search_plus(query="turntable reviews under 1000", mode="research", research_
 
 Important parameters:
 
-- `provider`: `auto`, or a concrete provider such as `you`, `serper`, `exa`, `firecrawl`, `tavily`, `linkup`, `brave`, `perplexity`, `kilo-perplexity`, `searxng`, `serpbase`, or `querit`. Brave, Perplexity/Kilo Perplexity, SerpBase, and Querit are available for explicit calls but default to `auto_allow=false`.
+- `provider`: `auto`, or a concrete provider such as `you`, `serper`, `exa`, `firecrawl`, `tavily`, `linkup`, `brave`, `perplexity`, `kilo-perplexity`, `searxng`, `serpbase`, or `querit`. Brave, Parallel, Perplexity/Kilo Perplexity, SerpBase, and Querit are available for explicit calls but default to `auto_allow=false`.
 - `count`: result count, from 1 to 20.
 - `time_range`: `day`, `week`, `month`, or `year` where supported.
 - `include_domains` / `exclude_domains`: provider-dependent domain filters.
@@ -212,7 +212,7 @@ web_extract_plus(urls=["https://example.com"], provider="firecrawl")
 web_extract_plus(urls=["https://docs.linkup.so"], provider="linkup", render_js=False)
 ```
 
-Auto extraction currently tries Tavily, Exa, Linkup, Firecrawl, and You.com when keys are available. Tavily is the fast reliable default; Exa is the fast docs/academic backup; Linkup stays the clean long-form fallback; Firecrawl remains the robust scraper safety net.
+Auto extraction currently tries Tavily, Exa, Linkup, Firecrawl, Parallel, and You.com when keys are available. Tavily is the fast reliable default; Exa is the fast docs/academic backup; Linkup stays the clean long-form fallback; Firecrawl remains the robust scraper safety net.
 
 ## Reliability and cost controls
 

--- a/search.py
+++ b/search.py
@@ -3,8 +3,8 @@
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
 Version: 2.1.0
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
-Brave Search, SerpBase, Querit, Perplexity, Kilo Perplexity, SearXNG.
-Supports extract providers: Firecrawl, Linkup, Tavily, Exa, You.com.
+Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG.
+Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com.
 
 Smart Routing uses multi-signal analysis:
   - Routing v2 language/script and query-class detection
@@ -294,7 +294,7 @@ DEFAULT_CONFIG = {
         "fallback_provider": "serper",
         # Low-trust / experimental providers can stay configured for explicit use
         # without being selected automatically.
-        "provider_priority": ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"],
+        "provider_priority": ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "parallel", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"],
         "disabled_providers": [],
         "auto_allow": {
             "serpbase": False,
@@ -302,6 +302,7 @@ DEFAULT_CONFIG = {
             "brave": False,
             "kilo-perplexity": False,
             "perplexity": False,
+            "parallel": False,
         },
         "confidence_threshold": 0.3,  # Below this, note low confidence
     },
@@ -339,6 +340,15 @@ DEFAULT_CONFIG = {
         "api_url": "https://api.perplexity.ai/chat/completions",
         "model": "sonar-pro"
     },
+    "parallel": {
+        "api_url": "https://api.parallel.ai/v1/search",
+        "extract_url": "https://api.parallel.ai/v1/extract",
+        "timeout": 45,
+        "extract_timeout": 60,
+        "client_model": None,
+        "max_chars_total": 12000,
+        "max_chars_per_result": 6000
+    },
     "kilo-perplexity": {
         "api_url": "https://api.kilo.ai/api/gateway/chat/completions",
         "model": "perplexity/sonar-pro"
@@ -374,7 +384,7 @@ def _deepcopy_default_config() -> Dict[str, Any]:
     return json.loads(json.dumps(DEFAULT_CONFIG))
 
 
-_ROUTING_PROVIDER_NAMES = {"tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "serpbase", "you", "searxng"}
+_ROUTING_PROVIDER_NAMES = {"tavily", "linkup", "querit", "exa", "firecrawl", "parallel", "perplexity", "kilo-perplexity", "brave", "serper", "serpbase", "you", "searxng"}
 
 
 def _normalize_routing_provider_config(provider: str) -> str:
@@ -408,6 +418,23 @@ def _normalize_routing_provider_list_config(value: Any) -> List[str]:
     return providers
 
 
+def _append_missing_default_providers(providers: List[str]) -> List[str]:
+    """Preserve user ordering while adding newly introduced default providers.
+
+    Existing config.json files often pin provider_priority from an older plugin
+    version. Without this migration, newly added explicit/guarded providers can
+    be valid but invisible to fallback/auto-allow configuration until users
+    manually reset config.
+    """
+    seen = set(providers)
+    merged = list(providers)
+    for provider in DEFAULT_CONFIG["auto_routing"].get("provider_priority", []):
+        if provider not in seen:
+            seen.add(provider)
+            merged.append(provider)
+    return merged
+
+
 def _validate_runtime_config(config: Dict[str, Any]) -> Dict[str, Any]:
     auto = config.get("auto_routing", {})
     if not isinstance(auto, dict):
@@ -417,7 +444,8 @@ def _validate_runtime_config(config: Dict[str, Any]) -> Dict[str, Any]:
     if auto.get("fallback_provider"):
         auto["fallback_provider"] = _normalize_routing_provider_config(str(auto["fallback_provider"]))
     if auto.get("provider_priority"):
-        auto["provider_priority"] = _normalize_routing_provider_list_config(auto["provider_priority"])
+        priority = _normalize_routing_provider_list_config(auto["provider_priority"])
+        auto["provider_priority"] = _append_missing_default_providers(priority) if auto.get("enabled", True) is not False else priority
     if "disabled_providers" in auto:
         disabled = auto.get("disabled_providers") or []
         if disabled:
@@ -526,6 +554,7 @@ def get_api_key(provider: str, config: Dict[str, Any] = None) -> Optional[str]:
         "linkup": "LINKUP_API_KEY",
         "exa": "EXA_API_KEY",
         "you": "YOU_API_KEY",
+        "parallel": "PARALLEL_API_KEY",
         "firecrawl": "FIRECRAWL_API_KEY",
     }
     return os.environ.get(key_map.get(provider, ""))
@@ -662,6 +691,7 @@ def validate_api_key(provider: str, config: Dict[str, Any] = None) -> str:
             "linkup": "https://app.linkup.so",
             "exa": "https://exa.ai",
             "you": "https://api.you.com",
+            "parallel": "https://platform.parallel.ai",
             "perplexity": "https://www.perplexity.ai/settings/api",
             "kilo-perplexity": "https://api.kilo.ai",
             "firecrawl": "https://www.firecrawl.dev/app/api-keys"
@@ -3182,7 +3212,69 @@ def extract_you(
     return {"provider": "you", "results": results}
 
 
-EXTRACT_PROVIDER_PRIORITY = ["tavily", "exa", "linkup", "firecrawl", "you"]
+def extract_parallel(
+    urls: List[str],
+    api_key: str,
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    api_url: str = "https://api.parallel.ai/v1/extract",
+    timeout: int = 60,
+    client_model: Optional[str] = None,
+    max_chars_total: int = 12000,
+    max_chars_per_result: int = 6000,
+) -> dict:
+    """Extract URL content using Parallel Extract.
+
+    Parallel returns excerpts by default; request full_content explicitly and
+    normalize it into the common markdown/content shape. HTML/raw-image options
+    are accepted for tool compatibility but ignored when unsupported upstream.
+    """
+    headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+    body: Dict[str, Any] = {
+        "urls": urls,
+        "max_chars_total": max_chars_total,
+        "advanced_settings": {
+            "full_content": {"max_chars_per_result": max_chars_per_result}
+        },
+    }
+    if client_model:
+        body["client_model"] = client_model
+
+    data = make_request(api_url, headers, body, timeout=timeout)
+    results: List[Dict[str, Any]] = []
+    for item in data.get("results", []) or []:
+        url = item.get("url") or ""
+        excerpts = item.get("excerpts") or []
+        excerpt_text = "\n\n".join(
+            (ex.get("text") or ex.get("content") or "") if isinstance(ex, dict) else str(ex)
+            for ex in excerpts
+        ).strip()
+        content = item.get("full_content") or item.get("markdown") or item.get("content") or excerpt_text
+        results.append(_normalize_extract_result(
+            "parallel",
+            url,
+            title=item.get("title", ""),
+            content=content,
+            raw_content=content,
+            excerpts=excerpts or None,
+            metadata={k: v for k, v in item.items() if k not in {"url", "title", "full_content", "markdown", "content", "excerpts"}},
+        ))
+    for failed in data.get("errors", []) or []:
+        failed_url = failed.get("url", "") if isinstance(failed, dict) else ""
+        results.append(_normalize_extract_result("parallel", failed_url, error=str(failed)))
+    return {
+        "provider": "parallel",
+        "results": results,
+        "metadata": {
+            "search_id": data.get("search_id"),
+            "session_id": data.get("session_id"),
+        },
+    }
+
+
+EXTRACT_PROVIDER_PRIORITY = ["tavily", "exa", "linkup", "parallel", "firecrawl", "you"]
 
 
 def extract_plus(
@@ -3236,6 +3328,16 @@ def extract_plus(
                 if prov == "exa":
                     exa = config.get("exa", {})
                     return extract_exa(urls, key, output_format, include_images, include_raw_html, render_js, api_url=exa.get("contents_url", "https://api.exa.ai/contents"), timeout=int(exa.get("timeout", 30)))
+                if prov == "parallel":
+                    parallel = config.get("parallel", {})
+                    return extract_parallel(
+                        urls, key, output_format, include_images, include_raw_html, render_js,
+                        api_url=parallel.get("extract_url", "https://api.parallel.ai/v1/extract"),
+                        timeout=int(parallel.get("extract_timeout", parallel.get("timeout", 60))),
+                        client_model=parallel.get("client_model"),
+                        max_chars_total=int(parallel.get("max_chars_total", 12000)),
+                        max_chars_per_result=int(parallel.get("max_chars_per_result", 6000)),
+                    )
                 you = config.get("you", {})
                 return extract_you(urls, key, output_format, include_images, include_raw_html, render_js, api_url=you.get("contents_url", "https://ydc-index.io/v1/contents"), timeout=int(you.get("timeout", 30)))
 
@@ -3437,6 +3539,77 @@ def search_exa(
         "results": results,
         "images": [],
         "answer": answer,
+    }
+
+
+# =============================================================================
+# Parallel (LLM-ready web search)
+# =============================================================================
+
+def search_parallel(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    api_url: str = "https://api.parallel.ai/v1/search",
+    timeout: int = 45,
+    client_model: Optional[str] = None,
+) -> dict:
+    """Search using Parallel's web search API.
+
+    Parallel returns source URLs plus long LLM-ready excerpts. Its API does not
+    currently accept a generic max_results parameter, so results are trimmed
+    locally to the requested count.
+    """
+    search_query = query
+    if include_domains:
+        search_query += " " + " ".join(f"site:{domain}" for domain in include_domains)
+    if exclude_domains:
+        search_query += " " + " ".join(f"-site:{domain}" for domain in exclude_domains)
+
+    body: Dict[str, Any] = {
+        "objective": query,
+        "search_queries": [search_query],
+    }
+    if client_model:
+        body["client_model"] = client_model
+
+    headers = {"x-api-key": api_key, "Content-Type": "application/json"}
+    data = make_request(api_url, headers, body, timeout=timeout)
+
+    raw_results = data.get("results") or []
+    results = []
+    for i, item in enumerate(raw_results[:max_results]):
+        excerpts = item.get("excerpts") or []
+        snippet_parts = []
+        for excerpt in excerpts:
+            if isinstance(excerpt, dict):
+                snippet_parts.append(excerpt.get("text") or excerpt.get("content") or "")
+            elif isinstance(excerpt, str):
+                snippet_parts.append(excerpt)
+        snippet = "\n\n".join(part for part in snippet_parts if part).strip()
+        results.append({
+            "title": item.get("title") or _title_from_url(item.get("url", "")),
+            "url": item.get("url", ""),
+            "snippet": snippet,
+            "score": round(1.0 - i * 0.05, 3),
+            "publish_date": item.get("publish_date"),
+            "excerpts": excerpts,
+        })
+
+    answer = " ".join(r.get("snippet", "") for r in results[:3])[:1200]
+    return {
+        "provider": "parallel",
+        "query": query,
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "metadata": {
+            "search_id": data.get("search_id"),
+            "session_id": data.get("session_id"),
+            "result_count_raw": len(raw_results),
+        },
     }
 
 
@@ -3891,7 +4064,7 @@ Full docs: See README.md and SKILL.md
     # Common arguments
     parser.add_argument(
         "--provider", "-p", 
-        choices=["serper", "serpbase", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "perplexity", "kilo-perplexity", "you", "searxng", "auto"],
+        choices=["serper", "serpbase", "brave", "tavily", "linkup", "querit", "exa", "firecrawl", "parallel", "perplexity", "kilo-perplexity", "you", "searxng", "auto"],
         help="Search provider (auto=intelligent routing)"
     )
     parser.add_argument(
@@ -4227,7 +4400,7 @@ Full docs: See README.md and SKILL.md
     
     # Build provider fallback list
     auto_config = config.get("auto_routing", {})
-    provider_priority = auto_config.get("provider_priority", ["tavily", "linkup", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"])
+    provider_priority = auto_config.get("provider_priority", ["tavily", "linkup", "parallel", "exa", "firecrawl", "perplexity", "kilo-perplexity", "brave", "serper", "you", "searxng", "serpbase", "querit"])
     disabled_providers = auto_config.get("disabled_providers", [])
 
     # Start with the selected provider, then try others in priority order.
@@ -4373,6 +4546,18 @@ Full docs: See README.md and SKILL.md
                 ignore_invalid_urls=firecrawl_config.get("ignore_invalid_urls", False),
                 api_url=firecrawl_config.get("api_url", "https://api.firecrawl.dev/v2/search"),
                 timeout_ms=int(firecrawl_config.get("timeout", 30000)),
+            )
+        elif prov == "parallel":
+            parallel_config = config.get("parallel", {})
+            return search_parallel(
+                query=args.query,
+                api_key=key,
+                max_results=args.max_results,
+                include_domains=args.include_domains,
+                exclude_domains=args.exclude_domains,
+                api_url=parallel_config.get("api_url", "https://api.parallel.ai/v1/search"),
+                timeout=int(parallel_config.get("timeout", 45)),
+                client_model=parallel_config.get("client_model"),
             )
         elif prov in {"perplexity", "kilo-perplexity"}:
             perplexity_config = config.get(prov, {})

--- a/tests/test_extract_plus.py
+++ b/tests/test_extract_plus.py
@@ -170,7 +170,7 @@ class ExtractPlusCoreTests(unittest.TestCase):
         mock_exa.assert_called_once()
 
     def test_extract_provider_priority_prefers_fast_clean_extractors(self):
-        self.assertEqual(search.EXTRACT_PROVIDER_PRIORITY, ["tavily", "exa", "linkup", "firecrawl", "you"])
+        self.assertEqual(search.EXTRACT_PROVIDER_PRIORITY, ["tavily", "exa", "linkup", "parallel", "firecrawl", "you"])
 
     def test_extract_plus_auto_prefers_tavily_over_exa(self):
         with mock.patch.dict(os.environ, {"EXA_API_KEY": "exa-test", "TAVILY_API_KEY": "tvly-test"}, clear=True):

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -224,7 +224,7 @@ def test_setup_dry_run_uses_target_env_path_for_dashboard(tmp_path, monkeypatch,
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "Providers: 1/12 configured" in out
+    assert "Providers: 1/13 configured" in out
     assert "Active: You.com" in out
     assert "Brave Search" not in out.split("Setup plan:", 1)[0]
 
@@ -240,7 +240,7 @@ def test_status_uses_target_env_path_for_dashboard(tmp_path, monkeypatch, capsys
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "Providers: 1/12 configured" in out
+    assert "Providers: 1/13 configured" in out
     assert "Active: Linkup" in out
     assert "Brave Search" not in out
 
@@ -327,6 +327,7 @@ def test_config_set_priority_normalizes_and_dedupes_providers(tmp_path, capsys):
 
     data = json.loads(config_path.read_text())
     assert data["auto_routing"]["provider_priority"][:3] == ["tavily", "brave", "linkup"]
+    assert "parallel" in data["auto_routing"]["provider_priority"]
     assert "duplicate provider ignored: tavily" in capsys.readouterr().err
 
 
@@ -364,6 +365,7 @@ def test_default_behavior_config_blocks_low_trust_auto_providers():
     assert config["auto_routing"]["auto_allow"]["serpbase"] is False
     assert config["auto_routing"]["auto_allow"]["querit"] is False
     assert config["auto_routing"]["auto_allow"]["brave"] is False
+    assert config["auto_routing"]["auto_allow"]["parallel"] is False
     assert config["auto_routing"]["auto_allow"]["kilo-perplexity"] is False
     assert config["auto_routing"]["auto_allow"]["perplexity"] is False
 
@@ -381,7 +383,7 @@ def test_setup_dry_run_can_auto_deny_provider(tmp_path, capsys):
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "auto-allow false: brave, kilo-perplexity, perplexity, querit, serpbase" in out
+    assert "auto-allow false: brave, kilo-perplexity, parallel, perplexity, querit, serpbase" in out
     assert not env_path.exists()
     assert not config_path.exists()
 

--- a/tests/test_parallel_provider.py
+++ b/tests/test_parallel_provider.py
@@ -1,0 +1,109 @@
+import importlib.util
+import os
+from pathlib import Path
+from unittest import mock
+
+SEARCH_PATH = Path(__file__).resolve().parents[1] / "search.py"
+search_spec = importlib.util.spec_from_file_location("wsp_search_parallel_under_test", SEARCH_PATH)
+search = importlib.util.module_from_spec(search_spec)
+assert search_spec.loader is not None
+search_spec.loader.exec_module(search)
+
+
+def test_get_api_key_reads_parallel_env():
+    with mock.patch.dict(os.environ, {"PARALLEL_API_KEY": "parallel-test-key"}, clear=False):
+        assert search.get_api_key("parallel", {}) == "parallel-test-key"
+
+
+def test_search_parallel_normalizes_excerpts_and_request_shape():
+    fake_response = {
+        "search_id": "search_123",
+        "session_id": "sess_123",
+        "results": [
+            {
+                "title": "Parallel docs",
+                "url": "https://docs.parallel.ai/search",
+                "excerpts": [{"text": "Search API excerpt."}, {"text": "Second excerpt."}],
+            },
+            {
+                "url": "https://docs.parallel.ai/extract",
+                "excerpts": ["Extract API excerpt."],
+            },
+        ],
+    }
+    with mock.patch.object(search, "make_request", return_value=fake_response) as mock_request:
+        result = search.search_parallel(
+            "Parallel AI Search API",
+            "parallel-test-key",
+            max_results=1,
+            include_domains=["docs.parallel.ai"],
+            exclude_domains=["example.com"],
+        )
+
+    assert result["provider"] == "parallel"
+    assert result["metadata"]["search_id"] == "search_123"
+    assert len(result["results"]) == 1
+    assert result["results"][0]["snippet"] == "Search API excerpt.\n\nSecond excerpt."
+
+    url, headers, body = mock_request.call_args.args[:3]
+    assert url == "https://api.parallel.ai/v1/search"
+    assert headers["x-api-key"] == "parallel-test-key"
+    assert body["objective"] == "Parallel AI Search API"
+    assert body["search_queries"] == ["Parallel AI Search API site:docs.parallel.ai -site:example.com"]
+    assert "max_results" not in body
+
+
+def test_extract_parallel_requests_full_content_and_normalizes_results():
+    fake_response = {
+        "search_id": "extract_123",
+        "results": [
+            {
+                "url": "https://docs.parallel.ai/getting-started/overview",
+                "title": "Overview",
+                "full_content": "Full extracted markdown",
+                "excerpts": [{"text": "Short excerpt"}],
+            }
+        ],
+    }
+    with mock.patch.object(search, "make_request", return_value=fake_response) as mock_request:
+        result = search.extract_parallel(
+            ["https://docs.parallel.ai/getting-started/overview"],
+            "parallel-test-key",
+            max_chars_total=1234,
+            max_chars_per_result=567,
+        )
+
+    assert result["provider"] == "parallel"
+    assert result["metadata"]["search_id"] == "extract_123"
+    item = result["results"][0]
+    assert item["provider"] == "parallel"
+    assert item["title"] == "Overview"
+    assert item["content"] == "Full extracted markdown"
+    assert item["raw_content"] == "Full extracted markdown"
+
+    url, headers, body = mock_request.call_args.args[:3]
+    assert url == "https://api.parallel.ai/v1/extract"
+    assert headers["x-api-key"] == "parallel-test-key"
+    assert body["urls"] == ["https://docs.parallel.ai/getting-started/overview"]
+    assert body["max_chars_total"] == 1234
+    assert body["advanced_settings"]["full_content"]["max_chars_per_result"] == 567
+
+
+def test_parallel_is_explicit_provider_but_blocked_from_auto_by_default():
+    config = search._deepcopy_default_config()
+    assert "parallel" in config["auto_routing"]["provider_priority"]
+    assert config["auto_routing"]["auto_allow"]["parallel"] is False
+
+    with mock.patch.dict(os.environ, {"PARALLEL_API_KEY": "parallel-test-key"}, clear=False):
+        assert search.validate_api_key("parallel", config) == "parallel-test-key"
+
+
+def test_existing_priority_config_appends_parallel_for_migration():
+    config = search._deepcopy_default_config()
+    config["auto_routing"]["provider_priority"] = ["tavily", "linkup", "serper"]
+
+    migrated = search._validate_runtime_config(config)
+
+    priority = migrated["auto_routing"]["provider_priority"]
+    assert priority[:3] == ["tavily", "linkup", "serper"]
+    assert "parallel" in priority


### PR DESCRIPTION
## Summary
- Adds Parallel as an explicit/guarded search provider and URL extraction provider.
- Wires `PARALLEL_API_KEY` into setup/status metadata, runtime provider schemas, config defaults, and docs.
- Keeps Parallel out of automatic routing by default via `auto_allow=false` while appending it to provider priority for explicit availability and config migrations.
- Updates extraction fallback order to `tavily -> exa -> linkup -> parallel -> firecrawl -> you`.

## Validation
- `PYTHONPATH=$PWD python3 -m py_compile search.py __init__.py setup.py`
- `PYTHONPATH=$PWD python3 -m pytest -q` → 143 passed
- `git diff --check`
- Privacy scan over changed public files for raw keys/private paths/agent names
- Live Parallel search smoke with `PARALLEL_API_KEY`: provider `parallel`, 5 results, first domain `docs.parallel.ai`
- Live Parallel extraction smoke on `https://docs.parallel.ai/task-api/task-quickstart`: extracted title `docs.parallel.ai — task quickstart`, content includes `Task API`

## Notes
Parallel search worked well for docs/API queries but was slower than the fastest search providers in local comparison, so this PR intentionally keeps it guarded for explicit use unless a user opts it into auto-routing. Parallel extraction was fast and useful on documentation pages, making it a good fallback between Linkup and Firecrawl.
