### PR TITLE
Add golden snapshot quality checks for provider outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### 🧪 Tests
+- Added offline golden snapshot quality checks for canonical source presence, blocked mirror domains, duplicate counts, and extracted-content substance without live provider calls.
+
 ## [v2.2.1] — 2026-05-25
 
 ### 🔧 Changed

--- a/README.md
+++ b/README.md
@@ -293,6 +293,12 @@ python3 search.py --query "Hermes Agent latest release" --provider auto --qualit
 python3 search.py --query "Hermes Agent latest release" --provider brave --max-results 2 --compact
 ```
 
+Golden snapshot quality checks are offline/replayable and safe for CI. They assert source-quality expectations such as canonical-domain presence, blocked mirror domains, duplicate counts, and extracted-content substance without making live provider calls:
+
+```bash
+python3 scripts/golden_eval.py --snapshot-fixtures tests/fixtures/golden_snapshots.json --out /tmp/golden-quality.jsonl
+```
+
 ---
 
 ## Project layout

--- a/scripts/golden_eval.py
+++ b/scripts/golden_eval.py
@@ -87,6 +87,31 @@ def _safe_domain(url: str) -> str:
         return ""
 
 
+def _normalized_result_url(url: str) -> str:
+    try:
+        parsed = urlparse(url or "")
+        netloc = parsed.netloc.lower()
+        if netloc.startswith("www."):
+            netloc = netloc[4:]
+        return f"{netloc}{parsed.path.rstrip('/')}"
+    except Exception:
+        return ""
+
+
+def _duplicate_url_count(results: List[Dict[str, Any]]) -> int:
+    seen = set()
+    duplicates = 0
+    for item in results:
+        normalized = _normalized_result_url(item.get("url", ""))
+        if not normalized:
+            continue
+        if normalized in seen:
+            duplicates += 1
+            continue
+        seen.add(normalized)
+    return duplicates
+
+
 def _json_from_stdout(stdout: str) -> Dict[str, Any]:
     try:
         parsed = json.loads(stdout or "{}")
@@ -116,8 +141,11 @@ def evaluate_snapshot_quality(snapshot: Dict[str, Any]) -> Dict[str, Any]:
     domain_set = set(d for d in domains if d)
     top_domain = domains[0] if domains else ""
     combined_text = "\n".join(_result_text(item) for item in results)
-    content_chars = sum(len(str(item.get("content") or item.get("raw_content") or "")) for item in results)
-    duplicate_count = int((payload.get("quality_report") or {}).get("duplicate_count", payload.get("metadata", {}).get("dedup_count", 0)) or 0)
+    source_summaries = payload.get("source_summaries") or []
+    content_items = list(results) + list(source_summaries)
+    content_chars = sum(len(str(item.get("content") or item.get("raw_content") or "")) for item in content_items)
+    reported_duplicate_count = int((payload.get("quality_report") or {}).get("duplicate_count", payload.get("metadata", {}).get("dedup_count", 0)) or 0)
+    duplicate_count = max(reported_duplicate_count, _duplicate_url_count(results))
 
     failure_flags: List[str] = []
     min_results = expect.get("min_results")

--- a/scripts/golden_eval.py
+++ b/scripts/golden_eval.py
@@ -95,6 +95,92 @@ def _json_from_stdout(stdout: str) -> Dict[str, Any]:
         return {"error": f"invalid JSON stdout: {e}", "results": []}
 
 
+def _result_text(item: Dict[str, Any]) -> str:
+    return " ".join(
+        str(item.get(key) or "")
+        for key in ("title", "snippet", "description", "content", "raw_content", "summary")
+    )
+
+
+def evaluate_snapshot_quality(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    """Evaluate an offline replay payload against deterministic quality expectations.
+
+    This is intentionally not a live benchmark: fixtures pin representative
+    provider outputs and assert source-quality properties that schema contract
+    tests cannot see, such as primary-domain presence and extraction substance.
+    """
+    payload = snapshot.get("payload") or {}
+    expect = snapshot.get("expect") or {}
+    results = payload.get("results") or []
+    domains = [_safe_domain(item.get("url", "")) for item in results if item.get("url")]
+    domain_set = set(d for d in domains if d)
+    top_domain = domains[0] if domains else ""
+    combined_text = "\n".join(_result_text(item) for item in results)
+    content_chars = sum(len(str(item.get("content") or item.get("raw_content") or "")) for item in results)
+    duplicate_count = int((payload.get("quality_report") or {}).get("duplicate_count", payload.get("metadata", {}).get("dedup_count", 0)) or 0)
+
+    failure_flags: List[str] = []
+    min_results = expect.get("min_results")
+    if min_results is not None and len(results) < int(min_results):
+        failure_flags.append("too_few_results")
+    min_domain_count = expect.get("min_domain_count")
+    if min_domain_count is not None and len(domain_set) < int(min_domain_count):
+        failure_flags.append("low_domain_count")
+    min_content_chars = expect.get("min_content_chars")
+    if min_content_chars is not None and content_chars < int(min_content_chars):
+        failure_flags.append("thin_extracted_content")
+
+    required_domains = set(expect.get("must_include_domains") or [])
+    missing_domains = sorted(required_domains - domain_set)
+    if missing_domains:
+        failure_flags.append("missing_required_domain")
+
+    top_domain_any_of = set(expect.get("top_domain_any_of") or [])
+    if top_domain_any_of and top_domain not in top_domain_any_of:
+        failure_flags.append("top_domain_not_canonical")
+
+    blocked_domains = set(expect.get("blocked_domains") or [])
+    blocked_hits = sorted(blocked_domains & domain_set)
+    if blocked_hits and expect.get("allow_blocked_domains") is not True:
+        failure_flags.append("blocked_domain_present")
+
+    missing_terms = [term for term in expect.get("required_terms") or [] if term.lower() not in combined_text.lower()]
+    if missing_terms:
+        failure_flags.append("missing_required_terms")
+
+    max_duplicate_count = expect.get("max_duplicate_count")
+    if max_duplicate_count is not None and duplicate_count > int(max_duplicate_count):
+        failure_flags.append("too_many_duplicates")
+
+    return {
+        "id": snapshot["id"],
+        "category": snapshot.get("category"),
+        "query": snapshot.get("query"),
+        "status": "ok" if not failure_flags else "fail",
+        "failure_flags": failure_flags,
+        "result_count": len(results),
+        "domain_count": len(domain_set),
+        "domains": sorted(domain_set),
+        "top_domain": top_domain,
+        "missing_domains": missing_domains,
+        "blocked_domain_hits": blocked_hits,
+        "missing_terms": missing_terms,
+        "content_chars": content_chars,
+        "duplicate_count": duplicate_count,
+    }
+
+
+def load_snapshot_fixtures(path: Path) -> List[Dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, list):
+        raise ValueError("Golden snapshot fixture must contain a JSON list")
+    return data
+
+
+def run_snapshot_quality(snapshots: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [evaluate_snapshot_quality(snapshot) for snapshot in snapshots]
+
+
 def summarize_result(
     case: Dict[str, Any],
     mode: str,
@@ -253,9 +339,27 @@ def main() -> int:
     parser.add_argument("--out", type=Path, default=Path("eval/golden-results.jsonl"))
     parser.add_argument("--report", type=Path, default=Path("eval/golden-report.md"))
     parser.add_argument("--limit", type=int, help="Limit number of cases for smoke runs")
+    parser.add_argument(
+        "--snapshot-fixtures",
+        type=Path,
+        help="Validate offline replay fixtures instead of making live provider calls",
+    )
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parents[1]
+    if args.snapshot_fixtures:
+        fixture_path = args.snapshot_fixtures if args.snapshot_fixtures.is_absolute() else repo_root / args.snapshot_fixtures
+        rows = run_snapshot_quality(load_snapshot_fixtures(fixture_path))
+        write_jsonl(rows, repo_root / args.out if not args.out.is_absolute() else args.out)
+        failed = [row for row in rows if row.get("status") != "ok"]
+        print(json.dumps({
+            "snapshots": len(rows),
+            "out": str(args.out),
+            "failed": len(failed),
+            "failure_flags": {row["id"]: row.get("failure_flags") for row in failed},
+        }, indent=2, sort_keys=True))
+        return 1 if failed else 0
+
     script_path = repo_root / "search.py"
     cases = load_golden_queries(args.queries)
     if args.limit:

--- a/tests/fixtures/golden_snapshots.json
+++ b/tests/fixtures/golden_snapshots.json
@@ -1,0 +1,94 @@
+[
+  {
+    "id": "github-primary-source",
+    "category": "software_canonical",
+    "query": "Hermes Web Search Plus GitHub",
+    "payload": {
+      "provider": "replay",
+      "results": [
+        {
+          "title": "GitHub - robbyczgw-cla/hermes-web-search-plus",
+          "url": "https://github.com/robbyczgw-cla/hermes-web-search-plus",
+          "snippet": "Hermes Agent flagship plugin for multi-provider web search and extraction."
+        },
+        {
+          "title": "Web Search Plus — One search. Every source.",
+          "url": "https://websearchplus.xyz/",
+          "snippet": "Public homepage for Web Search Plus."
+        },
+        {
+          "title": "Hermes Agent docs",
+          "url": "https://hermes-agent.nousresearch.com/docs",
+          "snippet": "Hermes Agent runtime repository."
+        }
+      ],
+      "quality_report": {"duplicate_count": 0}
+    },
+    "expect": {
+      "min_results": 3,
+      "min_domain_count": 3,
+      "top_domain_any_of": ["github.com"],
+      "must_include_domains": ["github.com", "websearchplus.xyz"],
+      "blocked_domains": ["example-mirror.invalid"],
+      "max_duplicate_count": 0
+    }
+  },
+  {
+    "id": "policy-primary-source",
+    "category": "policy_canonical",
+    "query": "EU AI Act official obligations",
+    "payload": {
+      "provider": "replay",
+      "results": [
+        {
+          "title": "AI Act | Shaping Europe's digital future",
+          "url": "https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai",
+          "snippet": "European Commission official policy page for the AI Act."
+        },
+        {
+          "title": "Artificial Intelligence Act | EUR-Lex",
+          "url": "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689",
+          "snippet": "Official legal text of Regulation (EU) 2024/1689."
+        },
+        {
+          "title": "Official AI Act overview",
+          "url": "https://artificialintelligenceact.eu/",
+          "snippet": "Public information site linking to official AI Act resources."
+        }
+      ],
+      "quality_report": {"duplicate_count": 0}
+    },
+    "expect": {
+      "min_results": 3,
+      "min_domain_count": 3,
+      "top_domain_any_of": ["digital-strategy.ec.europa.eu", "eur-lex.europa.eu"],
+      "must_include_domains": ["digital-strategy.ec.europa.eu", "eur-lex.europa.eu"],
+      "blocked_domains": ["example-consulting.invalid"],
+      "max_duplicate_count": 0
+    }
+  },
+  {
+    "id": "extract-content-quality",
+    "category": "extract_replay",
+    "query": "extract homepage docs",
+    "payload": {
+      "provider": "replay",
+      "results": [
+        {
+          "title": "Web Search Plus",
+          "url": "https://websearchplus.xyz/",
+          "content": "Web Search Plus routes web search and extraction across providers for Hermes Agent, OpenClaw and MCP clients. It documents install paths, providers, quickstart commands, quality reports and research mode.",
+          "raw_content": "Web Search Plus routes web search and extraction across providers for Hermes Agent, OpenClaw and MCP clients. It documents install paths, providers, quickstart commands, quality reports and research mode."
+        }
+      ],
+      "quality_report": {"duplicate_count": 0}
+    },
+    "expect": {
+      "min_results": 1,
+      "min_content_chars": 120,
+      "must_include_domains": ["websearchplus.xyz"],
+      "required_terms": ["Hermes Agent", "providers", "quality reports"],
+      "max_duplicate_count": 0
+    }
+  }
+]

--- a/tests/test_golden_eval.py
+++ b/tests/test_golden_eval.py
@@ -111,6 +111,44 @@ class GoldenEvalTests(unittest.TestCase):
         self.assertIn("top_domain_not_canonical", row["failure_flags"])
         self.assertIn("blocked_domain_present", row["failure_flags"])
 
+    def test_snapshot_quality_recomputes_duplicates_from_result_urls(self):
+        snapshot = {
+            "id": "dupes",
+            "category": "tech_release",
+            "query": "release notes",
+            "payload": {
+                "results": [
+                    {"url": "https://example.com/a"},
+                    {"url": "https://example.com/a/"},
+                    {"url": "https://example.com/b"},
+                ],
+                "quality_report": {"duplicate_count": 0},
+            },
+            "expect": {"max_duplicate_count": 0},
+        }
+
+        row = golden_eval.evaluate_snapshot_quality(snapshot)
+
+        self.assertEqual(row["duplicate_count"], 1)
+        self.assertIn("too_many_duplicates", row["failure_flags"])
+
+    def test_snapshot_quality_counts_research_source_summary_content(self):
+        snapshot = {
+            "id": "research-content",
+            "category": "research_policy",
+            "query": "EU AI Act",
+            "payload": {
+                "results": [{"url": "https://ec.europa.eu/a"}],
+                "source_summaries": [{"url": "https://ec.europa.eu/a", "content": "x" * 120}],
+            },
+            "expect": {"min_content_chars": 100},
+        }
+
+        row = golden_eval.evaluate_snapshot_quality(snapshot)
+
+        self.assertEqual(row["status"], "ok")
+        self.assertEqual(row["content_chars"], 120)
+
     def test_run_case_builds_expected_commands(self):
         calls = []
 

--- a/tests/test_golden_eval.py
+++ b/tests/test_golden_eval.py
@@ -92,6 +92,25 @@ class GoldenEvalTests(unittest.TestCase):
             self.assertIn("normal", text)
             self.assertIn("research", text)
 
+    def test_snapshot_fixture_quality_checks_pass_and_fail_deterministically(self):
+        fixture_path = Path(__file__).parent / "fixtures" / "golden_snapshots.json"
+        snapshots = golden_eval.load_snapshot_fixtures(fixture_path)
+        rows = golden_eval.run_snapshot_quality(snapshots)
+
+        self.assertEqual(len(rows), 3)
+        self.assertTrue(all(row["status"] == "ok" for row in rows))
+        self.assertEqual(rows[0]["top_domain"], "github.com")
+
+        broken = snapshots[0].copy()
+        broken["payload"] = {"results": [{"url": "https://example-mirror.invalid/only"}]}
+        row = golden_eval.evaluate_snapshot_quality(broken)
+
+        self.assertEqual(row["status"], "fail")
+        self.assertIn("too_few_results", row["failure_flags"])
+        self.assertIn("missing_required_domain", row["failure_flags"])
+        self.assertIn("top_domain_not_canonical", row["failure_flags"])
+        self.assertIn("blocked_domain_present", row["failure_flags"])
+
     def test_run_case_builds_expected_commands(self):
         calls = []
 


### PR DESCRIPTION
## Summary

- add offline golden snapshot fixtures for representative search/extract outputs
- validate canonical-domain presence, blocked mirror domains, duplicate count limits, and extracted-content substance
- expose `scripts/golden_eval.py --snapshot-fixtures ...` for CI-safe replay checks without live provider calls
- document the snapshot check in local development docs

Closes #35

## Test Plan

- `python scripts/golden_eval.py --snapshot-fixtures tests/fixtures/golden_snapshots.json --out /tmp/golden-quality.jsonl` → failed=0
- `python -m pytest tests/test_golden_eval.py -q` → 6 passed
- `python -m pytest tests/ -q` → 173 passed
- `python -m ruff check .` → passed
- `python -m py_compile scripts/golden_eval.py search.py quality.py`
- `git diff --check`

## Notes

This deliberately stays offline and deterministic. It does not benchmark every provider or introduce live provider calls into default CI.
