### PR TITLE
fix: load Hermes profile env for provider keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           http_client.py
           cache.py
           config.py
+          env_loader.py
           provider_health.py
           quality.py
           research.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - The Hermes plugin now runs `web_search_plus` and `web_extract_plus` in-process by default instead of spawning a `search.py` subprocess per call, removing interpreter-startup, module re-import, and JSON round-trip overhead on every tool invocation. The legacy subprocess path remains as an automatic fallback (used if the in-process import fails) and can be forced with `WSP_FORCE_SUBPROCESS=1`. A thread watchdog preserves the previous hard wall-clock timeout.
 - Research mode now queries its providers concurrently instead of sequentially, so wall-clock cost tracks the slowest provider rather than the sum of all of them. Result ordering stays deterministic (preserved by submission order) and the time budget still gates which providers launch and whether extraction runs.
 
+### 🐛 Fixed
+- Standalone `search.py`, config helpers, and `setup.py status` now load provider keys from the active Hermes profile `.env` in addition to plugin-local legacy `.env` files, preventing false `missing_api_key` fallbacks when keys live in `~/.hermes/.env`.
+
 ### 🔧 Improved
 - Provider retry backoff now adds bounded random jitter (`RETRY_JITTER_FRACTION`) so concurrent or repeated retries against a recovering provider no longer synchronize into bursts.
 - Provider health read-modify-write is now guarded by a lock so concurrent in-process provider calls (parallel research mode) cannot lose cooldown updates.

--- a/__init__.py
+++ b/__init__.py
@@ -34,6 +34,7 @@ try:  # Package load path used by Hermes plugin discovery.
         PROVIDER_SPECS,
         plugin_catalog,
     )
+    from .env_loader import clean_env_value as _shared_clean_env_value, get_hermes_env_path, load_env_files
 except ImportError:  # Direct script/test imports from the plugin directory.
     from provider_registry import (
         DEFAULT_AUTO_ALLOW,
@@ -43,6 +44,7 @@ except ImportError:  # Direct script/test imports from the plugin directory.
         PROVIDER_SPECS,
         plugin_catalog,
     )
+    from env_loader import clean_env_value as _shared_clean_env_value, get_hermes_env_path, load_env_files
 
 _SEARCH_SCRIPT = Path(__file__).parent / "search.py"
 _TOOLSET_NAME = "web-search-plus"
@@ -54,27 +56,15 @@ logger = logging.getLogger(__name__)
 
 def _clean_env_value(value: str) -> Optional[str]:
     """Return a real env value, or None for empty/template placeholders."""
-    stripped = (value or "").strip().strip('"').strip("'")
-    return None if not stripped or set(stripped) == {"*"} else stripped
+    return _shared_clean_env_value(value)
 
 
 _PROVIDER_CATALOG = plugin_catalog()
 
 
 def _load_plugin_env() -> None:
-    """Load the plugin's .env file into os.environ if keys aren't already set."""
-    plugin_env = Path(__file__).parent / ".env"
-    if not plugin_env.exists():
-        return
-    for line in plugin_env.read_text().splitlines():
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        key, _, val = line.partition("=")
-        key = key.strip()
-        val = _clean_env_value(val)
-        if val and key not in os.environ:
-            os.environ[key] = val
+    """Load plugin-local, legacy parent, and Hermes profile .env files."""
+    load_env_files(__file__)
 
 # Load plugin .env on import
 _load_plugin_env()
@@ -143,11 +133,7 @@ def _provider_config_status(env: Optional[Mapping[str, str]] = None) -> Dict[str
 
 def _get_hermes_env_path() -> Path:
     """Return Hermes' profile-aware .env path when available."""
-    try:
-        from hermes_constants import get_hermes_home  # type: ignore
-        return Path(get_hermes_home()) / ".env"
-    except Exception:
-        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / ".env"
+    return get_hermes_env_path()
 
 
 
@@ -737,7 +723,12 @@ def _web_search_plus_cli_command(args: Any) -> None:
     if command == "status":
         env_path = getattr(args, "env_path", None)
         config_path = getattr(args, "config_path", None)
-        env = _read_env_file(Path(env_path)) if env_path else None
+        if env_path:
+            env = _read_env_file(Path(env_path))
+        else:
+            env = dict(os.environ)
+            for key, value in _read_env_file(_get_hermes_env_path()).items():
+                env.setdefault(key, value)
         config = _load_behavior_config(Path(config_path)) if config_path else _load_behavior_config()
         if getattr(args, "json", False):
             print(json.dumps(_status_payload(env, config), indent=2, sort_keys=True))

--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from env_loader import clean_env_value as _shared_clean_env_value, load_env_files
 from provider_registry import DEFAULT_AUTO_ALLOW, DEFAULT_PROVIDER_PRIORITY, PROVIDER_SPECS
 
 
@@ -19,36 +20,16 @@ class ProviderConfigError(Exception):
 
 def _is_placeholder_env_value(value: str) -> bool:
     """Return True for template placeholders that should not count as credentials."""
-    stripped = (value or "").strip().strip('"').strip("'")
-    return not stripped or set(stripped) == {"*"}
+    return _shared_clean_env_value(value) is None
 
 
 def _clean_env_value(value: str) -> Optional[str]:
-    stripped = (value or "").strip().strip('"').strip("'")
-    return None if _is_placeholder_env_value(stripped) else stripped
+    return _shared_clean_env_value(value)
 
 
 def _load_env_file():
-    """Load .env files from plugin-local and legacy parent locations."""
-    env_paths = [
-        Path(__file__).parent / ".env",
-        Path(__file__).parent.parent / ".env",
-    ]
-    for env_path in env_paths:
-        if not env_path.exists():
-            continue
-        with open(env_path) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith("#") and "=" in line:
-                    # Handle export VAR=value or VAR=value
-                    if line.startswith("export "):
-                        line = line[7:]
-                    key, _, value = line.partition("=")
-                    key = key.strip()
-                    value = _clean_env_value(value)
-                    if key and value and key not in os.environ:
-                        os.environ[key] = value
+    """Load plugin-local, legacy parent, and Hermes profile .env files."""
+    load_env_files(__file__)
 
 DEFAULT_CONFIG = {
     "version": 1,

--- a/env_loader.py
+++ b/env_loader.py
@@ -1,0 +1,80 @@
+"""Shared environment loading helpers for Web Search Plus.
+
+The plugin supports three credential locations, in precedence order:
+1. plugin-local ``.env`` for standalone/plugin development
+2. legacy parent ``.env`` used by earlier installs
+3. Hermes profile ``.env`` (``$HERMES_HOME/.env`` or hermes_constants)
+
+Values already present in ``os.environ`` are never overwritten.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import List, MutableMapping, Optional, Set, Union
+
+
+def is_placeholder_env_value(value: str) -> bool:
+    """Return True for empty/template placeholders that are not credentials."""
+    stripped = (value or "").strip().strip('"').strip("'")
+    return not stripped or set(stripped) == {"*"}
+
+
+def clean_env_value(value: str) -> Optional[str]:
+    """Return a real env value, or None for empty/template placeholders."""
+    stripped = (value or "").strip().strip('"').strip("'")
+    return None if is_placeholder_env_value(stripped) else stripped
+
+
+def get_hermes_env_path() -> Path:
+    """Return Hermes' profile-aware .env path when available."""
+    try:
+        from hermes_constants import get_hermes_home  # type: ignore
+
+        return Path(get_hermes_home()) / ".env"
+    except Exception:
+        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / ".env"
+
+
+def candidate_env_paths(anchor_file: Union[str, Path]) -> List[Path]:
+    """Return .env files checked for a module anchored in the plugin dir."""
+    plugin_dir = Path(anchor_file).resolve().parent
+    paths = [
+        plugin_dir / ".env",
+        plugin_dir.parent / ".env",
+        get_hermes_env_path(),
+    ]
+    deduped: List[Path] = []
+    seen: Set[str] = set()
+    for path in paths:
+        key = str(path.expanduser())
+        if key not in seen:
+            deduped.append(path)
+            seen.add(key)
+    return deduped
+
+
+def load_env_files(anchor_file: Union[str, Path], environ: Optional[MutableMapping[str, str]] = None) -> List[Path]:
+    """Load supported .env files without overriding existing env vars.
+
+    Returns the files that existed and were inspected. Template placeholders such
+    as ``***`` are ignored so they do not mask later real credentials.
+    """
+    target_env = environ if environ is not None else os.environ
+    loaded: List[Path] = []
+    for env_path in candidate_env_paths(anchor_file):
+        if not env_path.exists():
+            continue
+        loaded.append(env_path)
+        for raw_line in env_path.read_text().splitlines():
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            if line.startswith("export "):
+                line = line[7:]
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = clean_env_value(value)
+            if key and value and key not in target_env:
+                target_env[key] = value
+    return loaded

--- a/search.py
+++ b/search.py
@@ -29,7 +29,6 @@ import json
 import os
 import sys
 import time
-from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple
 from http_client import (  # noqa: F401 - re-exported for backward-compatible tests/imports
     ProviderRequestError,
@@ -77,6 +76,7 @@ from quality import (  # noqa: F401 - re-exported for backward-compatible tests/
     select_research_providers,
 )
 from provider_registry import SEARCH_PROVIDER_IDS, doctor_catalog
+from env_loader import load_env_files
 from research import run_research_mode
 import providers as _providers
 import routing as _routing
@@ -90,25 +90,8 @@ get_cache_stats = cache_stats
 
 
 def _load_env_file():
-    """Load .env files using search.py's path for backward-compatible tests/shims."""
-    env_paths = [
-        Path(__file__).parent / ".env",
-        Path(__file__).parent.parent / ".env",
-    ]
-    for env_path in env_paths:
-        if not env_path.exists():
-            continue
-        with open(env_path) as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith("#") and "=" in line:
-                    if line.startswith("export "):
-                        line = line[7:]
-                    key, _, value = line.partition("=")
-                    key = key.strip()
-                    value = _clean_env_value(value)
-                    if key and value and key not in os.environ:
-                        os.environ[key] = value
+    """Load plugin-local, legacy parent, and Hermes profile .env files."""
+    load_env_files(__file__)
 
 
 ROUTING_POLICY = "routing-v2"

--- a/tests/test_env_loading.py
+++ b/tests/test_env_loading.py
@@ -6,6 +6,7 @@ from unittest import mock
 
 import search
 import config
+import env_loader
 
 
 class EnvLoadingTests(unittest.TestCase):
@@ -18,9 +19,10 @@ class EnvLoadingTests(unittest.TestCase):
             (plugin_dir / ".env").write_text("LINKUP_API_KEY=local-plugin-key\n")
 
             with mock.patch.object(search, "__file__", str(fake_script)):
-                with mock.patch.dict(os.environ, {}, clear=True):
-                    search._load_env_file()
-                    self.assertEqual(os.environ.get("LINKUP_API_KEY"), "local-plugin-key")
+                with mock.patch.object(env_loader, "get_hermes_env_path", return_value=Path(tmp) / "missing-hermes.env"):
+                    with mock.patch.dict(os.environ, {}, clear=True):
+                        search._load_env_file()
+                        self.assertEqual(os.environ.get("LINKUP_API_KEY"), "local-plugin-key")
 
     def test_load_env_file_ignores_template_placeholders(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -31,10 +33,59 @@ class EnvLoadingTests(unittest.TestCase):
             (plugin_dir / ".env").write_text("SERPER_API_KEY=***\nLINKUP_API_KEY=real-linkup-key\n")
 
             with mock.patch.object(search, "__file__", str(fake_script)):
-                with mock.patch.dict(os.environ, {}, clear=True):
-                    search._load_env_file()
-                    self.assertIsNone(os.environ.get("SERPER_API_KEY"))
-                    self.assertEqual(os.environ.get("LINKUP_API_KEY"), "real-linkup-key")
+                with mock.patch.object(env_loader, "get_hermes_env_path", return_value=Path(tmp) / "missing-hermes.env"):
+                    with mock.patch.dict(os.environ, {}, clear=True):
+                        search._load_env_file()
+                        self.assertIsNone(os.environ.get("SERPER_API_KEY"))
+                        self.assertEqual(os.environ.get("LINKUP_API_KEY"), "real-linkup-key")
+
+    def test_search_load_env_file_reads_hermes_profile_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "web-search-plus"
+            plugin_dir.mkdir()
+            fake_script = plugin_dir / "search.py"
+            fake_script.write_text("# fake")
+            hermes_env = Path(tmp) / "hermes-home" / ".env"
+            hermes_env.parent.mkdir()
+            hermes_env.write_text("TAVILY_API_KEY=tvly-from-hermes\n")
+
+            with mock.patch.object(search, "__file__", str(fake_script)):
+                with mock.patch.object(env_loader, "get_hermes_env_path", return_value=hermes_env):
+                    with mock.patch.dict(os.environ, {}, clear=True):
+                        search._load_env_file()
+                        self.assertEqual(os.environ.get("TAVILY_API_KEY"), "tvly-from-hermes")
+
+    def test_config_load_env_file_reads_hermes_profile_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "web-search-plus"
+            plugin_dir.mkdir()
+            fake_config = plugin_dir / "config.py"
+            fake_config.write_text("# fake")
+            hermes_env = Path(tmp) / "hermes-home" / ".env"
+            hermes_env.parent.mkdir()
+            hermes_env.write_text("EXA_API_KEY=exa-from-hermes\n")
+
+            with mock.patch.object(config, "__file__", str(fake_config)):
+                with mock.patch.object(env_loader, "get_hermes_env_path", return_value=hermes_env):
+                    with mock.patch.dict(os.environ, {}, clear=True):
+                        config._load_env_file()
+                        self.assertEqual(os.environ.get("EXA_API_KEY"), "exa-from-hermes")
+
+    def test_hermes_profile_env_does_not_override_existing_env(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            plugin_dir = Path(tmp) / "web-search-plus"
+            plugin_dir.mkdir()
+            fake_script = plugin_dir / "search.py"
+            fake_script.write_text("# fake")
+            hermes_env = Path(tmp) / "hermes-home" / ".env"
+            hermes_env.parent.mkdir()
+            hermes_env.write_text("TAVILY_API_KEY=tvly-from-hermes\n")
+
+            with mock.patch.object(search, "__file__", str(fake_script)):
+                with mock.patch.object(env_loader, "get_hermes_env_path", return_value=hermes_env):
+                    with mock.patch.dict(os.environ, {"TAVILY_API_KEY": "already-set"}, clear=True):
+                        search._load_env_file()
+                        self.assertEqual(os.environ.get("TAVILY_API_KEY"), "already-set")
 
     def test_config_api_key_treats_template_placeholder_as_missing(self):
         with mock.patch.dict(os.environ, {"SERPER_API_KEY": "***"}, clear=True):

--- a/tests/test_serpbase_provider.py
+++ b/tests/test_serpbase_provider.py
@@ -2,6 +2,7 @@ import importlib.util
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -115,27 +116,29 @@ class SerpBaseProviderTests(unittest.TestCase):
         self.assertIn("serpbase_signals", explanation["intent_breakdown"])
 
     def test_explicit_serpbase_missing_key_hard_fails_without_fallback(self):
-        env = os.environ.copy()
-        env.pop("SERPBASE_API_KEY", None)
-        env["SERPER_API_KEY"] = "serper-test-key-present-but-must-not-be-used"
-        proc = subprocess.run(
-            [
-                sys.executable,
-                str(SEARCH_PATH),
-                "--provider",
-                "serpbase",
-                "--query",
-                "Graz weather today",
-                "--max-results",
-                "1",
-                "--no-cache",
-            ],
-            cwd=str(SEARCH_PATH.parent),
-            env=env,
-            text=True,
-            capture_output=True,
-            timeout=20,
-        )
+        with tempfile.TemporaryDirectory() as tmp:
+            env = os.environ.copy()
+            env.pop("SERPBASE_API_KEY", None)
+            env["SERPER_API_KEY"] = "serper-test-key-present-but-must-not-be-used"
+            env["HERMES_HOME"] = str(Path(tmp) / "empty-hermes-home")
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SEARCH_PATH),
+                    "--provider",
+                    "serpbase",
+                    "--query",
+                    "Graz weather today",
+                    "--max-results",
+                    "1",
+                    "--no-cache",
+                ],
+                cwd=str(SEARCH_PATH.parent),
+                env=env,
+                text=True,
+                capture_output=True,
+                timeout=20,
+            )
         self.assertNotEqual(proc.returncode, 0)
         self.assertIn("Missing API key for serpbase", proc.stderr)
         self.assertNotIn('"trying_next"', proc.stderr)


### PR DESCRIPTION
## Summary
- Add a shared env loader that checks plugin-local `.env`, legacy parent `.env`, and the active Hermes profile `.env`.
- Wire the shared loader into plugin import, standalone `search.py`, and config helpers so provider keys in `~/.hermes/.env` are discovered consistently.
- Make `setup.py status` include the active Hermes profile env by default and add regression coverage for profile-env loading.

## Why
Standalone CLI paths were only checking plugin-local/legacy env files, while setup wrote provider keys to the active Hermes env. That made configured Tavily/Exa/Firecrawl keys look missing and caused bad fallback behavior in CLI benchmarks.

## Verification
- `python -m pytest tests/ -q` → 194 passed
- `ruff check .` → passed
- `git diff --check` → passed
- `python -m py_compile search.py __init__.py http_client.py cache.py config.py env_loader.py provider_health.py quality.py research.py routing.py providers.py extract.py scripts/golden_eval.py` → passed
- `python setup.py status --json` confirms Hermes-profile keys are detected: search providers 11, extract providers 6; Tavily/Exa/Linkup/Firecrawl configured
