### PR TITLE
feat: add parallel multi-provider fusion search mode (RRF)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           provider_health.py
           quality.py
           research.py
+          fusion.py
           routing.py
           providers.py
           extract.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v2.3.0] — 2026-05-29
+## [Unreleased]
 
 ### ✨ Added
 - Added an opt-in **fusion** search mode (`mode="fusion"`) that queries 2-3 auto-allowed providers in parallel and merges their ranked results with Reciprocal Rank Fusion (RRF). Fusion rewards cross-provider agreement for better coverage and diversity than single-provider routing, while staying far cheaper and faster than research mode because it skips extraction.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,16 @@
 ### ✨ Added
 - Added an opt-in **fusion** search mode (`mode="fusion"`) that queries 2-3 auto-allowed providers in parallel and merges their ranked results with Reciprocal Rank Fusion (RRF). Fusion rewards cross-provider agreement for better coverage and diversity than single-provider routing, while staying far cheaper and faster than research mode because it skips extraction.
 - Fused results expose `fusion_score` and a `found_by` provider list; response metadata reports `unique_results` and `overlap_count` (URLs surfaced by more than one provider).
-- Added a `fusion.py` orchestrator plus `reciprocal_rank_fusion`/`select_fusion_providers` helpers in `quality.py`.
-- Added CLI flags `--mode fusion`, `--fusion-providers`, `--fusion-max-providers`, `--fusion-k`, and `--fusion-time-budget`; `golden_eval.py --modes` can now evaluate fusion.
+- Fusion preserves single-provider intent guarantees: explicit domain scope (`site:` operators plus `include_domains`/`exclude_domains`) is hard-enforced after merging so a provider that ignores the operator can't leak off-domain results, and the same authority/intent rerank normal search runs after fetch is applied to the fused results (so official/regulatory/release sources are not buried by aggregators). `metadata.domain_filtered_count` and `metadata.intent_rerank` report when these fire.
+- Added a `fusion.py` orchestrator plus `reciprocal_rank_fusion`/`select_fusion_providers`/`apply_domain_constraints` helpers in `quality.py`.
+- Added CLI flags `--mode fusion`, `--fusion-providers`, `--fusion-max-providers`, `--fusion-k`, and `--fusion-time-budget`; `golden_eval.py --modes fusion` now actually runs fusion (passes `--mode fusion`) instead of silently running normal search under a fusion label.
 
 ### 🔧 Changed
 - Fusion is best-effort: providers that error or exceed the wall-clock budget are recorded under `provider_errors` and dropped from the merge, and whatever arrived in time is still fused and returned. The thread pool is shut down without waiting so a single straggler cannot delay the response beyond the budget.
 
 ### 🧪 Tests
 - Added fusion coverage: RRF cross-provider ranking, URL normalization, richest-snippet retention, provider selection order, deterministic parallel fan-out (barrier-synchronized), partial results on provider error, and time-budget skips.
+- Added domain-constraint unit tests and end-to-end `main()` fusion tests proving `site:` queries drop off-domain results and the authority rerank lifts official sources over aggregators; added a golden-eval test asserting `--mode fusion` is passed through.
 
 ## [v2.2.1] — 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [v2.3.0] — 2026-05-29
+
+### ✨ Added
+- Added an opt-in **fusion** search mode (`mode="fusion"`) that queries 2-3 auto-allowed providers in parallel and merges their ranked results with Reciprocal Rank Fusion (RRF). Fusion rewards cross-provider agreement for better coverage and diversity than single-provider routing, while staying far cheaper and faster than research mode because it skips extraction.
+- Fused results expose `fusion_score` and a `found_by` provider list; response metadata reports `unique_results` and `overlap_count` (URLs surfaced by more than one provider).
+- Added a `fusion.py` orchestrator plus `reciprocal_rank_fusion`/`select_fusion_providers` helpers in `quality.py`.
+- Added CLI flags `--mode fusion`, `--fusion-providers`, `--fusion-max-providers`, `--fusion-k`, and `--fusion-time-budget`; `golden_eval.py --modes` can now evaluate fusion.
+
+### 🔧 Changed
+- Fusion is best-effort: providers that error or exceed the wall-clock budget are recorded under `provider_errors` and dropped from the merge, and whatever arrived in time is still fused and returned. The thread pool is shut down without waiting so a single straggler cannot delay the response beyond the budget.
+
+### 🧪 Tests
+- Added fusion coverage: RRF cross-provider ranking, URL normalization, richest-snippet retention, provider selection order, deterministic parallel fan-out (barrier-synchronized), partial results on provider error, and time-budget skips.
+
 ## [v2.2.1] — 2026-05-25
 
 ### 🔧 Changed

--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ web_search_plus(query="Singapore CPI latest", provider="you")
 web_search_plus(query="alternatives to Notion", provider="exa")
 # → semantic discovery
 
+web_search_plus(query="state of the art retrieval augmented generation 2026", mode="fusion")
+# → query 2-3 providers in parallel, merge with Reciprocal Rank Fusion; cheap+fast, better coverage
+
 web_search_plus(query="compare recent reviews of turntables under 1000", mode="research", research_time_budget=45)
 # → opt-in multi-provider research; keeps partial results if extraction hits errors/budget
 
@@ -189,7 +192,7 @@ Parameters:
 | `include_domains` | string[] | — | Restrict search to domains |
 | `exclude_domains` | string[] | — | Exclude domains |
 | `quality_report` | boolean | `false` | Include routing diagnostics, provider scores, result counts, and extraction recommendation |
-| `mode` | string | `"normal"` | `normal` or opt-in `research` |
+| `mode` | string | `"normal"` | `normal` (single routed provider), opt-in `fusion` (parallel multi-provider RRF merge, no extraction), or opt-in `research` (multi-provider + extraction) |
 | `research_time_budget` | number | `55.0` | Best-effort seconds budget for research mode |
 
 ### `web_extract_plus`

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v2.2.1
-Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
+web-search-plus — Hermes Plugin v2.3.0
+Multi-provider web search, URL extraction, quality reports, and opt-in research/fusion modes.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "2.2.1"
+__version__ = "2.3.0"
 
 import argparse
 import getpass
@@ -971,8 +971,10 @@ def _run_search(
         cmd += ["--include-domains"] + include_domains
     if exclude_domains:
         cmd += ["--exclude-domains"] + exclude_domains
-    if mode != "normal":
+    if mode == "research":
         cmd += ["--mode", mode, "--research-time-budget", str(research_time_budget)]
+    elif mode == "fusion":
+        cmd += ["--mode", mode, "--fusion-time-budget", str(research_time_budget)]
     if quality_report:
         cmd.append("--quality-report")
     if language and language != "auto":
@@ -1191,8 +1193,8 @@ def register(ctx: Any) -> None:
                 },
                 "mode": {
                     "type": "string",
-                    "enum": ["normal", "research"],
-                    "description": "normal = fast routed search; research = multi-provider search plus top-source extraction.",
+                    "enum": ["normal", "research", "fusion"],
+                    "description": "normal = fast single-provider routed search; fusion = query 2-3 providers in parallel and merge with Reciprocal Rank Fusion for better coverage/agreement (no extraction, cheap+fast); research = multi-provider search plus top-source extraction.",
                     "default": "normal",
                 },
                 "quality_report": {
@@ -1202,7 +1204,7 @@ def register(ctx: Any) -> None:
                 },
                 "research_time_budget": {
                     "type": "number",
-                    "description": "Best-effort wall-clock budget in seconds for research mode. Checked between provider calls and before extraction.",
+                    "description": "Best-effort wall-clock budget in seconds. In research mode it is checked between provider calls and before extraction; in fusion mode it caps how long parallel providers are awaited before slower ones are dropped from the merge.",
                     "default": 55.0,
                     "minimum": 1,
                     "maximum": 75,

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v2.3.0
+web-search-plus — Hermes Plugin v2.2.1
 Multi-provider web search, URL extraction, quality reports, and opt-in research/fusion modes.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "2.3.0"
+__version__ = "2.2.1"
 
 import argparse
 import getpass

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,6 +143,7 @@ The plugin favors partial truth over fake certainty.
 - Cooldowns step through 1 minute, 5 minutes, 25 minutes, and 1 hour.
 - Cooldown state is local and stored in `provider_health.json` under the cache directory.
 - Research mode keeps partial provider results when later extraction or provider calls fail.
+- Fusion mode queries its providers in parallel and is best-effort: providers that error or exceed the wall-clock budget are recorded under `provider_errors` and dropped from the Reciprocal Rank Fusion merge, while results that arrived in time are still merged and returned. The thread pool is shut down without waiting so a single straggler cannot delay the response past the budget (each provider call is still bounded by its own HTTP timeout). Fusion does not write provider-health/cooldown state from its parallel workers.
 
 
 A provider outage should produce skipped-provider metadata or a structured error, not a confident hallucination.
@@ -166,6 +167,7 @@ The plugin has cost guards, not provider billing control.
 
 - `count` limits requested search result count.
 - Research mode has a best-effort `research_time_budget` checked between provider and extraction steps.
+- Fusion mode issues one search call per selected provider (default up to 3, `--fusion-max-providers`) and bounds the parallel wait with `--fusion-time-budget`. It adds provider calls but no extraction calls, so it costs more than a single routed search and far less than research mode.
 - Extraction provider order is bounded and explicit.
 - `disabled_providers`, `set-default`, and `auto_allow` let users control which providers can receive traffic.
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -191,6 +191,7 @@ Examples:
 web_search_plus(query="Graz weather today")
 web_search_plus(query="best bookshelf speakers under 1000 EUR", quality_report=True)
 web_search_plus(query="alternatives to Notion", provider="exa")
+web_search_plus(query="state of the art RAG 2026", mode="fusion")
 web_search_plus(query="turntable reviews under 1000", mode="research", research_time_budget=45)
 ```
 
@@ -201,6 +202,7 @@ Important parameters:
 - `time_range`: `day`, `week`, `month`, or `year` where supported.
 - `include_domains` / `exclude_domains`: provider-dependent domain filters.
 - `quality_report`: include routing diagnostics, skipped providers, result quality hints, and extraction recommendation.
+- `mode="fusion"`: query 2-3 auto-allowed providers in parallel and merge their ranked results with Reciprocal Rank Fusion. Cheaper and faster than research mode (no extraction), with better coverage and cross-provider agreement than a single routed provider. Fused results carry `fusion_score` and a `found_by` provider list; metadata reports `overlap_count`. Slower providers are dropped from the merge once the wall-clock budget is hit.
 - `mode="research"`: query multiple providers and optionally extract selected URLs within a best-effort wall-clock budget.
 
 ## Using `web_extract_plus`

--- a/fusion.py
+++ b/fusion.py
@@ -1,0 +1,124 @@
+"""Opt-in fusion mode: parallel multi-provider search merged with RRF.
+
+Fusion mode sits between normal single-provider routing and the heavier research
+mode. It queries a few providers concurrently and merges their ranked results with
+Reciprocal Rank Fusion, trading a couple of extra provider calls for much better
+coverage and cross-provider agreement — while staying far cheaper and faster than
+research mode because it does no extraction.
+
+It is best-effort: a provider that errors or runs past the wall-clock budget is
+recorded and skipped, and whatever arrived in time is still fused and returned.
+"""
+
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    TimeoutError as FutureTimeoutError,
+    as_completed,
+)
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from quality import reciprocal_rank_fusion
+
+
+def _build_fusion_payload(
+    query: str,
+    fused: List[Dict[str, Any]],
+    providers_queried: List[str],
+    provider_errors: List[Dict[str, Any]],
+    fusion_metadata: Dict[str, Any],
+) -> Dict[str, Any]:
+    return {
+        "mode": "fusion",
+        "provider": "fusion",
+        "query": query,
+        "results": fused,
+        "routing": {
+            "providers_queried": providers_queried,
+            "provider_errors": provider_errors,
+            "fusion_method": fusion_metadata.get("fusion_method"),
+            "fusion_k": fusion_metadata.get("fusion_k"),
+        },
+        "metadata": {
+            "providers_merged": providers_queried,
+            "dedup_count": 0,
+            "unique_results": fusion_metadata.get("unique_results", 0),
+            "overlap_count": fusion_metadata.get("overlap_count", 0),
+        },
+    }
+
+
+def run_fusion_mode(
+    query: str,
+    fusion_providers: List[str],
+    execute_search: Callable[[str], Dict[str, Any]],
+    max_results: int,
+    k: int = 60,
+    time_budget_seconds: Optional[float] = None,
+    max_workers: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Query several providers in parallel and merge their results with RRF.
+
+    Args:
+        query: The search query (echoed back into the payload).
+        fusion_providers: Providers to query concurrently, in preferred order.
+        execute_search: Callable that runs one provider and returns its payload.
+        max_results: Number of fused results to keep.
+        k: RRF damping constant (standard value is 60).
+        time_budget_seconds: Best-effort wall-clock cap. Providers slower than the
+            budget are dropped from the merge and recorded as skipped. ``None`` waits
+            for every provider (each call is still bounded by its own HTTP timeout).
+        max_workers: Thread pool size; defaults to one worker per provider.
+
+    Returns a fusion payload with merged ``results`` and routing/metadata diagnostics.
+    Uses wall-clock collection (not an injected clock) because parallel fan-out is
+    inherently real-time; the pool is shut down without waiting so a straggler cannot
+    delay the response beyond the budget.
+    """
+    providers = [p for p in fusion_providers if p]
+    provider_results: List[Tuple[str, Dict[str, Any]]] = []
+    provider_errors: List[Dict[str, Any]] = []
+
+    if not providers:
+        fused, fusion_metadata = reciprocal_rank_fusion([], max_results, k=k)
+        return _build_fusion_payload(query, fused, [], [], fusion_metadata)
+
+    workers = max(1, max_workers or len(providers))
+    executor = ThreadPoolExecutor(max_workers=workers)
+    try:
+        future_to_provider = {executor.submit(execute_search, p): p for p in providers}
+        pending = set(future_to_provider)
+        try:
+            for future in as_completed(future_to_provider, timeout=time_budget_seconds):
+                pending.discard(future)
+                provider = future_to_provider[future]
+                try:
+                    provider_results.append((provider, future.result()))
+                except Exception as exc:  # provider call failed; keep the rest
+                    provider_errors.append({"provider": provider, "error": str(exc)})
+        except FutureTimeoutError:
+            for future in pending:
+                future.cancel()
+                provider_errors.append({
+                    "provider": future_to_provider[future],
+                    "error": "skipped: fusion time budget exhausted",
+                })
+    finally:
+        # Do not block on stragglers; each provider call is HTTP-timeout bounded.
+        executor.shutdown(wait=False)
+
+    # Preserve the requested provider order for stable, reproducible provenance.
+    succeeded = {p for p, _ in provider_results}
+    ordered_results = [
+        (p, payload)
+        for p in providers
+        for (rp, payload) in provider_results
+        if rp == p and p in succeeded
+    ]
+    fused, fusion_metadata = reciprocal_rank_fusion(ordered_results, max_results, k=k)
+    return _build_fusion_payload(
+        query,
+        fused,
+        [p for p, _ in ordered_results],
+        provider_errors,
+        fusion_metadata,
+    )

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "2.3.0"
+version: "2.2.1"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research/fusion modes"
 author: robbyczgw-cla
 requires_env: []

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-search-plus
-version: "2.2.1"
-description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
+version: "2.3.0"
+description: "Multi-provider web search, URL extraction, quality reports, and opt-in research/fusion modes"
 author: robbyczgw-cla
 requires_env: []
 optional_env:

--- a/quality.py
+++ b/quality.py
@@ -57,6 +57,64 @@ def deduplicate_results_across_providers(results_by_provider: List[Tuple[str, Di
                 return deduped, dedup_count
     return deduped, dedup_count
 
+
+def reciprocal_rank_fusion(
+    results_by_provider: List[Tuple[str, Dict[str, Any]]],
+    max_results: int,
+    k: int = 60,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """Merge ranked provider result lists with Reciprocal Rank Fusion (RRF).
+
+    Each result contributes ``1 / (k + rank)`` to its URL's score, summed across
+    providers. A URL that several providers rank highly therefore outranks any single
+    provider's lucky top hit, and we never have to trust absolute provider scores —
+    which live on wildly different scales between providers. ``k`` damps the weight of
+    deep ranks; 60 is the standard RRF constant.
+
+    Returns ``(fused_results, metadata)``. Each fused result keeps the richest snippet
+    seen for that URL and gains ``fusion_score`` plus a ``found_by`` provider list.
+    Results without a usable URL are skipped because they cannot be matched across
+    providers.
+    """
+    fused: Dict[str, Dict[str, Any]] = {}
+    for provider_name, data in results_by_provider:
+        for rank, item in enumerate(data.get("results", []) or []):
+            norm = normalize_result_url(item.get("url", ""))
+            if not norm:
+                continue
+            candidate = item.copy()
+            candidate.setdefault("provider", provider_name)
+            entry = fused.get(norm)
+            if entry is None:
+                entry = {"item": candidate, "score": 0.0, "found_by": [], "best_snippet_len": -1}
+                fused[norm] = entry
+            entry["score"] += 1.0 / (k + rank + 1)
+            if provider_name not in entry["found_by"]:
+                entry["found_by"].append(provider_name)
+            snippet_len = len(_snippet_text(item))
+            if snippet_len > entry["best_snippet_len"]:
+                entry["best_snippet_len"] = snippet_len
+                entry["item"] = candidate
+
+    ranked = sorted(fused.values(), key=lambda e: (-e["score"], -len(e["found_by"])))
+    results: List[Dict[str, Any]] = []
+    overlap_count = 0
+    for entry in ranked[:max_results]:
+        item = entry["item"].copy()
+        item["fusion_score"] = round(entry["score"], 6)
+        item["found_by"] = list(entry["found_by"])
+        if len(entry["found_by"]) > 1:
+            overlap_count += 1
+        results.append(item)
+    metadata = {
+        "fusion_method": "rrf",
+        "fusion_k": k,
+        "unique_results": len(fused),
+        "overlap_count": overlap_count,
+    }
+    return results, metadata
+
+
 def _choose_tie_winner(query: str, winners: List[str], priority: List[str]) -> str:
     """Break score ties deterministically per query.
 
@@ -245,6 +303,27 @@ def select_research_providers(
     preferred = [primary_provider, "linkup", "tavily", "exa", "firecrawl", "brave", "serper", "you", "querit"]
     ordered: List[str] = []
     for provider in preferred + provider_priority:
+        if provider and provider in available_providers and provider not in ordered:
+            ordered.append(provider)
+        if len(ordered) >= max_providers:
+            break
+    return ordered
+
+
+def select_fusion_providers(
+    primary_provider: str,
+    provider_priority: List[str],
+    available_providers: set,
+    max_providers: int = 3,
+) -> List[str]:
+    """Pick a compact provider set for fusion mode.
+
+    The router's chosen provider goes first (it best matches query intent), then we
+    fill from routing priority. Unlike research mode we do not bias toward
+    extraction-capable providers — fusion only needs ranked result lists to merge.
+    """
+    ordered: List[str] = []
+    for provider in [primary_provider] + list(provider_priority):
         if provider and provider in available_providers and provider not in ordered:
             ordered.append(provider)
         if len(ordered) >= max_providers:

--- a/quality.py
+++ b/quality.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import re
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 
@@ -137,6 +137,66 @@ def _result_domain(url: str) -> str:
         return netloc[4:] if netloc.startswith("www.") else netloc
     except Exception:
         return ""
+
+
+def _normalize_domain(domain: str) -> str:
+    domain = (domain or "").strip().strip('"').strip("'").lower()
+    return domain[4:] if domain.startswith("www.") else domain
+
+
+def _required_domains_from_query(query: str) -> set:
+    """Extract domains from explicit ``site:`` operators in a query."""
+    domains = set()
+    for token in re.findall(r"site:([^\s]+)", (query or "").lower()):
+        host = _normalize_domain(token.split("/")[0])
+        if host:
+            domains.add(host)
+    return domains
+
+
+def _domain_satisfies(url: str, domains: set) -> bool:
+    netloc = _result_domain(url)
+    if not netloc:
+        return False
+    return any(netloc == d or netloc.endswith(f".{d}") for d in domains)
+
+
+def apply_domain_constraints(
+    results: List[Dict[str, Any]],
+    query: str,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Hard-filter merged results to honor explicit domain intent.
+
+    Fusion queries several providers and some ignore ``site:``/domain operators, so a
+    multi-provider merge can leak off-domain results that violate a domain-scoped
+    query (e.g. ``site:reddit.com`` picking up dev.to). This enforces the contract
+    after merging: required domains (``site:`` operators plus ``include_domains``) keep
+    only matching results, and ``exclude_domains`` drops matching results.
+
+    Returns ``(filtered_results, dropped_count)``. With no constraints the input is
+    returned unchanged.
+    """
+    required = _required_domains_from_query(query)
+    for domain in include_domains or []:
+        normalized = _normalize_domain(domain)
+        if normalized:
+            required.add(normalized)
+    excluded = {d for d in (_normalize_domain(x) for x in (exclude_domains or [])) if d}
+
+    if not required and not excluded:
+        return results, 0
+
+    kept = []
+    for item in results:
+        url = item.get("url", "")
+        if required and not _domain_satisfies(url, required):
+            continue
+        if excluded and _domain_satisfies(url, excluded):
+            continue
+        kept.append(item)
+    return kept, len(results) - len(kept)
 
 
 CANONICAL_DOMAIN_RULES: Dict[str, Dict[str, List[str]]] = {

--- a/scripts/golden_eval.py
+++ b/scripts/golden_eval.py
@@ -179,6 +179,10 @@ def run_case(
             cmd += ["--mode", "research", "--research-extract-count", str(research_extract_count)]
             if case.get("research_providers"):
                 cmd += ["--research-providers", *case["research_providers"]]
+        elif mode == "fusion":
+            cmd += ["--mode", "fusion"]
+            if case.get("fusion_providers"):
+                cmd += ["--fusion-providers", *case["fusion_providers"]]
         start = time.perf_counter()
         try:
             proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_seconds, env=env)

--- a/scripts/golden_eval.py
+++ b/scripts/golden_eval.py
@@ -246,7 +246,7 @@ def write_markdown_report(rows: List[Dict[str, Any]], path: Path) -> None:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run web-search-plus golden query evaluation")
     parser.add_argument("--queries", type=Path, help="Optional JSON file with golden query cases")
-    parser.add_argument("--modes", nargs="+", default=["normal", "research"], choices=["normal", "research"])
+    parser.add_argument("--modes", nargs="+", default=["normal", "research"], choices=["normal", "research", "fusion"])
     parser.add_argument("--max-results", type=int, default=4)
     parser.add_argument("--research-extract-count", type=int, default=2)
     parser.add_argument("--timeout", type=int, default=90)

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 2.2.1
+Version: 2.3.0
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com.
@@ -70,10 +70,13 @@ from quality import (  # noqa: F401 - re-exported for backward-compatible tests/
     _domain_matches_rule,
     build_quality_report,
     deduplicate_results_across_providers,
+    reciprocal_rank_fusion,
     rerank_results_for_intent,
+    select_fusion_providers,
     select_research_providers,
 )
 from research import run_research_mode
+from fusion import run_fusion_mode
 import providers as _providers
 import routing as _routing
 import extract as _extract
@@ -817,13 +820,36 @@ Full docs: See README.md and SKILL.md
     parser.add_argument(
         "--mode",
         default="normal",
-        choices=["normal", "research"],
-        help="Search mode: normal single-provider route or research multi-provider + extraction"
+        choices=["normal", "research", "fusion"],
+        help="Search mode: normal single-provider route, fusion multi-provider RRF merge, or research multi-provider + extraction"
     )
     parser.add_argument(
         "--research-providers",
         nargs="+",
         help="Explicit provider list for --mode research"
+    )
+    parser.add_argument(
+        "--fusion-providers",
+        nargs="+",
+        help="Explicit provider list for --mode fusion (default: router pick + routing priority)"
+    )
+    parser.add_argument(
+        "--fusion-max-providers",
+        type=int,
+        default=3,
+        help="Maximum providers to query in parallel for --mode fusion"
+    )
+    parser.add_argument(
+        "--fusion-k",
+        type=int,
+        default=60,
+        help="Reciprocal Rank Fusion damping constant for --mode fusion (standard: 60)"
+    )
+    parser.add_argument(
+        "--fusion-time-budget",
+        type=float,
+        default=25.0,
+        help="Best-effort wall-clock budget for --mode fusion; providers slower than this are dropped from the merge"
     )
     parser.add_argument(
         "--research-extract-count",
@@ -1226,6 +1252,66 @@ Full docs: See README.md and SKILL.md
             cooldown_skips=cooldown_skips,
             errors=result.get("routing", {}).get("provider_errors", []),
         )
+        indent = None if args.compact else 2
+        print(json.dumps(result, indent=indent, ensure_ascii=False))
+        return
+
+    if args.mode == "fusion":
+        if not args.query:
+            parser.error("--query is required for --mode fusion")
+        available_fusion_providers = {
+            p for p in providers_to_try
+            if p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config) and not provider_in_cooldown(p)[0]
+        }
+        if provider and get_api_key(provider, config) and not provider_in_cooldown(provider)[0]:
+            available_fusion_providers.add(provider)
+        if args.fusion_providers:
+            fusion_providers = [
+                p for p in args.fusion_providers
+                if p not in disabled_providers and _provider_auto_allowed(p, auto_config) and get_api_key(p, config) and not provider_in_cooldown(p)[0]
+            ]
+        else:
+            fusion_providers = select_fusion_providers(
+                primary_provider=provider,
+                provider_priority=provider_priority,
+                available_providers=available_fusion_providers,
+                max_providers=max(1, args.fusion_max_providers),
+            )
+
+        if not fusion_providers:
+            error_result = {
+                "error": "No configured providers available for fusion mode",
+                "provider": provider,
+                "query": args.query,
+                "routing": routing_info,
+                "cooldown_skips": cooldown_skips,
+            }
+            print(json.dumps(error_result, indent=2), file=sys.stderr)
+            sys.exit(1)
+
+        result = run_fusion_mode(
+            query=args.query,
+            fusion_providers=fusion_providers,
+            execute_search=execute_with_retry,
+            max_results=args.max_results,
+            k=args.fusion_k,
+            time_budget_seconds=args.fusion_time_budget,
+        )
+        routing_info["mode"] = "fusion"
+        routing_info["provider"] = "fusion"
+        result["routing"].update(routing_info)
+        if cooldown_skips:
+            result["routing"]["cooldown_skips"] = cooldown_skips
+        if args.quality_report:
+            result["quality_report"] = build_quality_report(
+                query=args.query,
+                result=result,
+                routing_info=routing_info,
+                providers_considered=providers_considered,
+                eligible_providers=fusion_providers,
+                cooldown_skips=cooldown_skips,
+                errors=result.get("routing", {}).get("provider_errors", []),
+            )
         indent = None if args.compact else 2
         print(json.dumps(result, indent=indent, ensure_ascii=False))
         return

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 2.3.0
+Version: 2.2.1
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com.

--- a/search.py
+++ b/search.py
@@ -68,6 +68,7 @@ from provider_health import (  # noqa: F401 - re-exported for backward-compatibl
 from quality import (  # noqa: F401 - re-exported for backward-compatible tests/imports
     _choose_tie_winner,
     _domain_matches_rule,
+    apply_domain_constraints,
     build_quality_report,
     deduplicate_results_across_providers,
     reciprocal_rank_fusion,
@@ -1297,6 +1298,25 @@ Full docs: See README.md and SKILL.md
             k=args.fusion_k,
             time_budget_seconds=args.fusion_time_budget,
         )
+
+        # Fusion must not weaken a single routed provider's intent guarantees:
+        # 1) honor explicit domain scope (site:/include_domains/exclude_domains) that
+        #    some providers ignore, so the merge can't leak off-domain results, and
+        # 2) apply the same authority/intent rerank normal search runs after fetch,
+        #    which the early-return fusion path would otherwise skip (letting
+        #    SEO/aggregator pages drift above official/regulatory/release sources).
+        if isinstance(result.get("results"), list):
+            constrained, dropped = apply_domain_constraints(
+                result["results"], args.query or "", args.include_domains, args.exclude_domains
+            )
+            if dropped:
+                result.setdefault("metadata", {})["domain_filtered_count"] = dropped
+            routing_class = routing_info.get("analysis_summary", {}).get("routing_class", "general")
+            reranked, rerank_metadata = rerank_results_for_intent(args.query or "", routing_class, constrained)
+            result["results"] = reranked
+            if rerank_metadata.get("reranked"):
+                result.setdefault("metadata", {})["intent_rerank"] = rerank_metadata
+
         routing_info["mode"] = "fusion"
         routing_info["provider"] = "fusion"
         result["routing"].update(routing_info)

--- a/tests/test_fusion_mode.py
+++ b/tests/test_fusion_mode.py
@@ -1,7 +1,41 @@
+import contextlib
+import io
+import json
+import sys
 import threading
 import unittest
+from unittest import mock
 
 import search
+
+
+def _run_fusion_main(argv, route, provider_payloads):
+    """Drive search.main() through the fusion path with mocked providers/routing."""
+    captured = io.StringIO()
+    with mock.patch.object(search, "get_api_key", return_value="k"), \
+            mock.patch.object(search, "provider_in_cooldown", return_value=(False, 0)), \
+            mock.patch.object(search, "validate_api_key", return_value="k"), \
+            mock.patch.object(search, "auto_route_provider", return_value=route), \
+            mock.patch.object(search, "search_serper", side_effect=lambda **k: provider_payloads["serper"]), \
+            mock.patch.object(search, "search_you", side_effect=lambda **k: provider_payloads["you"]), \
+            mock.patch.object(sys, "argv", argv), \
+            contextlib.redirect_stdout(captured):
+        search.main()
+    return json.loads(captured.getvalue())
+
+
+def _route(provider, routing_class):
+    return {
+        "provider": provider,
+        "confidence": 0.8,
+        "confidence_level": "high",
+        "reason": "test",
+        "routing_policy": "routing-v2",
+        "top_signals": [],
+        "scores": {"serper": 5.0, "you": 4.0},
+        "auto_allow_excluded": [],
+        "analysis_summary": {"routing_class": routing_class, "language_hint": "en"},
+    }
 
 
 class ReciprocalRankFusionTests(unittest.TestCase):
@@ -183,6 +217,95 @@ class RunFusionModeTests(unittest.TestCase):
         self.assertEqual(result["results"], [])
         self.assertEqual(result["routing"]["providers_queried"], [])
         self.assertEqual(result["metadata"]["overlap_count"], 0)
+
+
+class ApplyDomainConstraintsTests(unittest.TestCase):
+    def test_site_operator_filters_off_domain_results(self):
+        results = [
+            {"url": "https://www.reddit.com/r/x/1"},
+            {"url": "https://dev.to/post"},
+            {"url": "https://old.reddit.com/r/x/2"},
+        ]
+        kept, dropped = search.apply_domain_constraints(results, "site:reddit.com best llm", None, None)
+        self.assertEqual(
+            [r["url"] for r in kept],
+            ["https://www.reddit.com/r/x/1", "https://old.reddit.com/r/x/2"],
+        )
+        self.assertEqual(dropped, 1)
+
+    def test_include_domains_filter(self):
+        results = [{"url": "https://arxiv.org/abs/1"}, {"url": "https://medium.com/p"}]
+        kept, dropped = search.apply_domain_constraints(results, "scaling laws", ["arxiv.org"], None)
+        self.assertEqual([r["url"] for r in kept], ["https://arxiv.org/abs/1"])
+        self.assertEqual(dropped, 1)
+
+    def test_exclude_domains_filter(self):
+        results = [{"url": "https://reddit.com/x"}, {"url": "https://docs.python.org/3"}]
+        kept, dropped = search.apply_domain_constraints(results, "asyncio taskgroup", None, ["reddit.com"])
+        self.assertEqual([r["url"] for r in kept], ["https://docs.python.org/3"])
+        self.assertEqual(dropped, 1)
+
+    def test_no_constraints_passthrough(self):
+        results = [{"url": "https://a.test/1"}, {"url": "https://b.test/2"}]
+        kept, dropped = search.apply_domain_constraints(results, "general query", None, None)
+        self.assertEqual(kept, results)
+        self.assertEqual(dropped, 0)
+
+
+class FusionMainPathTests(unittest.TestCase):
+    def test_site_query_drops_off_domain_results(self):
+        # Regression: fusion must not dilute a site: query with off-domain results
+        # just because one provider ignored the operator.
+        payloads = {
+            "serper": {"provider": "serper", "results": [
+                {"url": "https://www.reddit.com/r/LocalLLaMA/a", "title": "R1", "snippet": "x"},
+                {"url": "https://reddit.com/r/LocalLLaMA/b", "title": "R2", "snippet": "y"},
+            ]},
+            "you": {"provider": "you", "results": [
+                {"url": "https://dev.to/some-article", "title": "D", "snippet": "z"},
+                {"url": "https://reddit.com/r/LocalLLaMA/c", "title": "R3", "snippet": "w"},
+            ]},
+        }
+        out = _run_fusion_main(
+            ["search.py", "--query", "site:reddit.com best local llm server",
+             "--mode", "fusion", "--fusion-providers", "serper", "you",
+             "--max-results", "5", "--compact"],
+            route=_route("serper", "reddit_community"),
+            provider_payloads=payloads,
+        )
+
+        self.assertEqual(out["provider"], "fusion")
+        urls = [r["url"] for r in out["results"]]
+        self.assertTrue(urls, "expected reddit results to survive the filter")
+        self.assertTrue(all("reddit.com" in u for u in urls), urls)
+        self.assertFalse(any("dev.to" in u for u in urls), urls)
+        self.assertEqual(out["metadata"]["domain_filtered_count"], 1)
+
+    def test_authority_rerank_runs_in_fusion_path(self):
+        # Regression: fusion returned before normal search's authority rerank, letting
+        # aggregators outrank official sources on release/regulatory queries.
+        payloads = {
+            "serper": {"provider": "serper", "results": [
+                {"url": "https://medium.com/p", "title": "M", "snippet": "m"},
+                {"url": "https://www.anthropic.com/news/claude", "title": "A", "snippet": "a"},
+            ]},
+            "you": {"provider": "you", "results": [
+                {"url": "https://medium.com/p", "title": "M2", "snippet": "m2"},
+                {"url": "https://anthropic.com/news/claude", "title": "A2", "snippet": "a2"},
+            ]},
+        }
+        out = _run_fusion_main(
+            ["search.py", "--query", "official Anthropic Claude release notes",
+             "--mode", "fusion", "--fusion-providers", "serper", "you",
+             "--max-results", "5", "--compact"],
+            route=_route("you", "official_vendor_release"),
+            provider_payloads=payloads,
+        )
+
+        # Raw RRF would rank medium.com first (both providers list it at rank 0);
+        # the authority rerank must lift the official anthropic.com source above it.
+        self.assertIn("anthropic.com", out["results"][0]["url"])
+        self.assertTrue(out["metadata"]["intent_rerank"]["reranked"])
 
 
 if __name__ == "__main__":

--- a/tests/test_fusion_mode.py
+++ b/tests/test_fusion_mode.py
@@ -1,0 +1,189 @@
+import threading
+import unittest
+
+import search
+
+
+class ReciprocalRankFusionTests(unittest.TestCase):
+    def test_rewards_cross_provider_agreement(self):
+        results_by_provider = [
+            ("alpha", {"results": [
+                {"url": "https://x.test/x", "title": "X", "snippet": "x"},
+                {"url": "https://y.test/y", "title": "Y", "snippet": "y"},
+            ]}),
+            ("beta", {"results": [
+                {"url": "https://z.test/z", "title": "Z", "snippet": "z"},
+                {"url": "https://x.test/x", "title": "X2", "snippet": "x again"},
+            ]}),
+        ]
+
+        fused, metadata = search.reciprocal_rank_fusion(results_by_provider, max_results=5)
+
+        # x is ranked by both providers, so RRF lifts it above either provider's solo top hit.
+        self.assertEqual([r["url"] for r in fused], [
+            "https://x.test/x",
+            "https://z.test/z",
+            "https://y.test/y",
+        ])
+        self.assertEqual(metadata["unique_results"], 3)
+        self.assertEqual(metadata["overlap_count"], 1)
+        self.assertEqual(metadata["fusion_method"], "rrf")
+        self.assertEqual(fused[0]["found_by"], ["alpha", "beta"])
+        self.assertGreater(fused[0]["fusion_score"], fused[1]["fusion_score"])
+
+    def test_normalizes_urls_across_providers(self):
+        results_by_provider = [
+            ("alpha", {"results": [{"url": "https://www.example.com/page/", "snippet": "a"}]}),
+            ("beta", {"results": [{"url": "http://example.com/page", "snippet": "b"}]}),
+        ]
+
+        fused, metadata = search.reciprocal_rank_fusion(results_by_provider, max_results=5)
+
+        self.assertEqual(len(fused), 1)
+        self.assertEqual(metadata["unique_results"], 1)
+        self.assertEqual(metadata["overlap_count"], 1)
+        self.assertEqual(fused[0]["found_by"], ["alpha", "beta"])
+
+    def test_keeps_richest_snippet_for_shared_url(self):
+        results_by_provider = [
+            ("alpha", {"results": [{"url": "https://shared.test/a", "title": "Short", "snippet": "tiny"}]}),
+            ("beta", {"results": [{"url": "https://shared.test/a", "title": "Long", "snippet": "a much longer and more useful snippet"}]}),
+        ]
+
+        fused, _ = search.reciprocal_rank_fusion(results_by_provider, max_results=5)
+
+        self.assertEqual(len(fused), 1)
+        self.assertEqual(fused[0]["title"], "Long")
+        self.assertEqual(fused[0]["snippet"], "a much longer and more useful snippet")
+        self.assertEqual(fused[0]["found_by"], ["alpha", "beta"])
+
+    def test_skips_results_without_url_and_respects_max_results(self):
+        results_by_provider = [
+            ("alpha", {"results": [
+                {"url": "", "snippet": "no url"},
+                {"url": "https://a.test/1", "snippet": "1"},
+                {"url": "https://a.test/2", "snippet": "2"},
+            ]}),
+        ]
+
+        fused, metadata = search.reciprocal_rank_fusion(results_by_provider, max_results=1)
+
+        self.assertEqual(len(fused), 1)
+        self.assertEqual(metadata["unique_results"], 2)
+
+    def test_empty_input_returns_empty_results(self):
+        fused, metadata = search.reciprocal_rank_fusion([], max_results=5)
+        self.assertEqual(fused, [])
+        self.assertEqual(metadata["unique_results"], 0)
+        self.assertEqual(metadata["overlap_count"], 0)
+
+
+class SelectFusionProvidersTests(unittest.TestCase):
+    def test_prefers_primary_then_routing_priority(self):
+        selected = search.select_fusion_providers(
+            primary_provider="exa",
+            provider_priority=["you", "serper", "exa", "firecrawl", "tavily"],
+            available_providers={"exa", "serper", "tavily", "you"},
+            max_providers=3,
+        )
+        self.assertEqual(selected, ["exa", "you", "serper"])
+
+    def test_skips_unavailable_and_dedups(self):
+        selected = search.select_fusion_providers(
+            primary_provider="brave",
+            provider_priority=["you", "you", "serper"],
+            available_providers={"you", "serper"},
+            max_providers=5,
+        )
+        self.assertEqual(selected, ["you", "serper"])
+
+
+class RunFusionModeTests(unittest.TestCase):
+    def test_queries_providers_in_parallel_and_merges(self):
+        # A 2-party barrier only releases if both providers run concurrently; a
+        # sequential implementation would block on the first call and time out.
+        barrier = threading.Barrier(2, timeout=5)
+        payloads = {
+            "you": {"provider": "you", "results": [{"url": "https://a.test/1", "title": "A1", "snippet": "alpha"}]},
+            "serper": {"provider": "serper", "results": [{"url": "https://b.test/2", "title": "B2", "snippet": "beta"}]},
+        }
+
+        def execute(provider):
+            barrier.wait()
+            return payloads[provider]
+
+        result = search.run_fusion_mode(
+            query="parallel fan-out",
+            fusion_providers=["you", "serper"],
+            execute_search=execute,
+            max_results=5,
+        )
+
+        self.assertEqual(result["mode"], "fusion")
+        self.assertEqual(result["provider"], "fusion")
+        self.assertEqual(result["routing"]["providers_queried"], ["you", "serper"])
+        self.assertEqual(result["routing"]["provider_errors"], [])
+        self.assertEqual({r["url"] for r in result["results"]}, {"https://a.test/1", "https://b.test/2"})
+
+    def test_records_provider_errors_and_keeps_others(self):
+        def execute(provider):
+            if provider == "broken":
+                raise RuntimeError("boom")
+            return {"provider": provider, "results": [{"url": f"https://{provider}.test/x", "snippet": "s"}]}
+
+        result = search.run_fusion_mode(
+            query="partial failure",
+            fusion_providers=["you", "broken"],
+            execute_search=execute,
+            max_results=5,
+        )
+
+        self.assertEqual(result["routing"]["providers_queried"], ["you"])
+        self.assertEqual(result["routing"]["provider_errors"], [{"provider": "broken", "error": "boom"}])
+        self.assertEqual([r["url"] for r in result["results"]], ["https://you.test/x"])
+
+    def test_drops_providers_past_time_budget(self):
+        release = threading.Event()
+
+        def execute(provider):
+            if provider == "slow":
+                release.wait(timeout=5)  # never completes within the budget
+                return {"provider": "slow", "results": [{"url": "https://slow.test/x", "snippet": "s"}]}
+            return {"provider": provider, "results": [{"url": f"https://{provider}.test/x", "snippet": "s"}]}
+
+        try:
+            result = search.run_fusion_mode(
+                query="time boxed fusion",
+                fusion_providers=["you", "slow"],
+                execute_search=execute,
+                max_results=5,
+                time_budget_seconds=0.5,
+            )
+        finally:
+            release.set()
+
+        self.assertEqual(result["routing"]["providers_queried"], ["you"])
+        self.assertEqual(
+            result["routing"]["provider_errors"],
+            [{"provider": "slow", "error": "skipped: fusion time budget exhausted"}],
+        )
+        self.assertEqual([r["url"] for r in result["results"]], ["https://you.test/x"])
+
+    def test_no_providers_returns_well_formed_empty_payload(self):
+        def execute(provider):  # pragma: no cover - should never be called
+            raise AssertionError("execute_search should not run with no providers")
+
+        result = search.run_fusion_mode(
+            query="nothing configured",
+            fusion_providers=[],
+            execute_search=execute,
+            max_results=5,
+        )
+
+        self.assertEqual(result["results"], [])
+        self.assertEqual(result["routing"]["providers_queried"], [])
+        self.assertEqual(result["metadata"]["overlap_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_golden_eval.py
+++ b/tests/test_golden_eval.py
@@ -120,6 +120,35 @@ class GoldenEvalTests(unittest.TestCase):
         self.assertIn("--mode", calls[1])
         self.assertIn("research", calls[1])
 
+    def test_run_case_includes_mode_fusion(self):
+        calls = []
+
+        def fake_run(cmd, capture_output, text, timeout, env):
+            calls.append(cmd)
+            class Result:
+                returncode = 0
+                stdout = json.dumps({"provider": "fusion", "results": [{"url": "https://example.com"}], "quality_report": {}})
+                stderr = ""
+            return Result()
+
+        with mock.patch("scripts.golden_eval.subprocess.run", side_effect=fake_run):
+            golden_eval.run_case(
+                case={"id": "q1", "category": "hifi_product", "query": "turntables", "fusion_providers": ["you", "serper"]},
+                script_path=Path("search.py"),
+                modes=["fusion"],
+                max_results=3,
+                research_extract_count=1,
+                timeout_seconds=10,
+                env={},
+            )
+
+        # The fusion mode must actually pass --mode fusion, not silently run normal search.
+        self.assertIn("--mode", calls[0])
+        self.assertIn("fusion", calls[0])
+        self.assertIn("--fusion-providers", calls[0])
+        self.assertIn("you", calls[0])
+        self.assertIn("serper", calls[0])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "2.2.1"
+EXPECTED_VERSION = "2.3.0"
 
 
 def _load_plugin_module():

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "2.3.0"
+EXPECTED_VERSION = "2.2.1"
 
 
 def _load_plugin_module():


### PR DESCRIPTION
## Summary

Adds an opt-in **`mode="fusion"`** that queries 2–3 auto-allowed providers **in parallel** and merges their ranked lists with **Reciprocal Rank Fusion (RRF)**. Fusion sits between `normal` (single routed provider) and `research` (multi-provider + extraction): better coverage and cross-provider agreement than a single provider, far cheaper/faster than research because it does no extraction.

No version bump — change is logged under CHANGELOG `[Unreleased]`; tagging is left to the maintainer.

## Intent preservation (does not regress single-provider behavior)
Fusion keeps the guarantees a single routed provider gives you:
- **Explicit domain scope is hard-enforced after the merge** — `site:` operators and `include_domains`/`exclude_domains` filter the fused results, so a provider that ignores the operator cannot leak off-domain hits (e.g. `site:reddit.com` no longer mixing in dev.to). Reported via `metadata.domain_filtered_count`.
- **The same authority/intent rerank as normal search is applied to fused results** — the early-return fusion path previously skipped `rerank_results_for_intent`, which let aggregators outrank official/regulatory/release sources. Reported via `metadata.intent_rerank`.

## What changed
- **`quality.py`** — `reciprocal_rank_fusion()` (URL-normalized merge adding `fusion_score`/`found_by`, reporting `unique_results`/`overlap_count`, keeping the richest snippet per URL), `select_fusion_providers()`, and `apply_domain_constraints()`.
- **`fusion.py`** (new) — best-effort parallel orchestrator (`ThreadPoolExecutor` + `as_completed(timeout=...)`); providers that error or exceed the wall-clock budget are recorded and dropped, and the pool is shut down without waiting so a single straggler can't delay the response. No provider-health writes from workers.
- **`search.py`** — `--mode fusion` plus `--fusion-providers/-max-providers/-k/-time-budget`, the `main()` fusion branch, domain enforcement + authority rerank, and `quality_report` support.
- **`__init__.py`** — tool-schema `mode` enum gains `fusion`; subprocess budget mapping.
- **`scripts/golden_eval.py`** — `--modes fusion` now actually passes `--mode fusion` (previously it ran normal search under a fusion label).
- **Docs** — README, USER_GUIDE, ARCHITECTURE; CHANGELOG under `[Unreleased]`.

## Tests
- New `tests/test_fusion_mode.py`: RRF ranking/normalization/snippet retention, provider selection, deterministic parallel fan-out (`threading.Barrier`), partial-failure and time-budget behavior, domain-constraint units, and two end-to-end `main()` tests reproducing the `site:reddit.com` filter and the official-release rerank cases.
- Golden-eval test asserting `--mode fusion` passthrough.
- Full suite: **190 passing**; `ruff` clean; all modules compile.

## Notes
- No new runtime dependencies (stdlib `concurrent.futures` only).
- Backward compatible: default `mode` stays `normal`; existing tool surface unchanged.
- Known follow-up: fusion intentionally does not write provider-health/cooldown state from its parallel workers; wiring that in safely depends on making the `provider_health.json` writes atomic (separate change).