### PR TITLE
Add compatibility-shim deprecation path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### 📚 Docs
+- Documented the `search.py` compatibility-shim policy and removal path for the monolith-to-module split.
+
 ## [v2.2.1] — 2026-05-25
 
 ### 🔧 Changed

--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ python3 search.py --query "Hermes Agent latest release" --provider auto --qualit
 python3 search.py --query "Hermes Agent latest release" --provider brave --max-results 2 --compact
 ```
 
+Compatibility shims in `search.py` intentionally preserve legacy imports and monkeypatch seams while the modular split settles. The public shim policy is available via `get_compatibility_shim_policy()` and must keep wrappers in place until the ProviderSpec registry has stabilized for a documented minor release window.
+
 ---
 
 ## Project layout

--- a/search.py
+++ b/search.py
@@ -110,6 +110,36 @@ def _load_env_file():
 
 ROUTING_POLICY = "routing-v2"
 
+COMPATIBILITY_SHIM_DEPRECATION = {
+    "public_surface": [
+        "QueryAnalyzer",
+        "auto_route_provider",
+        "search_provider",
+        "extract_url_content",
+        "get_cached_result",
+        "cache_search_result",
+        "clear_cache",
+        "get_cache_stats",
+    ],
+    "internal_shims": [
+        "_sync_routing_dependencies",
+        "_sync_provider_dependencies",
+        "_sync_extract_dependencies",
+        "provider function wrappers",
+    ],
+    "removal_target": "after ProviderSpec registry stabilization and one documented minor release window",
+    "tracking_issue": "#34",
+    "policy": "Keep search.py imports working while tests/users migrate to module-level seams; do not remove wrappers in feature PRs.",
+}
+
+
+def get_compatibility_shim_policy() -> Dict[str, Any]:
+    """Return the documented compatibility-shim policy for tests and release notes."""
+    return {
+        key: value.copy() if isinstance(value, list) else value
+        for key, value in COMPATIBILITY_SHIM_DEPRECATION.items()
+    }
+
 
 def _sync_routing_dependencies() -> None:
     """Keep moved routing implementation compatible with search.py monkeypatches.

--- a/search.py
+++ b/search.py
@@ -115,7 +115,7 @@ COMPATIBILITY_SHIM_DEPRECATION = {
         "QueryAnalyzer",
         "auto_route_provider",
         "search_provider",
-        "extract_url_content",
+        "extract_plus",
         "get_cached_result",
         "cache_search_result",
         "clear_cache",
@@ -144,7 +144,7 @@ def get_compatibility_shim_policy() -> Dict[str, Any]:
 def _sync_routing_dependencies() -> None:
     """Keep moved routing implementation compatible with search.py monkeypatches.
 
-    TODO(v2.3): collapse once routing tests inject dependencies at routing.py.
+    Removal target: after ProviderSpec registry stabilization and one documented minor release window.
     """
     _routing.get_api_key = get_api_key
 
@@ -280,8 +280,7 @@ def _provider_auto_allowed(*args, **kwargs):
 def _sync_provider_dependencies() -> None:
     """Keep moved provider implementations compatible with search.py monkeypatches.
 
-    TODO(v2.3): remove these transitional shims after tests and callers patch
-    provider-module dependencies directly instead of search.py module globals.
+    Removal target: after ProviderSpec registry stabilization and one documented minor release window.
     """
     _providers.make_request = make_request
     _providers.make_get_request = make_get_request
@@ -443,7 +442,7 @@ def search_searxng(*args, **kwargs):
 def _sync_extract_dependencies() -> None:
     """Keep moved extract orchestrator compatible with search.py monkeypatches.
 
-    TODO(v2.3): remove once extract tests patch extract.py/provider modules directly.
+    Removal target: after ProviderSpec registry stabilization and one documented minor release window.
     """
     _extract.get_api_key = get_api_key
     _extract.load_config = load_config

--- a/tests/test_compatibility_shims.py
+++ b/tests/test_compatibility_shims.py
@@ -14,8 +14,11 @@ def test_compatibility_shim_policy_documents_public_surface_and_removal_path():
 
     assert policy["tracking_issue"] == "#34"
     assert "ProviderSpec registry" in policy["removal_target"]
+    assert "one documented minor release window" in policy["removal_target"]
+    assert "v2.3" not in policy["removal_target"]
     assert "QueryAnalyzer" in policy["public_surface"]
-    assert "extract_url_content" in policy["public_surface"]
+    assert "extract_plus" in policy["public_surface"]
+    assert "extract_url_content" not in policy["public_surface"]
     assert "_sync_provider_dependencies" in policy["internal_shims"]
     assert "do not remove wrappers" in policy["policy"]
 

--- a/tests/test_compatibility_shims.py
+++ b/tests/test_compatibility_shims.py
@@ -1,0 +1,23 @@
+import importlib.util
+from pathlib import Path
+
+SEARCH_PATH = Path(__file__).resolve().parents[1] / "search.py"
+search_spec = importlib.util.spec_from_file_location("wsp_search_shim_policy_under_test", SEARCH_PATH)
+assert search_spec is not None
+search = importlib.util.module_from_spec(search_spec)
+assert search_spec.loader is not None
+search_spec.loader.exec_module(search)
+
+
+def test_compatibility_shim_policy_documents_public_surface_and_removal_path():
+    policy = search.get_compatibility_shim_policy()
+
+    assert policy["tracking_issue"] == "#34"
+    assert "ProviderSpec registry" in policy["removal_target"]
+    assert "QueryAnalyzer" in policy["public_surface"]
+    assert "extract_url_content" in policy["public_surface"]
+    assert "_sync_provider_dependencies" in policy["internal_shims"]
+    assert "do not remove wrappers" in policy["policy"]
+
+    policy["public_surface"].append("mutated")
+    assert "mutated" not in search.get_compatibility_shim_policy()["public_surface"]


### PR DESCRIPTION
## Summary

- document the `search.py` compatibility-shim policy after the modular split
- add a small public policy helper for the intended compatibility surface and removal path
- lock the policy with regression coverage so compatibility wrappers are not removed accidentally

Addresses #34

## Test Plan

- `python -m pytest tests/test_compatibility_shims.py -q` → 1 passed
- `python -m pytest tests/ -q` → 176 passed
- `python -m ruff check .` → passed
- `python -m py_compile search.py`
- `git diff --check`

## Notes

This PR is stacked on `feat/provider-spec-registry` / PR #40 because #34 explicitly depends on the ProviderSpec registry being stable. It should be merged after #40, not before it.
