### PR TITLE
Fix doctor robustness for provider errors

### DIFF
--- a/search.py
+++ b/search.py
@@ -453,26 +453,65 @@ def extract_plus(*args, **kwargs):
     return _extract.extract_plus(*args, **kwargs)
 
 
+def _doctor_error(error_type: str, message: str) -> Dict[str, str]:
+    """Return a deliberately sanitized doctor error.
+
+    Doctor output is often pasted into issues/support chats. Keep it useful without
+    echoing private URLs, filesystem paths, tokens, or corrupt raw cache values.
+    """
+    safe_messages = {
+        "config": "Provider configuration is invalid; inspect local config/env for this provider.",
+        "cooldown": "Provider health cache has an invalid cooldown entry; reset provider health cache if it persists.",
+    }
+    return {"type": error_type, "message": safe_messages.get(error_type, "Provider diagnostic failed.")}
+
+
+def _doctor_provider_has_error_type(provider_report: Dict[str, Any], error_type: str) -> bool:
+    error = provider_report.get("error")
+    if isinstance(error, dict):
+        return error.get("type") == error_type
+    if isinstance(error, list):
+        return any(isinstance(item, dict) and item.get("type") == error_type for item in error)
+    return False
+
+
 def _build_doctor_report(config: Dict[str, Any], *, live: bool = False) -> Dict[str, Any]:
     auto_config = config.get("auto_routing", {})
     disabled = set(auto_config.get("disabled_providers", []) or [])
     providers = []
     for provider, spec in PROVIDER_DOCTOR_CATALOG.items():
-        in_cooldown, remaining = provider_in_cooldown(provider)
-        providers.append({
+        errors = []
+        try:
+            in_cooldown, remaining = provider_in_cooldown(provider)
+            cooldown = {"active": bool(in_cooldown), "remaining_seconds": int(remaining)}
+        except (TypeError, ValueError):
+            cooldown = {"active": False, "remaining_seconds": 0}
+            errors.append(_doctor_error("cooldown", "invalid provider health cache value"))
+
+        try:
+            key_present = bool(get_api_key(provider, config))
+        except (ProviderConfigError, ValueError):
+            key_present = False
+            errors.append(_doctor_error("config", "invalid provider configuration"))
+
+        provider_report = {
             "provider": provider,
             "env_var": spec["env_var"],
             "search_capable": spec["search_capable"],
             "extract_capable": spec["extract_capable"],
-            "key_present": bool(get_api_key(provider, config)),
+            "key_present": key_present,
             "auto_allowed": _provider_auto_allowed(provider, auto_config),
             "disabled": provider in disabled,
-            "cooldown": {"active": bool(in_cooldown), "remaining_seconds": int(remaining)},
-        })
+            "cooldown": cooldown,
+        }
+        if errors:
+            provider_report["error"] = errors[0] if len(errors) == 1 else errors
+        providers.append(provider_report)
 
     usable = [p for p in providers if p["key_present"] and not p["disabled"]]
+    config_errors = [p for p in providers if _doctor_provider_has_error_type(p, "config")]
     return {
-        "ok": bool(usable),
+        "ok": bool(usable) and not config_errors,
         "mode": "live" if live else "offline",
         "config": {
             "auto_routing_enabled": auto_config.get("enabled", True),

--- a/tests/test_doctor_command.py
+++ b/tests/test_doctor_command.py
@@ -102,3 +102,49 @@ def test_doctor_plain_text_is_human_readable(monkeypatch, tmp_path, capsys):
     assert "serper" in stdout
     assert "SERPER_API_KEY" in stdout
     assert "very-sensitive" not in stdout
+
+
+def test_doctor_reports_provider_config_errors_without_crashing(monkeypatch, tmp_path, capsys):
+    _clear_provider_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"version": 1, "searxng": {"instance_url": "http://127.0.0.1:8888"}}))
+    monkeypatch.setenv("WEB_SEARCH_PLUS_CONFIG", str(config_path))
+    monkeypatch.delenv("SEARXNG_ALLOW_PRIVATE", raising=False)
+    monkeypatch.setattr(search, "provider_in_cooldown", lambda _provider: (False, 0))
+    monkeypatch.setattr(sys, "argv", ["search.py", "doctor", "--json"])
+
+    search.main()
+
+    data = json.loads(capsys.readouterr().out)
+    providers = {provider["provider"]: provider for provider in data["providers"]}
+    assert data["ok"] is False
+    assert providers["searxng"]["key_present"] is False
+    assert providers["searxng"]["error"]["type"] == "config"
+    assert "127.0.0.1" not in providers["searxng"]["error"]["message"]
+
+
+def test_doctor_reports_cooldown_errors_without_crashing(monkeypatch, tmp_path, capsys):
+    _clear_provider_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"version": 1}))
+    monkeypatch.setenv("WEB_SEARCH_PLUS_CONFIG", str(config_path))
+    monkeypatch.setenv("SERPER_API_KEY", "very-sensitive-serper-secret")
+
+    def broken_cooldown(provider):
+        if provider == "serper":
+            raise ValueError("invalid literal for int() with base 10: 'not-int'")
+        return False, 0
+
+    monkeypatch.setattr(search, "provider_in_cooldown", broken_cooldown)
+    monkeypatch.setattr(sys, "argv", ["search.py", "doctor", "--json"])
+
+    search.main()
+
+    stdout = capsys.readouterr().out
+    data = json.loads(stdout)
+    providers = {provider["provider"]: provider for provider in data["providers"]}
+    assert data["ok"] is True
+    assert providers["serper"]["key_present"] is True
+    assert providers["serper"]["cooldown"] == {"active": False, "remaining_seconds": 0}
+    assert providers["serper"]["error"]["type"] == "cooldown"
+    assert "not-int" not in stdout


### PR DESCRIPTION
## Summary
- catch per-provider config errors in `doctor` instead of crashing
- catch corrupt provider health cooldown values and report sanitized cooldown diagnostics
- add regression tests for private SearXNG config and corrupt cooldown cache paths

## Verification
- `python -m ruff check .`
- `python -m py_compile search.py config.py provider_health.py cache.py http_client.py quality.py research.py routing.py providers.py extract.py __init__.py`
- `python -m pytest tests/ -q` → 170 passed
- real-file smoke: private SearXNG URL does not crash and does not echo private URL
- real-file smoke: corrupt provider_health cooldown does not crash and does not echo corrupt raw value
- diff secret scan clean