### PR TITLE
fix: load provider registry in Hermes plugin package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## [v2.3.1] — 2026-05-31
+
+### 🐛 Fixed
+- Fixed Hermes plugin loading by using package-relative provider registry imports with direct-import fallback compatibility.
+
 ## [v2.3.0] — 2026-05-29
 
 ### ✨ Added

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v2.3.0
+web-search-plus — Hermes Plugin v2.3.1
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 
 import argparse
 import getpass
@@ -21,14 +21,24 @@ import webbrowser
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
-from provider_registry import (
-    DEFAULT_AUTO_ALLOW,
-    DEFAULT_PROVIDER_PRIORITY,
-    EXTRACT_PROVIDER_ENV_KEYS,
-    PROVIDER_ENV_KEYS,
-    PROVIDER_SPECS,
-    plugin_catalog,
-)
+try:  # Package load path used by Hermes plugin discovery.
+    from .provider_registry import (
+        DEFAULT_AUTO_ALLOW,
+        DEFAULT_PROVIDER_PRIORITY,
+        EXTRACT_PROVIDER_ENV_KEYS,
+        PROVIDER_ENV_KEYS,
+        PROVIDER_SPECS,
+        plugin_catalog,
+    )
+except ImportError:  # Direct script/test imports from the plugin directory.
+    from provider_registry import (
+        DEFAULT_AUTO_ALLOW,
+        DEFAULT_PROVIDER_PRIORITY,
+        EXTRACT_PROVIDER_ENV_KEYS,
+        PROVIDER_ENV_KEYS,
+        PROVIDER_SPECS,
+        plugin_catalog,
+    )
 
 _SEARCH_SCRIPT = Path(__file__).parent / "search.py"
 _TOOLSET_NAME = "web-search-plus"

--- a/http_client.py
+++ b/http_client.py
@@ -11,7 +11,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.3.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.3.1"
 
 
 class ProviderRequestError(Exception):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "2.3.0"
+version: "2.3.1"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 2.3.0
+Version: 2.3.1
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com.

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -45,4 +45,4 @@ def test_http_client_provider_request_error_exports_retry_metadata():
 
 
 def test_default_user_agent_uses_release_version():
-    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.3.0"
+    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.3.1"

--- a/tests/test_plugin_package_import.py
+++ b/tests/test_plugin_package_import.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_plugin_loads_with_hermes_package_style_import():
+    parent_name = "hermes_plugins"
+    module_name = f"{parent_name}.web_search_plus_import_test"
+
+    sys.modules.pop(module_name, None)
+    previous_parent = sys.modules.get(parent_name)
+    if previous_parent is None:
+        parent = types.ModuleType(parent_name)
+        parent.__path__ = []  # type: ignore[attr-defined]
+        sys.modules[parent_name] = parent
+
+    try:
+        spec = importlib.util.spec_from_file_location(
+            module_name,
+            ROOT / "__init__.py",
+            submodule_search_locations=[str(ROOT)],
+        )
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        module.__package__ = module_name
+        module.__path__ = [str(ROOT)]  # type: ignore[attr-defined]
+        sys.modules[module_name] = module
+
+        spec.loader.exec_module(module)
+
+        assert module.__version__ == "2.3.1"
+        assert module._get_provider_catalog()
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_parent is None:
+            sys.modules.pop(parent_name, None)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "2.3.0"
+EXPECTED_VERSION = "2.3.1"
 
 
 def _load_plugin_module():


### PR DESCRIPTION
## Summary
- Fixes Hermes package-style plugin loading by using a relative `provider_registry` import in `__init__.py`.
- Keeps direct import/test compatibility with a fallback to the existing top-level import path.
- Bumps release surfaces to v2.3.1 and documents the hotfix.

## Test Plan
- `python -m pytest tests/ -q` → 192 passed
- Hermes-style package load smoke from `/opt/hermes` → OK, version 2.3.1
- `git diff --check` → clean
- changed-line privacy scan → clean

Closes #47
