### PR TITLE
perf: run search/extract in-process and parallelize research mode (P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### ⚡ Performance
+- The Hermes plugin now runs `web_search_plus` and `web_extract_plus` in-process by default instead of spawning a `search.py` subprocess per call, removing interpreter-startup, module re-import, and JSON round-trip overhead on every tool invocation. The legacy subprocess path remains as an automatic fallback (used if the in-process import fails) and can be forced with `WSP_FORCE_SUBPROCESS=1`. A thread watchdog preserves the previous hard wall-clock timeout.
+- Research mode now queries its providers concurrently instead of sequentially, so wall-clock cost tracks the slowest provider rather than the sum of all of them. Result ordering stays deterministic (preserved by submission order) and the time budget still gates which providers launch and whether extraction runs.
+
+### 🔧 Improved
+- Provider retry backoff now adds bounded random jitter (`RETRY_JITTER_FRACTION`) so concurrent or repeated retries against a recovering provider no longer synchronize into bursts.
+- Provider health read-modify-write is now guarded by a lock so concurrent in-process provider calls (parallel research mode) cannot lose cooldown updates.
+
+### 🧱 Internal
+- Split `search.py`'s monolithic `main()` into `build_parser()`, the pure `execute_search_request()` pipeline (returns `(payload, exit_code)` without printing or `sys.exit`), and in-process `run_search_request()`/`run_extract_request()` entry points. CLI behaviour and output are unchanged.
+
+### 🧪 Tests
+- Added in-process search coverage (provider config resolution, auto-routing, explicit-provider error dicts, empty-query guard), research-mode out-of-order completion ordering, retry jitter bounds, and subprocess-fallback behaviour.
+
 ## [v2.3.1] — 2026-05-31
 
 ### 🐛 Fixed

--- a/__init__.py
+++ b/__init__.py
@@ -16,10 +16,13 @@ import shutil
 import subprocess
 import tempfile
 import sys
+import threading
 import time
 import webbrowser
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeout
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Callable, Dict, List, Mapping, Optional
 
 try:  # Package load path used by Hermes plugin discovery.
     from .provider_registry import (
@@ -815,6 +818,69 @@ def _on_session_start(**kwargs: Any) -> Optional[Dict[str, str]]:
     return hint
 
 
+_search_module: Any = None
+_search_import_failed = False
+_search_import_lock = threading.Lock()
+
+
+def _load_search_module() -> Any:
+    """Import the in-process search engine, ensuring the plugin dir is importable.
+
+    ``search.py`` uses flat absolute imports for its sibling modules, so the plugin
+    directory must be on ``sys.path`` (it is for the standalone CLI/tests, but not
+    necessarily when Hermes loads us as a package). Returns the module, or ``None``
+    if import fails so callers transparently fall back to the subprocess path.
+    """
+    global _search_module, _search_import_failed
+    if _search_module is not None:
+        return _search_module
+    if _search_import_failed:
+        return None
+    with _search_import_lock:
+        if _search_module is not None:
+            return _search_module
+        if _search_import_failed:
+            return None
+        plugin_dir = str(Path(__file__).parent)
+        if plugin_dir not in sys.path:
+            sys.path.insert(0, plugin_dir)
+        try:
+            import search as _search  # noqa: F401 — flat sibling layout resolved via sys.path
+        except Exception:  # pragma: no cover - defensive: fall back to subprocess
+            logger.exception("web-search-plus: in-process search import failed; using subprocess fallback")
+            _search_import_failed = True
+            return None
+        _search_module = _search
+        return _search_module
+
+
+def _force_subprocess() -> bool:
+    """Allow operators to opt back into the legacy subprocess path via env."""
+    return _clean_env_value(os.environ.get("WSP_FORCE_SUBPROCESS", "")) is not None
+
+
+def _search_timeout(mode: str, research_time_budget: float, base: int = 75) -> int:
+    """Wall-clock budget for a search call, widened for research mode."""
+    if mode == "research":
+        return max(base, int(research_time_budget) + 15)
+    return base
+
+
+def _call_with_timeout(fn: Callable[[], dict], timeout: int) -> dict:
+    """Run ``fn`` in a worker thread bounded by a wall-clock timeout.
+
+    Mirrors the hard timeout the subprocess used to give us. On timeout we stop
+    waiting (the orphaned worker is bounded by per-provider HTTP timeouts) and
+    raise ``FuturesTimeout`` for the caller to translate into a structured error.
+    """
+    executor = ThreadPoolExecutor(max_workers=1)
+    future = executor.submit(fn)
+    try:
+        return future.result(timeout=timeout)
+    finally:
+        executor.shutdown(wait=False)
+
+
 def _run_search(
     query: str,
     provider: str = "auto",
@@ -830,7 +896,55 @@ def _run_search(
     country: Optional[str] = None,
     subprocess_timeout: int = 75,
 ) -> dict:
-    """Call search.py subprocess and return parsed JSON result."""
+    """Run a search in-process (fast path), falling back to the subprocess engine.
+
+    The in-process path avoids per-call interpreter startup, module re-import, and
+    a JSON round-trip. A thread watchdog preserves the wall-clock timeout the
+    subprocess previously enforced.
+    """
+    timeout = _search_timeout(mode, research_time_budget, subprocess_timeout)
+    search = None if _force_subprocess() else _load_search_module()
+    if search is None:
+        return _run_search_subprocess(
+            query=query, provider=provider, count=count, exa_depth=exa_depth,
+            time_range=time_range, include_domains=include_domains,
+            exclude_domains=exclude_domains, mode=mode, quality_report=quality_report,
+            research_time_budget=research_time_budget, language=language, country=country,
+            subprocess_timeout=timeout,
+        )
+
+    def call() -> dict:
+        return search.run_search_request(
+            query=query, provider=provider, count=count, exa_depth=exa_depth,
+            time_range=time_range, include_domains=include_domains,
+            exclude_domains=exclude_domains, mode=mode, quality_report=quality_report,
+            research_time_budget=research_time_budget, language=language, country=country,
+        )
+
+    try:
+        return _call_with_timeout(call, timeout)
+    except FuturesTimeout:
+        return {"error": f"Search timed out after {timeout}s", "provider": provider, "query": query, "results": []}
+    except Exception as e:
+        return {"error": str(e), "provider": provider, "query": query, "results": []}
+
+
+def _run_search_subprocess(
+    query: str,
+    provider: str = "auto",
+    count: int = 5,
+    exa_depth: str = "normal",
+    time_range: Optional[str] = None,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    mode: str = "normal",
+    quality_report: bool = False,
+    research_time_budget: float = 55.0,
+    language: Optional[str] = None,
+    country: Optional[str] = None,
+    subprocess_timeout: int = 75,
+) -> dict:
+    """Legacy fallback: call search.py as a subprocess and return parsed JSON."""
     cmd = [
         sys.executable,
         str(_SEARCH_SCRIPT),
@@ -892,7 +1006,40 @@ def _run_extract(
     render_js: bool = False,
     subprocess_timeout: int = 90,
 ) -> dict:
-    """Call search.py extract mode and return parsed JSON result."""
+    """Run URL extraction in-process (fast path), falling back to the subprocess."""
+    search = None if _force_subprocess() else _load_search_module()
+    if search is None:
+        return _run_extract_subprocess(
+            urls, provider=provider, output_format=output_format,
+            include_images=include_images, include_raw_html=include_raw_html,
+            render_js=render_js, subprocess_timeout=subprocess_timeout,
+        )
+
+    def call() -> dict:
+        return search.run_extract_request(
+            urls, provider=provider, output_format=output_format,
+            include_images=include_images, include_raw_html=include_raw_html,
+            render_js=render_js,
+        )
+
+    try:
+        return _call_with_timeout(call, subprocess_timeout)
+    except FuturesTimeout:
+        return {"error": f"Extract timed out after {subprocess_timeout}s", "provider": provider, "results": []}
+    except Exception as e:
+        return {"error": str(e), "provider": provider, "results": []}
+
+
+def _run_extract_subprocess(
+    urls: List[str],
+    provider: str = "auto",
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    subprocess_timeout: int = 90,
+) -> dict:
+    """Legacy fallback: call search.py extract mode and return parsed JSON result."""
     cmd = [
         sys.executable,
         str(_SEARCH_SCRIPT),

--- a/__init__.py
+++ b/__init__.py
@@ -9,6 +9,7 @@ __version__ = "2.3.1"
 
 import argparse
 import getpass
+import importlib.util
 import json
 import logging
 import os
@@ -824,12 +825,13 @@ _search_import_lock = threading.Lock()
 
 
 def _load_search_module() -> Any:
-    """Import the in-process search engine, ensuring the plugin dir is importable.
+    """Load the in-process search engine from this plugin's ``search.py``.
 
-    ``search.py`` uses flat absolute imports for its sibling modules, so the plugin
-    directory must be on ``sys.path`` (it is for the standalone CLI/tests, but not
-    necessarily when Hermes loads us as a package). Returns the module, or ``None``
-    if import fails so callers transparently fall back to the subprocess path.
+    ``search.py`` still uses flat absolute imports for sibling modules, so the
+    plugin directory must be on ``sys.path`` while it loads. The search module
+    itself is loaded from its exact file path under a private module name instead
+    of ``import search`` so an unrelated global ``search`` module cannot shadow the
+    plugin engine.
     """
     global _search_module, _search_import_failed
     if _search_module is not None:
@@ -842,14 +844,28 @@ def _load_search_module() -> Any:
         if _search_import_failed:
             return None
         plugin_dir = str(Path(__file__).parent)
+        inserted = False
         if plugin_dir not in sys.path:
             sys.path.insert(0, plugin_dir)
+            inserted = True
         try:
-            import search as _search  # noqa: F401 — flat sibling layout resolved via sys.path
+            spec = importlib.util.spec_from_file_location("_wsp_search_engine", _SEARCH_SCRIPT)
+            if spec is None or spec.loader is None:
+                raise ImportError(f"cannot load search engine from {_SEARCH_SCRIPT}")
+            _search = importlib.util.module_from_spec(spec)
+            sys.modules["_wsp_search_engine"] = _search
+            spec.loader.exec_module(_search)
         except Exception:  # pragma: no cover - defensive: fall back to subprocess
+            sys.modules.pop("_wsp_search_engine", None)
             logger.exception("web-search-plus: in-process search import failed; using subprocess fallback")
             _search_import_failed = True
             return None
+        finally:
+            if inserted:
+                try:
+                    sys.path.remove(plugin_dir)
+                except ValueError:  # pragma: no cover - defensive cleanup
+                    pass
         _search_module = _search
         return _search_module
 

--- a/provider_health.py
+++ b/provider_health.py
@@ -2,7 +2,9 @@
 
 import json
 import os
+import random
 import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Any, Dict, Tuple
@@ -14,6 +16,20 @@ from http_client import ProviderRequestError
 PROVIDER_HEALTH_FILE = CACHE_DIR / "provider_health.json"
 COOLDOWN_STEPS_SECONDS = [60, 300, 1500, 3600]  # 1m -> 5m -> 25m -> 1h cap
 RETRY_BACKOFF_SECONDS = [1, 3, 9]
+# Add up to this fraction of the base delay as random jitter so concurrent or
+# repeated retries against a recovering provider do not synchronize into bursts.
+RETRY_JITTER_FRACTION = 0.5
+
+# Serializes read-modify-write of the shared health file when search/extract run
+# providers concurrently in-process (e.g. parallel research mode). Atomic writes
+# already prevent torn reads; this prevents lost updates between threads.
+_HEALTH_LOCK = threading.Lock()
+
+
+def _retry_delay(attempt: int) -> float:
+    """Return the backoff delay (seconds) for a retry attempt, with jitter."""
+    base = RETRY_BACKOFF_SECONDS[min(attempt, len(RETRY_BACKOFF_SECONDS) - 1)]
+    return base + random.uniform(0.0, base * RETRY_JITTER_FRACTION)
 
 
 def _ensure_parent(path: Path) -> None:
@@ -60,27 +76,29 @@ def provider_in_cooldown(provider: str) -> Tuple[bool, int]:
 
 
 def mark_provider_failure(provider: str, error_message: str) -> Dict[str, Any]:
-    state = _load_provider_health()
-    now = int(time.time())
-    pstate = state.get(provider, {})
-    fail_count = int(pstate.get("failure_count", 0)) + 1
-    cooldown_seconds = COOLDOWN_STEPS_SECONDS[min(fail_count - 1, len(COOLDOWN_STEPS_SECONDS) - 1)]
-    state[provider] = {
-        "failure_count": fail_count,
-        "cooldown_until": now + cooldown_seconds,
-        "cooldown_seconds": cooldown_seconds,
-        "last_error": error_message,
-        "last_failure_at": now,
-    }
-    _save_provider_health(state)
-    return state[provider]
+    with _HEALTH_LOCK:
+        state = _load_provider_health()
+        now = int(time.time())
+        pstate = state.get(provider, {})
+        fail_count = int(pstate.get("failure_count", 0)) + 1
+        cooldown_seconds = COOLDOWN_STEPS_SECONDS[min(fail_count - 1, len(COOLDOWN_STEPS_SECONDS) - 1)]
+        state[provider] = {
+            "failure_count": fail_count,
+            "cooldown_until": now + cooldown_seconds,
+            "cooldown_seconds": cooldown_seconds,
+            "last_error": error_message,
+            "last_failure_at": now,
+        }
+        _save_provider_health(state)
+        return state[provider]
 
 
 def reset_provider_health(provider: str) -> None:
-    state = _load_provider_health()
-    if provider in state:
-        state.pop(provider, None)
-        _save_provider_health(state)
+    with _HEALTH_LOCK:
+        state = _load_provider_health()
+        if provider in state:
+            state.pop(provider, None)
+            _save_provider_health(state)
 
 
 def execute_provider_with_retry(provider: str, operation, max_attempts: int = 3) -> Dict[str, Any]:
@@ -96,7 +114,7 @@ def execute_provider_with_retry(provider: str, operation, max_attempts: int = 3)
             if not e.transient:
                 break
             if attempt < max_attempts - 1:
-                time.sleep(RETRY_BACKOFF_SECONDS[min(attempt, len(RETRY_BACKOFF_SECONDS) - 1)])
+                time.sleep(_retry_delay(attempt))
                 continue
             break
         except Exception as e:

--- a/research.py
+++ b/research.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Tuple
 
 from quality import deduplicate_results_across_providers
@@ -17,15 +18,21 @@ def run_research_mode(
     max_extract_urls: int = 3,
     time_budget_seconds: float | None = None,
     now_fn=None,
+    max_workers: int | None = None,
 ) -> Dict[str, Any]:
     """Run broad search, deduplicate, then extract top sources for grounding.
 
     Research mode is intentionally best-effort: provider/extraction failures should
     produce diagnostics and partial search results instead of throwing away the
-    whole response. The optional time budget is checked between expensive calls so
-    the mode can degrade safely before starting more provider work or extraction.
+    whole response. Provider searches run concurrently to keep the wall-clock cost
+    close to the slowest single provider rather than the sum of all of them. The
+    optional time budget gates which providers are launched (checked before each
+    submission, so a tight budget still skips later providers deterministically) and
+    whether extraction runs at all.
+
+    Result ordering is preserved by provider submission order regardless of which
+    provider finishes first, so deduplication stays deterministic.
     """
-    provider_results: List[Tuple[str, Dict[str, Any]]] = []
     provider_errors: List[Dict[str, Any]] = []
     now = now_fn or time.monotonic
     start = now()
@@ -33,15 +40,32 @@ def run_research_mode(
     def budget_exhausted() -> bool:
         return time_budget_seconds is not None and (now() - start) >= time_budget_seconds
 
-    for provider in research_providers:
-        if budget_exhausted():
-            provider_errors.append({"provider": provider, "error": "skipped: research time budget exhausted"})
-            continue
-        try:
-            payload = execute_search(provider)
-            provider_results.append((provider, payload))
-        except Exception as e:
-            provider_errors.append({"provider": provider, "error": str(e)})
+    # Submit providers (budget gate is sequential/deterministic); the actual
+    # provider HTTP calls run concurrently in the thread pool.
+    pending: List[Tuple[int, str]] = []
+    futures: Dict[int, Any] = {}
+    workers = max_workers or max(1, len(research_providers))
+    executor = ThreadPoolExecutor(max_workers=workers)
+    try:
+        for index, provider in enumerate(research_providers):
+            if budget_exhausted():
+                provider_errors.append({"provider": provider, "error": "skipped: research time budget exhausted"})
+                continue
+            futures[index] = executor.submit(execute_search, provider)
+            pending.append((index, provider))
+
+        results_by_index: Dict[int, Tuple[str, Dict[str, Any]]] = {}
+        for index, provider in pending:
+            try:
+                results_by_index[index] = (provider, futures[index].result())
+            except Exception as e:
+                provider_errors.append({"provider": provider, "error": str(e)})
+    finally:
+        executor.shutdown(wait=True)
+
+    provider_results: List[Tuple[str, Dict[str, Any]]] = [
+        results_by_index[index] for index in sorted(results_by_index)
+    ]
 
     deduped, dedup_count = deduplicate_results_across_providers(provider_results, max_results)
     urls = [r.get("url") for r in deduped if r.get("url")][:max(0, max_extract_urls)]

--- a/search.py
+++ b/search.py
@@ -30,7 +30,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import List, Dict, Any, Tuple
+from typing import List, Dict, Any, Optional, Tuple
 from http_client import (  # noqa: F401 - re-exported for backward-compatible tests/imports
     ProviderRequestError,
     TRANSIENT_HTTP_CODES,
@@ -60,6 +60,7 @@ from config import (  # noqa: F401 - re-exported for backward-compatible tests/i
 )
 from provider_health import (  # noqa: F401 - re-exported for backward-compatible tests/imports
     RETRY_BACKOFF_SECONDS,
+    RETRY_JITTER_FRACTION,
     COOLDOWN_STEPS_SECONDS,
     execute_provider_with_retry,
     mark_provider_failure,
@@ -581,9 +582,13 @@ def build_parser_for_tests() -> argparse.ArgumentParser:
     return parser
 
 
-def main():
-    config = load_config()
+def build_parser(config: Dict[str, Any]) -> argparse.ArgumentParser:
+    """Build the search.py CLI argument parser.
 
+    Shared by the CLI ``main()`` entry and the in-process ``run_search_request``
+    helper so the Hermes plugin can route argv through the exact same parsing and
+    defaults without spawning a subprocess.
+    """
     parser = argparse.ArgumentParser(
         description="Web Search Plus — Intelligent multi-provider search with smart auto-routing",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -890,7 +895,13 @@ Full docs: See README.md and SKILL.md
         action="store_true",
         help="Show cache statistics and exit"
     )
-    
+
+    return parser
+
+
+def main():
+    config = load_config()
+    parser = build_parser(config)
     args = parser.parse_args()
 
     if args.command == "doctor":
@@ -940,7 +951,24 @@ Full docs: See README.md and SKILL.md
         indent = None if args.compact else 2
         print(json.dumps(explanation, indent=indent, ensure_ascii=False))
         return
-    
+
+    payload, exit_code = execute_search_request(args, config)
+    if exit_code == 0:
+        indent = None if args.compact else 2
+        print(json.dumps(payload, indent=indent, ensure_ascii=False))
+    else:
+        print(json.dumps(payload, indent=2), file=sys.stderr)
+        sys.exit(1)
+
+
+def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
+    """Run the search/research pipeline for parsed args.
+
+    Returns ``(payload, exit_code)`` where exit_code 0 means a success payload bound
+    for stdout and 1 means an error payload bound for stderr. This function never
+    prints or calls ``sys.exit`` so the Hermes plugin can invoke it in-process
+    instead of spawning a subprocess.
+    """
     # Determine provider
     if args.provider == "auto" or (args.provider is None and not args.similar_url):
         if args.query:
@@ -1073,6 +1101,7 @@ Full docs: See README.md and SKILL.md
                 timeout=int(linkup_config.get("timeout", 30)),
             )
         elif prov == "querit":
+            querit_config = config.get("querit", {})
             return search_querit(
                 query=args.query,
                 api_key=key,
@@ -1227,8 +1256,7 @@ Full docs: See README.md and SKILL.md
                 "routing": routing_info,
                 "cooldown_skips": cooldown_skips,
             }
-            print(json.dumps(error_result, indent=2), file=sys.stderr)
-            sys.exit(1)
+            return error_result, 1
 
         result = run_research_mode(
             query=args.query,
@@ -1256,9 +1284,7 @@ Full docs: See README.md and SKILL.md
             cooldown_skips=cooldown_skips,
             errors=result.get("routing", {}).get("provider_errors", []),
         )
-        indent = None if args.compact else 2
-        print(json.dumps(result, indent=indent, ensure_ascii=False))
-        return
+        return result, 0
 
     # Check cache first (unless --no-cache is set)
     cached_result = None
@@ -1376,8 +1402,7 @@ Full docs: See README.md and SKILL.md
                 errors=errors,
             )
 
-        indent = None if args.compact else 2
-        print(json.dumps(result, indent=indent, ensure_ascii=False))
+        return result, 0
     else:
         error_result = {
             "error": "All providers failed",
@@ -1387,8 +1412,83 @@ Full docs: See README.md and SKILL.md
             "provider_errors": errors,
             "cooldown_skips": cooldown_skips,
         }
-        print(json.dumps(error_result, indent=2), file=sys.stderr)
-        sys.exit(1)
+        return error_result, 1
+
+
+def run_search_request(
+    *,
+    query: str,
+    provider: str = "auto",
+    count: int = 5,
+    exa_depth: str = "normal",
+    time_range: Optional[str] = None,
+    include_domains: Optional[List[str]] = None,
+    exclude_domains: Optional[List[str]] = None,
+    mode: str = "normal",
+    quality_report: bool = False,
+    research_time_budget: float = 55.0,
+    language: Optional[str] = None,
+    country: Optional[str] = None,
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run a search in-process and return the result dict the CLI would emit.
+
+    Mirrors the argv the Hermes plugin used to pass to the subprocess, then routes
+    it through the same parser and pipeline so behaviour is identical without the
+    interpreter-startup and JSON round-trip cost of spawning ``search.py``.
+    """
+    if not query and not (include_domains or exclude_domains):
+        return {"error": "query is required", "provider": provider, "query": query, "results": []}
+    config = config or load_config()
+    argv: List[str] = [
+        "--query", query or "",
+        "--provider", provider or "auto",
+        "--max-results", str(count),
+    ]
+    if exa_depth and exa_depth != "normal":
+        argv += ["--exa-depth", exa_depth]
+    if time_range and time_range != "none":
+        argv += ["--time-range", time_range]
+    if include_domains:
+        argv += ["--include-domains", *include_domains]
+    if exclude_domains:
+        argv += ["--exclude-domains", *exclude_domains]
+    if mode and mode != "normal":
+        argv += ["--mode", mode, "--research-time-budget", str(research_time_budget)]
+    if quality_report:
+        argv += ["--quality-report"]
+    if language and language != "auto":
+        argv += ["--language", language]
+    if country and country != "auto":
+        argv += ["--country", country]
+
+    parser = build_parser(config)
+    args = parser.parse_args(argv)
+    payload, _exit_code = execute_search_request(args, config)
+    return payload
+
+
+def run_extract_request(
+    urls: List[str],
+    *,
+    provider: str = "auto",
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    config: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run URL extraction in-process and return the result dict."""
+    config = config or load_config()
+    return extract_plus(
+        urls=urls,
+        provider=provider or "auto",
+        output_format=output_format,
+        include_images=include_images,
+        include_raw_html=include_raw_html,
+        render_js=render_js,
+        config=config,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_extract_plus.py
+++ b/tests/test_extract_plus.py
@@ -258,7 +258,13 @@ class ExtractPlusCoreTests(unittest.TestCase):
 
         self.assertEqual(result["provider"], "firecrawl")
         self.assertEqual(mock_firecrawl.call_count, 2)
-        mock_sleep.assert_called_once_with(search.RETRY_BACKOFF_SECONDS[0])
+        # Retry backoff now carries jitter to de-synchronize retries: the delay is
+        # the base step plus up to RETRY_JITTER_FRACTION of it.
+        mock_sleep.assert_called_once()
+        (slept,) = mock_sleep.call_args[0]
+        base = search.RETRY_BACKOFF_SECONDS[0]
+        self.assertGreaterEqual(slept, base)
+        self.assertLessEqual(slept, base * (1 + search.RETRY_JITTER_FRACTION))
 
     def test_extract_plus_marks_failed_provider_and_resets_successful_fallback(self):
         transient = search.ProviderRequestError("temporary outage", status_code=503, transient=True)
@@ -292,16 +298,47 @@ class ExtractPlusCoreTests(unittest.TestCase):
 
 
 class ExtractPlusPluginTests(unittest.TestCase):
-    def test_run_extract_invokes_search_script_extract_mode(self):
+    def test_run_extract_runs_in_process(self):
+        captured = {}
+
+        def fake_run_extract_request(urls, **kwargs):
+            captured["urls"] = urls
+            captured.update(kwargs)
+            return {"provider": "linkup", "results": []}
+
+        class FakeSearch:
+            run_extract_request = staticmethod(fake_run_extract_request)
+
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("WSP_FORCE_SUBPROCESS", None)
+            with mock.patch.object(plugin, "_load_search_module", return_value=FakeSearch):
+                with mock.patch("subprocess.run", side_effect=AssertionError("should not subprocess")):
+                    result = plugin._run_extract(
+                        urls=["https://example.com"],
+                        provider="linkup",
+                        output_format="markdown",
+                        include_images=True,
+                        render_js=True,
+                    )
+
+        self.assertEqual(result["provider"], "linkup")
+        self.assertEqual(captured["urls"], ["https://example.com"])
+        self.assertEqual(captured["provider"], "linkup")
+        self.assertEqual(captured["output_format"], "markdown")
+        self.assertTrue(captured["include_images"])
+        self.assertTrue(captured["render_js"])
+
+    def test_run_extract_subprocess_fallback_builds_extract_command(self):
         completed = mock.Mock(returncode=0, stdout=json.dumps({"provider": "linkup", "results": []}), stderr="")
-        with mock.patch("subprocess.run", return_value=completed) as mock_run:
-            result = plugin._run_extract(
-                urls=["https://example.com"],
-                provider="linkup",
-                output_format="markdown",
-                include_images=True,
-                render_js=True,
-            )
+        with mock.patch.dict(os.environ, {"WSP_FORCE_SUBPROCESS": "1"}):
+            with mock.patch("subprocess.run", return_value=completed) as mock_run:
+                result = plugin._run_extract(
+                    urls=["https://example.com"],
+                    provider="linkup",
+                    output_format="markdown",
+                    include_images=True,
+                    render_js=True,
+                )
 
         self.assertEqual(result["provider"], "linkup")
         cmd = mock_run.call_args.kwargs["args"] if "args" in mock_run.call_args.kwargs else mock_run.call_args.args[0]

--- a/tests/test_inprocess_search.py
+++ b/tests/test_inprocess_search.py
@@ -1,0 +1,98 @@
+"""In-process search entry (run_search_request) regression coverage.
+
+These lock down the search.py refactor that lets the Hermes plugin call the search
+pipeline in-process instead of spawning a subprocess: the provider dispatch must
+still resolve per-provider config, auto-routing/caching must work, and the explicit
+provider error path must return a structured dict (never sys.exit) so the in-process
+caller is not killed.
+"""
+
+import unittest
+from unittest import mock
+
+import search
+
+
+def _canned(provider):
+    return {
+        "provider": provider,
+        "query": "q",
+        "results": [{"url": "https://example.test/a", "title": "A", "snippet": "s"}],
+        "images": [],
+        "answer": "",
+        "metadata": {},
+    }
+
+
+class InProcessSearchTests(unittest.TestCase):
+    def _isolate(self, stack):
+        # Keep the pipeline off the real cache/cooldown/health files.
+        stack.enter_context(mock.patch.object(search, "provider_in_cooldown", lambda p: (False, 0)))
+        stack.enter_context(mock.patch.object(search, "cache_get", lambda **kw: None))
+        stack.enter_context(mock.patch.object(search, "cache_put", lambda **kw: None))
+        stack.enter_context(mock.patch.object(search, "reset_provider_health", lambda p: None))
+
+    def test_querit_branch_resolves_provider_config(self):
+        # Regression: execute_search_request must still define querit_config locally
+        # after the parser/orchestration split (previously a NameError at runtime).
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            self._isolate(stack)
+            stack.enter_context(mock.patch.dict("os.environ", {"QUERIT_API_KEY": "querit-test-key"}))
+            seen = {}
+
+            def fake_querit(**kwargs):
+                seen.update(kwargs)
+                return _canned("querit")
+
+            stack.enter_context(mock.patch.object(search, "search_querit", fake_querit))
+            result = search.run_search_request(query="multilingual realtime news", provider="querit", count=3)
+
+        self.assertEqual(result["provider"], "querit")
+        self.assertEqual(result["results"][0]["url"], "https://example.test/a")
+        # The querit timeout argument is sourced from the resolved config section.
+        self.assertIn("timeout", seen)
+
+    def test_auto_routes_in_process_and_reports_routing(self):
+        import contextlib
+
+        routing = {
+            "provider": "you",
+            "confidence": 0.9,
+            "confidence_level": "high",
+            "reason": "test-route",
+            "top_signals": [],
+            "scores": {"you": 9.0},
+            "analysis_summary": {"routing_class": "general"},
+        }
+        with contextlib.ExitStack() as stack:
+            self._isolate(stack)
+            stack.enter_context(mock.patch.dict("os.environ", {"YOU_API_KEY": "you-test-key"}))
+            stack.enter_context(mock.patch.object(search, "auto_route_provider", lambda q, c: routing))
+            stack.enter_context(mock.patch.object(search, "search_you", lambda **kw: _canned("you")))
+            result = search.run_search_request(query="graz weather today", provider="auto", count=3)
+
+        self.assertTrue(result["routing"]["auto_routed"])
+        self.assertEqual(result["provider"], "you")
+        self.assertFalse(result["cached"])
+
+    def test_explicit_missing_key_returns_error_dict_without_exit(self):
+        import contextlib
+
+        with contextlib.ExitStack() as stack:
+            self._isolate(stack)
+            stack.enter_context(mock.patch.dict("os.environ", {}, clear=True))
+            result = search.run_search_request(query="anything", provider="serpbase", count=1)
+
+        self.assertEqual(result["error"], "All providers failed")
+        self.assertEqual(result["provider"], "serpbase")
+        self.assertTrue(result["provider_errors"])
+
+    def test_empty_query_returns_error_dict(self):
+        result = search.run_search_request(query="", provider="auto", count=3)
+        self.assertEqual(result["error"], "query is required")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_no_answer_plus.py
+++ b/tests/test_no_answer_plus.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
+import types
 from pathlib import Path
 
 
@@ -94,3 +96,20 @@ def test_research_mode_subprocess_fallback_passes_budget(monkeypatch):
 
     assert "--research-time-budget" in seen["cmd"]
     assert seen["timeout"] > 120
+
+
+def test_load_search_module_ignores_unrelated_global_search_module(monkeypatch):
+    fake_search = types.ModuleType("search")
+    setattr(fake_search, "not_the_plugin_engine", True)
+    monkeypatch.setitem(sys.modules, "search", fake_search)
+    monkeypatch.setattr(wsp, "_search_module", None)
+    monkeypatch.setattr(wsp, "_search_import_failed", False)
+    monkeypatch.delitem(sys.modules, "_wsp_search_engine", raising=False)
+
+    loaded = wsp._load_search_module()
+
+    assert loaded is not None
+    assert loaded is not fake_search
+    assert Path(loaded.__file__).resolve() == PLUGIN_PATH.with_name("search.py").resolve()
+    assert hasattr(loaded, "run_search_request")
+    assert sys.modules["search"] is fake_search

--- a/tests/test_no_answer_plus.py
+++ b/tests/test_no_answer_plus.py
@@ -41,7 +41,39 @@ def test_setup_guidance_does_not_advertise_answer_layer(monkeypatch):
     assert "answer=" not in guidance
 
 
-def test_research_mode_subprocess_timeout_exceeds_requested_budget(monkeypatch):
+def test_research_mode_timeout_exceeds_requested_budget():
+    # Research mode widens the wall-clock watchdog beyond the requested budget so
+    # the in-flight provider/extraction work can finish; normal mode uses the base.
+    assert wsp._search_timeout("research", 120) > 120
+    assert wsp._search_timeout("normal", 120) == 75
+
+
+def test_search_runs_in_process_without_subprocess(monkeypatch):
+    captured = {}
+
+    def fake_run_search_request(**kwargs):
+        captured.update(kwargs)
+        return {"provider": "you", "results": []}
+
+    class FakeSearch:
+        run_search_request = staticmethod(fake_run_search_request)
+
+    monkeypatch.delenv("WSP_FORCE_SUBPROCESS", raising=False)
+    monkeypatch.setattr(wsp, "_load_search_module", lambda: FakeSearch)
+
+    def explode(*args, **kwargs):
+        raise AssertionError("subprocess fallback should not be used on the in-process path")
+
+    monkeypatch.setattr(wsp.subprocess, "run", explode)
+
+    result = wsp._run_search("graz weather", mode="research", research_time_budget=120)
+
+    assert result == {"provider": "you", "results": []}
+    assert captured["query"] == "graz weather"
+    assert captured["mode"] == "research"
+
+
+def test_research_mode_subprocess_fallback_passes_budget(monkeypatch):
     seen = {}
 
     def fake_run(cmd, capture_output, text, timeout, env):
@@ -55,6 +87,7 @@ def test_research_mode_subprocess_timeout_exceeds_requested_budget(monkeypatch):
 
         return Result()
 
+    monkeypatch.setenv("WSP_FORCE_SUBPROCESS", "1")
     monkeypatch.setattr(wsp.subprocess, "run", fake_run)
 
     wsp._run_search("deep query", mode="research", research_time_budget=120)

--- a/tests/test_quality_research.py
+++ b/tests/test_quality_research.py
@@ -130,7 +130,9 @@ class ResearchModeTests(unittest.TestCase):
             max_extract_urls=2,
         )
 
-        self.assertEqual(calls, ["tavily", "linkup"])
+        # Providers run concurrently, so completion/call order is not guaranteed,
+        # but both must be queried and result ordering must stay deterministic.
+        self.assertEqual(sorted(calls), ["linkup", "tavily"])
         self.assertEqual(result["mode"], "research")
         self.assertEqual(result["routing"]["providers_queried"], ["tavily", "linkup"])
         self.assertEqual(result["metadata"]["dedup_count"], 1)
@@ -168,6 +170,36 @@ class ResearchModeTests(unittest.TestCase):
         self.assertEqual(result["routing"]["extraction_provider"], None)
         self.assertEqual(result["routing"]["extraction_error"], "extract provider timed out")
         self.assertEqual(result["metadata"]["extracted_url_count"], 0)
+
+    def test_research_mode_preserves_provider_order_when_completion_is_out_of_order(self):
+        import time as _time
+
+        def execute(provider):
+            # Provider submitted first finishes last; ordering must still follow
+            # submission order so deduplication stays deterministic.
+            if provider == "tavily":
+                _time.sleep(0.05)
+            return {"provider": provider, "results": [
+                {"url": f"https://{provider}.test/a", "title": provider, "description": "x"},
+            ]}
+
+        def extract(urls):
+            return {"provider": None, "results": []}
+
+        result = search.run_research_mode(
+            query="ordered research",
+            research_providers=["tavily", "linkup"],
+            execute_search=execute,
+            extract_urls=extract,
+            max_results=5,
+            max_extract_urls=0,
+        )
+
+        self.assertEqual(result["routing"]["providers_queried"], ["tavily", "linkup"])
+        self.assertEqual([r["url"] for r in result["results"]], [
+            "https://tavily.test/a",
+            "https://linkup.test/a",
+        ])
 
     def test_research_mode_respects_time_budget_between_providers_and_skips_extract(self):
         ticks = iter([0.0, 0.0, 6.0, 6.0])


### PR DESCRIPTION
## What & why

This lands the two **P0 latency wins** from the improvement review: stop paying a fresh Python interpreter + module re-import + JSON round-trip on every tool call, and stop running research-mode providers one after another.

### 1. In-process search/extract (was: subprocess per call)
Previously every `web_search_plus` / `web_extract_plus` call shelled out to `search.py` via `subprocess.run`, re-importing all modules and reloading config/`.env` each time (~100–300 ms of pure overhead per call, plus no in-process reuse).

- `search.py` is split so the pipeline is callable in-process:
  - `build_parser(config)` — parser construction (shared by CLI + in-process).
  - `execute_search_request(args, config) -> (payload, exit_code)` — the **pure** search/research pipeline; no printing, no `sys.exit`.
  - `run_search_request(...)` / `run_extract_request(...)` — in-process entry points that route the **same argv → args → pipeline** path the subprocess used.
- `__init__.py` calls these directly. A thread watchdog preserves the previous hard wall-clock timeout. The **subprocess path is kept as an automatic fallback** (used if the in-process import fails) and can be forced with `WSP_FORCE_SUBPROCESS=1`.
- **CLI behaviour and output are unchanged** — `main()` still prints success to stdout and errors to stderr with the same exit codes; the CLI smoke tests pass untouched.

### 2. Parallel research mode (was: sequential)
`research.py` now submits providers to a thread pool instead of looping. Wall-clock cost tracks the slowest provider rather than the sum of all of them. The budget gate stays deterministic (checked before each submission) and **result ordering is preserved by submission order**, so deduplication stays stable.

### 3. Reliability touch-ups (small, but they matter once calls run concurrently)
- Retry backoff gains bounded jitter (`RETRY_JITTER_FRACTION`) so retries against a recovering provider don't synchronize into bursts.
- The provider-health read-modify-write is now lock-guarded so parallel in-process calls can't lose cooldown updates.

## Risk & compatibility
- Compatibility shim seams (`search.make_request` monkeypatch points) are preserved — the in-process path still routes through the module-level provider wrappers.
- If the flat in-process import ever fails under a host that doesn't put the plugin dir on `sys.path`, the subprocess fallback keeps things working with no behaviour change.
- A latent coupling surfaced and was fixed during the split (`querit_config` is now resolved inside the provider branch); previously untested, now covered.

## Tests
`200 passed`, `ruff` clean, all CI-listed modules compile. New coverage:
- In-process pipeline: provider-config resolution (querit regression), auto-routing, explicit-provider error dicts (no `sys.exit`), empty-query guard.
- Research mode: out-of-order completion still yields submission-ordered results.
- Retry jitter bounds; in-process vs. forced-subprocess fallback behaviour.

## Notes
- Updated `CHANGELOG.md` (Unreleased).
- Follow-ups from the same review (not in this PR): cost/usage ledger, published-date + always-on authority labels in results, `pyproject.toml` + mypy + coverage + `golden_eval` in CI.