### PR TITLE
refactor: extract shared HTTP client helpers

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -1,0 +1,149 @@
+"""Shared HTTP client helpers for Web Search Plus providers."""
+
+from http.client import IncompleteRead
+import gzip
+import json
+import zlib
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+TRANSIENT_HTTP_CODES = {429, 503}
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.1"
+
+
+class ProviderRequestError(Exception):
+    """Structured provider error with retry/cooldown metadata."""
+
+    def __init__(self, message: str, status_code: int | None = None, transient: bool = False):
+        super().__init__(message)
+        self.status_code = status_code
+        self.transient = transient
+
+
+def _response_header(response, name: str) -> str:
+    """Return an HTTP response header from urllib response/error objects."""
+    if hasattr(response, "getheader"):
+        value = response.getheader(name)
+        if value is not None:
+            return str(value)
+    headers = getattr(response, "headers", None)
+    if headers is not None:
+        try:
+            value = headers.get(name)
+        except AttributeError:
+            value = None
+        if value is not None:
+            return str(value)
+    return ""
+
+
+def _read_response_body(response) -> bytes:
+    """Read an urllib response body and decode supported Content-Encoding values."""
+    raw = response.read()
+    encoding = _response_header(response, "Content-Encoding").strip().lower()
+
+    if encoding in {"gzip", "x-gzip"} or raw.startswith(b"\x1f\x8b"):
+        return gzip.decompress(raw)
+    if encoding == "deflate":
+        try:
+            return zlib.decompress(raw)
+        except zlib.error:
+            # Some servers send raw deflate without the zlib wrapper.
+            return zlib.decompress(raw, -zlib.MAX_WBITS)
+    if encoding == "br":
+        raise ProviderRequestError(
+            "Brotli-compressed response received, but web-search-plus does not bundle brotli support. "
+            "Disable brotli for this provider or install a brotli-capable transport.",
+            transient=False,
+        )
+    return raw
+
+
+def _read_json_response(response) -> dict:
+    """Read an urllib response as UTF-8 JSON with Content-Encoding handling."""
+    return json.loads(_read_response_body(response).decode("utf-8"))
+
+
+def _friendly_http_error(code: int, error_detail: str) -> str:
+    error_messages = {
+        401: "Invalid or expired API key. Please check your credentials.",
+        403: "Access forbidden. Your API key may not have permission for this operation.",
+        429: "Rate limit exceeded. Please wait a moment and try again.",
+        500: "Server error. The search provider is experiencing issues.",
+        503: "Service unavailable. The search provider may be down.",
+    }
+    return error_messages.get(code, f"API error: {error_detail}")
+
+
+def _extract_http_error_detail(error: HTTPError) -> str:
+    error_body = _read_response_body(error).decode("utf-8") if error.fp else str(error)
+    try:
+        error_json = json.loads(error_body)
+        return error_json.get("error") or error_json.get("message") or error_body
+    except json.JSONDecodeError:
+        return error_body[:500]
+
+
+def _raise_provider_http_error(error: HTTPError) -> None:
+    error_detail = _extract_http_error_detail(error)
+    friendly_msg = _friendly_http_error(error.code, error_detail)
+    raise ProviderRequestError(
+        f"{friendly_msg} (HTTP {error.code})",
+        status_code=error.code,
+        transient=error.code in TRANSIENT_HTTP_CODES,
+    )
+
+
+def make_request(url: str, headers: dict, body: dict, timeout: int = 30) -> dict:
+    """Make HTTP POST request and return JSON response."""
+    # Ensure User-Agent is set (required by some APIs like Exa/Cloudflare)
+    if "User-Agent" not in headers:
+        headers["User-Agent"] = DEFAULT_USER_AGENT
+    data = json.dumps(body).encode("utf-8")
+    req = Request(url, data=data, headers=headers, method="POST")
+
+    try:
+        with urlopen(req, timeout=timeout) as response:
+            return _read_json_response(response)
+    except HTTPError as e:
+        _raise_provider_http_error(e)
+        raise
+    except URLError as e:
+        reason = str(getattr(e, "reason", e))
+        is_timeout = "timed out" in reason.lower()
+        raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
+    except IncompleteRead as e:
+        partial_len = len(getattr(e, "partial", b"") or b"")
+        raise ProviderRequestError(
+            f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
+            transient=True,
+        )
+    except TimeoutError:
+        raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)
+
+
+def make_get_request(url: str, headers: dict, timeout: int = 30) -> dict:
+    """Make HTTP GET request and return JSON response."""
+    if "User-Agent" not in headers:
+        headers["User-Agent"] = DEFAULT_USER_AGENT
+    req = Request(url, headers=headers, method="GET")
+
+    try:
+        with urlopen(req, timeout=timeout) as response:
+            return _read_json_response(response)
+    except HTTPError as e:
+        _raise_provider_http_error(e)
+        raise
+    except URLError as e:
+        reason = str(getattr(e, "reason", e))
+        is_timeout = "timed out" in reason.lower()
+        raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
+    except IncompleteRead as e:
+        partial_len = len(getattr(e, "partial", b"") or b"")
+        raise ProviderRequestError(
+            f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
+            transient=True,
+        )
+    except TimeoutError:
+        raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)

--- a/search.py
+++ b/search.py
@@ -26,20 +26,25 @@ Examples:
 
 import argparse
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from http.client import IncompleteRead
-import gzip
 import hashlib
 import json
 import os
 import re
 import sys
 import time
-import zlib
 from pathlib import Path
 from typing import Optional, List, Dict, Any, Tuple
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError, URLError
 from urllib.parse import quote, urlencode, urlparse, parse_qsl, urlunparse
+from http_client import (
+    ProviderRequestError,
+    TRANSIENT_HTTP_CODES,
+    _read_json_response,
+    _read_response_body,
+    make_get_request,
+    make_request,
+)
 
 ROUTING_POLICY = "routing-v2"
 
@@ -1832,16 +1837,7 @@ class ProviderConfigError(Exception):
     pass
 
 
-class ProviderRequestError(Exception):
-    """Structured provider error with retry/cooldown metadata."""
 
-    def __init__(self, message: str, status_code: Optional[int] = None, transient: bool = False):
-        super().__init__(message)
-        self.status_code = status_code
-        self.transient = transient
-
-
-TRANSIENT_HTTP_CODES = {429, 503}
 COOLDOWN_STEPS_SECONDS = [60, 300, 1500, 3600]  # 1m -> 5m -> 25m -> 1h cap
 RETRY_BACKOFF_SECONDS = [1, 3, 9]
 
@@ -2241,133 +2237,6 @@ def execute_provider_with_retry(provider: str, operation, max_attempts: int = 3)
             break
     raise last_error if last_error else Exception(f"Unknown {provider} provider execution error")
 
-
-def _response_header(response, name: str) -> str:
-    """Return an HTTP response header from urllib response/error objects."""
-    if hasattr(response, "getheader"):
-        value = response.getheader(name)
-        if value is not None:
-            return str(value)
-    headers = getattr(response, "headers", None)
-    if headers is not None:
-        try:
-            value = headers.get(name)
-        except AttributeError:
-            value = None
-        if value is not None:
-            return str(value)
-    return ""
-
-
-def _read_response_body(response) -> bytes:
-    """Read an urllib response body and decode supported Content-Encoding values."""
-    raw = response.read()
-    encoding = _response_header(response, "Content-Encoding").strip().lower()
-
-    if encoding in {"gzip", "x-gzip"} or raw.startswith(b"\x1f\x8b"):
-        return gzip.decompress(raw)
-    if encoding == "deflate":
-        try:
-            return zlib.decompress(raw)
-        except zlib.error:
-            # Some servers send raw deflate without the zlib wrapper.
-            return zlib.decompress(raw, -zlib.MAX_WBITS)
-    if encoding == "br":
-        raise ProviderRequestError(
-            "Brotli-compressed response received, but web-search-plus does not bundle brotli support. "
-            "Disable brotli for this provider or install a brotli-capable transport.",
-            transient=False,
-        )
-    return raw
-
-
-def _read_json_response(response) -> dict:
-    """Read an urllib response as UTF-8 JSON with Content-Encoding handling."""
-    return json.loads(_read_response_body(response).decode("utf-8"))
-
-
-def make_request(url: str, headers: dict, body: dict, timeout: int = 30) -> dict:
-    """Make HTTP POST request and return JSON response."""
-    # Ensure User-Agent is set (required by some APIs like Exa/Cloudflare)
-    if "User-Agent" not in headers:
-        headers["User-Agent"] = "ClawdBot-WebSearchPlus/2.1"
-    data = json.dumps(body).encode("utf-8")
-    req = Request(url, data=data, headers=headers, method="POST")
-    
-    try:
-        with urlopen(req, timeout=timeout) as response:
-            return _read_json_response(response)
-    except HTTPError as e:
-        error_body = _read_response_body(e).decode("utf-8") if e.fp else str(e)
-        try:
-            error_json = json.loads(error_body)
-            error_detail = error_json.get("error") or error_json.get("message") or error_body
-        except json.JSONDecodeError:
-            error_detail = error_body[:500]
-        
-        error_messages = {
-            401: "Invalid or expired API key. Please check your credentials.",
-            403: "Access forbidden. Your API key may not have permission for this operation.",
-            429: "Rate limit exceeded. Please wait a moment and try again.",
-            500: "Server error. The search provider is experiencing issues.",
-            503: "Service unavailable. The search provider may be down."
-        }
-        
-        friendly_msg = error_messages.get(e.code, f"API error: {error_detail}")
-        raise ProviderRequestError(f"{friendly_msg} (HTTP {e.code})", status_code=e.code, transient=e.code in TRANSIENT_HTTP_CODES)
-    except URLError as e:
-        reason = str(getattr(e, "reason", e))
-        is_timeout = "timed out" in reason.lower()
-        raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
-    except IncompleteRead as e:
-        partial_len = len(getattr(e, "partial", b"") or b"")
-        raise ProviderRequestError(
-            f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
-            transient=True,
-        )
-    except TimeoutError:
-        raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)
-
-
-def make_get_request(url: str, headers: dict, timeout: int = 30) -> dict:
-    """Make HTTP GET request and return JSON response."""
-    if "User-Agent" not in headers:
-        headers["User-Agent"] = "ClawdBot-WebSearchPlus/2.1"
-    req = Request(url, headers=headers, method="GET")
-
-    try:
-        with urlopen(req, timeout=timeout) as response:
-            return _read_json_response(response)
-    except HTTPError as e:
-        error_body = _read_response_body(e).decode("utf-8") if e.fp else str(e)
-        try:
-            error_json = json.loads(error_body)
-            error_detail = error_json.get("error") or error_json.get("message") or error_body
-        except json.JSONDecodeError:
-            error_detail = error_body[:500]
-
-        error_messages = {
-            401: "Invalid or expired API key. Please check your credentials.",
-            403: "Access forbidden. Your API key may not have permission for this operation.",
-            429: "Rate limit exceeded. Please wait a moment and try again.",
-            500: "Server error. The search provider is experiencing issues.",
-            503: "Service unavailable. The search provider may be down."
-        }
-
-        friendly_msg = error_messages.get(e.code, f"API error: {error_detail}")
-        raise ProviderRequestError(f"{friendly_msg} (HTTP {e.code})", status_code=e.code, transient=e.code in TRANSIENT_HTTP_CODES)
-    except URLError as e:
-        reason = str(getattr(e, "reason", e))
-        is_timeout = "timed out" in reason.lower()
-        raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
-    except IncompleteRead as e:
-        partial_len = len(getattr(e, "partial", b"") or b"")
-        raise ProviderRequestError(
-            f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
-            transient=True,
-        )
-    except TimeoutError:
-        raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)
 
 
 # =============================================================================

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -1,0 +1,44 @@
+import gzip
+import json
+from unittest import mock
+
+import http_client
+
+
+class FakeResponse:
+    def __init__(self, body: bytes, headers=None):
+        self._body = body
+        self.headers = headers or {}
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_http_client_make_get_request_handles_gzip_urllib_response():
+    body = {"web": {"results": [{"title": "Brave works"}]}}
+    compressed = gzip.compress(json.dumps(body).encode("utf-8"))
+
+    with mock.patch(
+        "http_client.urlopen",
+        return_value=FakeResponse(compressed, {"Content-Encoding": "gzip"}),
+    ):
+        result = http_client.make_get_request(
+            "https://api.search.brave.com/res/v1/web/search?q=test",
+            {"Accept": "application/json", "X-Subscription-Token": "test"},
+        )
+
+    assert result == body
+
+
+def test_http_client_provider_request_error_exports_retry_metadata():
+    error = http_client.ProviderRequestError("down", status_code=503, transient=True)
+
+    assert str(error) == "down"
+    assert error.status_code == 503
+    assert error.transient is True

--- a/tests/test_http_content_encoding.py
+++ b/tests/test_http_content_encoding.py
@@ -59,7 +59,7 @@ class HttpContentEncodingTests(unittest.TestCase):
         compressed = gzip.compress(json.dumps(body).encode("utf-8"))
 
         with mock.patch(
-            "search.urlopen",
+            "http_client.urlopen",
             return_value=FakeResponse(compressed, {"Content-Encoding": "gzip"}),
         ):
             result = search.make_get_request(
@@ -74,7 +74,7 @@ class HttpContentEncodingTests(unittest.TestCase):
         compressed = gzip.compress(json.dumps(body).encode("utf-8"))
 
         with mock.patch(
-            "search.urlopen",
+            "http_client.urlopen",
             return_value=FakeResponse(compressed, {"Content-Encoding": "gzip"}),
         ):
             result = search.make_request(


### PR DESCRIPTION
## Summary
- Extract shared provider HTTP request helpers into `http_client.py`
- Keep `search.py` compatibility by importing the same helper names
- Move gzip/deflate/error-path tests to patch the new module boundary

## Test Plan
- `python3 -m pytest tests/test_http_client_module.py tests/test_http_content_encoding.py -q` → 7 passed
- `python3 -m pytest tests/ -q` → 145 passed
- `python3 -m py_compile search.py http_client.py __init__.py scripts/golden_eval.py`
- `ruff check .`
- `git diff --check`
- Live smoke: auto search returned 3 results via You.com, first URL `https://mistral.ai/news/mistral-3`
- Live smoke: Tavily extraction of `https://example.com` returned 1 usable result

## Notes
This is PR 1 of the search.py split. It intentionally avoids routing/provider/extraction behavior changes beyond moving the shared HTTP helpers.
