### PR TITLE
feat: add provider doctor diagnostics

### DIFF
--- a/search.py
+++ b/search.py
@@ -40,6 +40,7 @@ from http_client import (  # noqa: F401 - re-exported for backward-compatible te
     make_request,
 )
 from cache import (
+    CACHE_DIR,
     DEFAULT_CACHE_TTL,
     cache_clear,
     cache_get,
@@ -430,13 +431,90 @@ def _sync_extract_dependencies() -> None:
 EXTRACT_PROVIDER_PRIORITY = _extract.EXTRACT_PROVIDER_PRIORITY
 
 
+PROVIDER_DOCTOR_CATALOG = {
+    "serper": {"env_var": "SERPER_API_KEY", "search_capable": True, "extract_capable": False},
+    "serpbase": {"env_var": "SERPBASE_API_KEY", "search_capable": True, "extract_capable": False},
+    "brave": {"env_var": "BRAVE_API_KEY", "search_capable": True, "extract_capable": False},
+    "tavily": {"env_var": "TAVILY_API_KEY", "search_capable": True, "extract_capable": True},
+    "querit": {"env_var": "QUERIT_API_KEY", "search_capable": True, "extract_capable": False},
+    "linkup": {"env_var": "LINKUP_API_KEY", "search_capable": True, "extract_capable": True},
+    "exa": {"env_var": "EXA_API_KEY", "search_capable": True, "extract_capable": True},
+    "firecrawl": {"env_var": "FIRECRAWL_API_KEY", "search_capable": True, "extract_capable": True},
+    "parallel": {"env_var": "PARALLEL_API_KEY", "search_capable": True, "extract_capable": True},
+    "perplexity": {"env_var": "PERPLEXITY_API_KEY", "search_capable": True, "extract_capable": False},
+    "kilo-perplexity": {"env_var": "KILOCODE_API_KEY", "search_capable": True, "extract_capable": False},
+    "you": {"env_var": "YOU_API_KEY", "search_capable": True, "extract_capable": True},
+    "searxng": {"env_var": "SEARXNG_INSTANCE_URL", "search_capable": True, "extract_capable": False},
+}
+
+
 def extract_plus(*args, **kwargs):
     _sync_extract_dependencies()
     return _extract.extract_plus(*args, **kwargs)
 
+
+def _build_doctor_report(config: Dict[str, Any], *, live: bool = False) -> Dict[str, Any]:
+    auto_config = config.get("auto_routing", {})
+    disabled = set(auto_config.get("disabled_providers", []) or [])
+    providers = []
+    for provider, spec in PROVIDER_DOCTOR_CATALOG.items():
+        in_cooldown, remaining = provider_in_cooldown(provider)
+        providers.append({
+            "provider": provider,
+            "env_var": spec["env_var"],
+            "search_capable": spec["search_capable"],
+            "extract_capable": spec["extract_capable"],
+            "key_present": bool(get_api_key(provider, config)),
+            "auto_allowed": _provider_auto_allowed(provider, auto_config),
+            "disabled": provider in disabled,
+            "cooldown": {"active": bool(in_cooldown), "remaining_seconds": int(remaining)},
+        })
+
+    usable = [p for p in providers if p["key_present"] and not p["disabled"]]
+    return {
+        "ok": bool(usable),
+        "mode": "live" if live else "offline",
+        "config": {
+            "auto_routing_enabled": auto_config.get("enabled", True),
+            "default_provider": config.get("default_provider"),
+            "fallback_provider": auto_config.get("fallback_provider"),
+            "disabled_providers": sorted(disabled),
+        },
+        "cache": {
+            "dir": str(CACHE_DIR),
+            "exists": CACHE_DIR.exists(),
+            "writable": os.access(CACHE_DIR if CACHE_DIR.exists() else CACHE_DIR.parent, os.W_OK),
+            "provider_health_file": str(CACHE_DIR / "provider_health.json"),
+        },
+        "providers": providers,
+    }
+
+
+def _format_doctor_text(report: Dict[str, Any]) -> str:
+    lines = ["Web Search Plus Doctor", f"Mode: {report['mode']}", f"OK: {report['ok']}", "", "Providers:"]
+    for provider in report["providers"]:
+        capabilities = []
+        if provider["search_capable"]:
+            capabilities.append("search")
+        if provider["extract_capable"]:
+            capabilities.append("extract")
+        cooldown = provider["cooldown"]
+        cooldown_text = f"cooldown {cooldown['remaining_seconds']}s" if cooldown["active"] else "no cooldown"
+        lines.append(
+            f"- {provider['provider']}: env={provider['env_var']} "
+            f"key={'yes' if provider['key_present'] else 'no'} "
+            f"capabilities={','.join(capabilities)} "
+            f"auto_allowed={'yes' if provider['auto_allowed'] else 'no'} "
+            f"disabled={'yes' if provider['disabled'] else 'no'} "
+            f"{cooldown_text}"
+        )
+    lines.extend(["", f"Cache: {report['cache']['dir']} (writable={report['cache']['writable']})"])
+    return "\n".join(lines)
+
+
 def main():
     config = load_config()
-    
+
     parser = argparse.ArgumentParser(
         description="Web Search Plus — Intelligent multi-provider search with smart auto-routing",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -469,6 +547,16 @@ Full docs: See README.md and SKILL.md
         """,
     )
     
+    # Command arguments
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=["doctor"],
+        help="Run a maintenance command such as 'doctor'",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON for maintenance commands")
+    parser.add_argument("--live", action="store_true", help="Allow doctor to run live provider smokes (reserved; offline by default)")
+
     # Common arguments
     parser.add_argument(
         "--provider", "-p", 
@@ -735,6 +823,15 @@ Full docs: See README.md and SKILL.md
     )
     
     args = parser.parse_args()
+
+    if args.command == "doctor":
+        report = _build_doctor_report(config, live=args.live)
+        if args.json or args.compact:
+            indent = None if args.compact else 2
+            print(json.dumps(report, indent=indent, ensure_ascii=False))
+        else:
+            print(_format_doctor_text(report))
+        return
     
     # Handle cache management commands first (before query validation)
     if args.clear_cache:

--- a/tests/test_doctor_command.py
+++ b/tests/test_doctor_command.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+SEARCH_PATH = Path(__file__).resolve().parents[1] / "search.py"
+search_spec = importlib.util.spec_from_file_location("wsp_search_doctor_under_test", SEARCH_PATH)
+search = importlib.util.module_from_spec(search_spec)
+assert search_spec.loader is not None
+search_spec.loader.exec_module(search)
+
+
+PROVIDER_ENV_VARS = [
+    "SERPER_API_KEY",
+    "SERPBASE_API_KEY",
+    "BRAVE_API_KEY",
+    "TAVILY_API_KEY",
+    "QUERIT_API_KEY",
+    "LINKUP_API_KEY",
+    "EXA_API_KEY",
+    "YOU_API_KEY",
+    "PARALLEL_API_KEY",
+    "PERPLEXITY_API_KEY",
+    "KILOCODE_API_KEY",
+    "FIRECRAWL_API_KEY",
+    "SEARXNG_INSTANCE_URL",
+]
+
+
+def _clear_provider_env(monkeypatch):
+    for name in PROVIDER_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_doctor_json_reports_provider_capabilities_without_secrets(monkeypatch, tmp_path, capsys):
+    _clear_provider_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"version": 1, "auto_routing": {"disabled_providers": ["brave"]}}))
+    monkeypatch.setenv("WEB_SEARCH_PLUS_CONFIG", str(config_path))
+    monkeypatch.setenv("SERPER_API_KEY", "very-sensitive-serper-secret")
+    monkeypatch.setenv("TAVILY_API_KEY", "very-sensitive-tavily-secret")
+    monkeypatch.setattr(search, "provider_in_cooldown", lambda _provider: (False, 0))
+    monkeypatch.setattr(sys, "argv", ["search.py", "doctor", "--json"])
+
+    search.main()
+
+    stdout = capsys.readouterr().out
+    data = json.loads(stdout)
+    assert data["ok"] is True
+    assert data["mode"] == "offline"
+    assert "very-sensitive" not in stdout
+
+    providers = {provider["provider"]: provider for provider in data["providers"]}
+    assert providers["serper"] == {
+        "provider": "serper",
+        "env_var": "SERPER_API_KEY",
+        "search_capable": True,
+        "extract_capable": False,
+        "key_present": True,
+        "auto_allowed": True,
+        "disabled": False,
+        "cooldown": {"active": False, "remaining_seconds": 0},
+    }
+    assert providers["tavily"]["search_capable"] is True
+    assert providers["tavily"]["extract_capable"] is True
+    assert providers["tavily"]["key_present"] is True
+    assert providers["brave"]["disabled"] is True
+
+
+def test_doctor_json_reports_provider_cooldowns(monkeypatch, tmp_path, capsys):
+    _clear_provider_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"version": 1}))
+    monkeypatch.setenv("WEB_SEARCH_PLUS_CONFIG", str(config_path))
+    monkeypatch.setenv("SERPER_API_KEY", "very-sensitive-serper-secret")
+    monkeypatch.setattr(search, "provider_in_cooldown", lambda provider: (provider == "serper", 42 if provider == "serper" else 0))
+    monkeypatch.setattr(sys, "argv", ["search.py", "doctor", "--json"])
+
+    search.main()
+
+    data = json.loads(capsys.readouterr().out)
+    providers = {provider["provider"]: provider for provider in data["providers"]}
+    assert providers["serper"]["cooldown"] == {"active": True, "remaining_seconds": 42}
+
+
+def test_doctor_plain_text_is_human_readable(monkeypatch, tmp_path, capsys):
+    _clear_provider_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"version": 1}))
+    monkeypatch.setenv("WEB_SEARCH_PLUS_CONFIG", str(config_path))
+    monkeypatch.setenv("SERPER_API_KEY", "very-sensitive-serper-secret")
+    monkeypatch.setattr(search, "provider_in_cooldown", lambda _provider: (False, 0))
+    monkeypatch.setattr(sys, "argv", ["search.py", "doctor"])
+
+    search.main()
+
+    stdout = capsys.readouterr().out
+    assert "Web Search Plus Doctor" in stdout
+    assert "serper" in stdout
+    assert "SERPER_API_KEY" in stdout
+    assert "very-sensitive" not in stdout


### PR DESCRIPTION
## Summary
- Add `python search.py doctor` for offline provider/setup diagnostics.
- Add `--json` output for machine-readable diagnostics and compact support.
- Report provider capabilities, key presence, auto-allow/disabled state, cooldowns, and cache writability without printing secrets.
- Reserve `--live` as an explicit future/live-smoke mode while keeping the current command offline by default.

## Test Plan
- [x] `python3 -m ruff check .`
- [x] `python3 -m pytest tests/ -q` — 168 passed
- [x] `python3 -m py_compile search.py __init__.py http_client.py cache.py config.py provider_health.py quality.py research.py routing.py providers.py extract.py scripts/golden_eval.py`
- [x] `git diff --check origin/main...HEAD`
- [x] `python3 search.py doctor --json`
- [x] `python3 search.py doctor`
- [x] Changed-diff privacy/private-agent scan

## Notes
- This follows the provider/extract contract-test PR by adding a user-facing diagnostics layer for setup and routing support.
- No provider behavior, routing policy, extraction order, or public Hermes tool schema changes are intended.
