### PR TITLE
Fix reliability bugs: research budget enforcement, future timeouts, 429 handling, cooldown decay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
           python -m py_compile
           search.py
           __init__.py
+          daemon_tasks.py
           http_client.py
           cache.py
           config.py

--- a/__init__.py
+++ b/__init__.py
@@ -20,7 +20,6 @@ import sys
 import threading
 import time
 import webbrowser
-from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeout
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional
@@ -45,6 +44,11 @@ except ImportError:  # Direct script/test imports from the plugin directory.
         plugin_catalog,
     )
     from env_loader import clean_env_value as _shared_clean_env_value, get_hermes_env_path, load_env_files
+
+try:
+    from .daemon_tasks import DaemonTask
+except ImportError:
+    from daemon_tasks import DaemonTask
 
 _SEARCH_SCRIPT = Path(__file__).parent / "search.py"
 _TOOLSET_NAME = "web-search-plus"
@@ -874,18 +878,15 @@ def _search_timeout(mode: str, research_time_budget: float, base: int = 75) -> i
 
 
 def _call_with_timeout(fn: Callable[[], dict], timeout: int) -> dict:
-    """Run ``fn`` in a worker thread bounded by a wall-clock timeout.
+    """Run ``fn`` on a daemon thread bounded by a wall-clock timeout.
 
     Mirrors the hard timeout the subprocess used to give us. On timeout we stop
     waiting (the orphaned worker is bounded by per-provider HTTP timeouts) and
     raise ``FuturesTimeout`` for the caller to translate into a structured error.
+    A daemon thread — unlike a ThreadPoolExecutor worker — is not joined at
+    interpreter exit, so an overdue call cannot stall process shutdown either.
     """
-    executor = ThreadPoolExecutor(max_workers=1)
-    future = executor.submit(fn)
-    try:
-        return future.result(timeout=timeout)
-    finally:
-        executor.shutdown(wait=False)
+    return DaemonTask(fn).result(timeout=timeout)
 
 
 def _run_search(

--- a/daemon_tasks.py
+++ b/daemon_tasks.py
@@ -1,0 +1,56 @@
+"""Future-like tasks on daemon threads that never block interpreter exit.
+
+``concurrent.futures`` registers an atexit hook that joins every worker
+thread, so even after ``ThreadPoolExecutor.shutdown(wait=False)`` a hung
+provider call keeps the *process* alive until the worker finishes. The
+budget-bounded caller returns on time, but a CLI/subprocess invocation then
+stalls at exit — exactly the path web-search-plus uses for its subprocess
+fallback. Daemon threads are abandoned at interpreter shutdown instead, so
+the time budget bounds both the function return and the process lifetime.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from typing import Any, Callable, Optional
+
+
+class DaemonTask:
+    """Run a callable on a daemon thread with a Future-like ``result(timeout)``."""
+
+    def __init__(self, fn: Callable[..., Any], *args: Any, **kwargs: Any):
+        self._done = threading.Event()
+        self._result: Any = None
+        self._exc: Optional[BaseException] = None
+        self._thread = threading.Thread(
+            target=self._run,
+            args=(fn, args, kwargs),
+            daemon=True,
+            name="wsp-daemon-task",
+        )
+        self._thread.start()
+
+    def _run(self, fn: Callable[..., Any], args: tuple, kwargs: dict) -> None:
+        try:
+            self._result = fn(*args, **kwargs)
+        except BaseException as exc:  # re-raised to result() callers
+            self._exc = exc
+        finally:
+            self._done.set()
+
+    def done(self) -> bool:
+        return self._done.is_set()
+
+    def result(self, timeout: Optional[float] = None) -> Any:
+        """Return the callable's result, raising FuturesTimeoutError on timeout.
+
+        A timeout abandons the task: the daemon thread keeps running in the
+        background (bounded by per-request HTTP timeouts) but neither blocks
+        the caller nor interpreter shutdown.
+        """
+        if not self._done.wait(timeout):
+            raise FuturesTimeoutError("daemon task did not finish in time")
+        if self._exc is not None:
+            raise self._exc
+        return self._result

--- a/extract.py
+++ b/extract.py
@@ -104,7 +104,7 @@ def extract_plus(
             return result
         except Exception as e:
             error_msg = str(e)
-            cooldown_info = mark_provider_failure(prov, error_msg)
+            cooldown_info = mark_provider_failure(prov, error_msg, retry_after=getattr(e, "retry_after", None))
             errors.append({"provider": prov, "error": error_msg, "cooldown_seconds": cooldown_info.get("cooldown_seconds")})
             continue
     error_result = {"provider": selected, "results": [], "error": "All extraction providers failed", "fallback_errors": errors}

--- a/http_client.py
+++ b/http_client.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from email.utils import parsedate_to_datetime
 from http.client import IncompleteRead
 import gzip
 import json
+import time
 import zlib
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
@@ -17,10 +19,18 @@ DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.4.0"
 class ProviderRequestError(Exception):
     """Structured provider error with retry/cooldown metadata."""
 
-    def __init__(self, message: str, status_code: int | None = None, transient: bool = False):
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        transient: bool = False,
+        retry_after: float | None = None,
+    ):
         super().__init__(message)
         self.status_code = status_code
         self.transient = transient
+        # Provider-requested wait (seconds) from a Retry-After header, if any.
+        self.retry_after = retry_after
 
 
 def _response_header(response, name: str) -> str:
@@ -87,6 +97,24 @@ def _extract_http_error_detail(error: HTTPError) -> str:
         return error_body[:500]
 
 
+def _parse_retry_after(error: HTTPError) -> float | None:
+    """Parse a Retry-After header (delta-seconds or HTTP-date) into seconds."""
+    value = _response_header(error, "Retry-After").strip()
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+    try:
+        retry_at = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    if retry_at is None:
+        return None
+    return max(0.0, retry_at.timestamp() - time.time())
+
+
 def _raise_provider_http_error(error: HTTPError) -> None:
     error_detail = _extract_http_error_detail(error)
     friendly_msg = _friendly_http_error(error.code, error_detail)
@@ -94,6 +122,7 @@ def _raise_provider_http_error(error: HTTPError) -> None:
         f"{friendly_msg} (HTTP {error.code})",
         status_code=error.code,
         transient=error.code in TRANSIENT_HTTP_CODES,
+        retry_after=_parse_retry_after(error) if error.code == 429 else None,
     )
 
 

--- a/provider_health.py
+++ b/provider_health.py
@@ -7,7 +7,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from cache import CACHE_DIR
 from http_client import ProviderRequestError
@@ -19,6 +19,16 @@ RETRY_BACKOFF_SECONDS = [1, 3, 9]
 # Add up to this fraction of the base delay as random jitter so concurrent or
 # repeated retries against a recovering provider do not synchronize into bursts.
 RETRY_JITTER_FRACTION = 0.5
+# Failures older than this no longer escalate the cooldown ladder: a provider
+# that fails once every few hours should restart at the shortest cooldown step
+# instead of compounding toward the 1h cap.
+FAILURE_DECAY_SECONDS = 1800
+# Rate-limit (429) responses get at most one retry per request; burning the full
+# retry budget against an exhausted quota only wastes time and provider credits.
+RATE_LIMIT_MAX_ATTEMPTS = 2
+# Longest Retry-After wait we will honor inline. Anything above this is left to
+# the cooldown ladder instead of blocking the current request.
+MAX_RETRY_AFTER_WAIT_SECONDS = 30.0
 
 # Serializes read-modify-write of the shared health file when search/extract run
 # providers concurrently in-process (e.g. parallel research mode). Atomic writes
@@ -75,13 +85,21 @@ def provider_in_cooldown(provider: str) -> Tuple[bool, int]:
     return (remaining > 0, max(0, remaining))
 
 
-def mark_provider_failure(provider: str, error_message: str) -> Dict[str, Any]:
+def mark_provider_failure(provider: str, error_message: str, retry_after: Optional[float] = None) -> Dict[str, Any]:
     with _HEALTH_LOCK:
         state = _load_provider_health()
         now = int(time.time())
         pstate = state.get(provider, {})
-        fail_count = int(pstate.get("failure_count", 0)) + 1
+        prev_count = int(pstate.get("failure_count", 0))
+        last_failure_at = int(pstate.get("last_failure_at", 0) or 0)
+        if last_failure_at and now - last_failure_at > FAILURE_DECAY_SECONDS:
+            # Stale failure history: restart the escalation ladder.
+            prev_count = 0
+        fail_count = prev_count + 1
         cooldown_seconds = COOLDOWN_STEPS_SECONDS[min(fail_count - 1, len(COOLDOWN_STEPS_SECONDS) - 1)]
+        if retry_after is not None and retry_after > 0:
+            # Respect the provider's explicit wait request, capped at the ladder max.
+            cooldown_seconds = min(max(cooldown_seconds, int(retry_after)), COOLDOWN_STEPS_SECONDS[-1])
         state[provider] = {
             "failure_count": fail_count,
             "cooldown_until": now + cooldown_seconds,
@@ -113,10 +131,20 @@ def execute_provider_with_retry(provider: str, operation, max_attempts: int = 3)
                 break
             if not e.transient:
                 break
-            if attempt < max_attempts - 1:
+            is_rate_limited = e.status_code == 429
+            attempt_cap = min(max_attempts, RATE_LIMIT_MAX_ATTEMPTS) if is_rate_limited else max_attempts
+            if attempt >= attempt_cap - 1:
+                break
+            retry_after = getattr(e, "retry_after", None)
+            if is_rate_limited and retry_after is not None:
+                if retry_after > MAX_RETRY_AFTER_WAIT_SECONDS:
+                    # Provider asked for a longer pause than we will block inline;
+                    # let the cooldown ladder handle it instead.
+                    break
+                time.sleep(retry_after)
+            else:
                 time.sleep(_retry_delay(attempt))
-                continue
-            break
+            continue
         except Exception as e:
             last_error = e
             break

--- a/providers.py
+++ b/providers.py
@@ -1,6 +1,7 @@
 """Provider implementations for Web Search Plus search and extraction backends."""
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 import json
 import re
 from typing import Any, Dict, List, Optional
@@ -18,6 +19,11 @@ from http_client import (
     make_request,
 )
 from quality import _title_from_url
+
+
+# Extra scheduling headroom added on top of the per-request HTTP timeout when
+# bounding a concurrent extraction batch.
+_BATCH_TIMEOUT_GRACE_SECONDS = 5
 
 
 def search_serper(
@@ -706,11 +712,31 @@ def extract_linkup(
         return {"provider": "linkup", "results": [fetch_one(url) for url in urls]}
 
     indexed_results: Dict[int, Dict[str, Any]] = {}
-    with ThreadPoolExecutor(max_workers=min(len(urls), 5)) as executor:
+    workers = min(len(urls), 5)
+    # Bound the total wait so one hung fetch cannot stall the whole batch beyond
+    # the per-request HTTP timeout window (plus a small scheduling grace).
+    overall_timeout = timeout * ((len(urls) + workers - 1) // workers) + _BATCH_TIMEOUT_GRACE_SECONDS
+    executor = ThreadPoolExecutor(max_workers=workers)
+    try:
         futures = {executor.submit(fetch_one, url): idx for idx, url in enumerate(urls)}
-        for future in as_completed(futures):
-            indexed_results[futures[future]] = future.result()
-    results = [indexed_results[idx] for idx in range(len(urls)) if idx in indexed_results]
+        try:
+            for future in as_completed(futures, timeout=overall_timeout):
+                indexed_results[futures[future]] = future.result()
+        except FuturesTimeoutError:
+            for future in futures:
+                future.cancel()
+    finally:
+        # Keep partial results instead of blocking on overdue fetches; leftover
+        # threads finish in the background bounded by the HTTP timeout.
+        executor.shutdown(wait=False)
+    results = []
+    for idx, url in enumerate(urls):
+        if idx in indexed_results:
+            results.append(indexed_results[idx])
+        else:
+            results.append(_normalize_extract_result(
+                "linkup", url, error=f"Extraction timed out after {overall_timeout}s",
+            ))
     return {"provider": "linkup", "results": results}
 
 def extract_tavily(

--- a/providers.py
+++ b/providers.py
@@ -1,14 +1,16 @@
 """Provider implementations for Web Search Plus search and extraction backends."""
 
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 import json
 import re
+import threading
+import time
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError, URLError
 from urllib.parse import parse_qsl, quote, urlencode, urlparse, urlunparse
 from urllib.request import Request, urlopen
 
+from daemon_tasks import DaemonTask
 from http_client import (
     DEFAULT_USER_AGENT,
     ProviderRequestError,
@@ -711,29 +713,27 @@ def extract_linkup(
     if len(urls) <= 1:
         return {"provider": "linkup", "results": [fetch_one(url) for url in urls]}
 
-    indexed_results: Dict[int, Dict[str, Any]] = {}
     workers = min(len(urls), 5)
     # Bound the total wait so one hung fetch cannot stall the whole batch beyond
     # the per-request HTTP timeout window (plus a small scheduling grace).
+    # Daemon tasks (instead of a ThreadPoolExecutor) keep overdue fetches from
+    # blocking interpreter exit in the CLI/subprocess path.
     overall_timeout = timeout * ((len(urls) + workers - 1) // workers) + _BATCH_TIMEOUT_GRACE_SECONDS
-    executor = ThreadPoolExecutor(max_workers=workers)
-    try:
-        futures = {executor.submit(fetch_one, url): idx for idx, url in enumerate(urls)}
-        try:
-            for future in as_completed(futures, timeout=overall_timeout):
-                indexed_results[futures[future]] = future.result()
-        except FuturesTimeoutError:
-            for future in futures:
-                future.cancel()
-    finally:
-        # Keep partial results instead of blocking on overdue fetches; leftover
-        # threads finish in the background bounded by the HTTP timeout.
-        executor.shutdown(wait=False)
+    gate = threading.Semaphore(workers)
+
+    def fetch_gated(url: str) -> Dict[str, Any]:
+        with gate:
+            return fetch_one(url)
+
+    tasks = [DaemonTask(fetch_gated, url) for url in urls]
+    deadline = time.monotonic() + overall_timeout
     results = []
-    for idx, url in enumerate(urls):
-        if idx in indexed_results:
-            results.append(indexed_results[idx])
-        else:
+    for url, task in zip(urls, tasks):
+        try:
+            results.append(task.result(timeout=max(0.0, deadline - time.monotonic())))
+        except FuturesTimeoutError:
+            # Keep partial results; the overdue fetch finishes in the background
+            # bounded by the HTTP timeout without blocking caller or process exit.
             results.append(_normalize_extract_result(
                 "linkup", url, error=f"Extraction timed out after {overall_timeout}s",
             ))

--- a/research.py
+++ b/research.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from typing import Any, Dict, List, Optional, Tuple
 
+from daemon_tasks import DaemonTask
 from quality import deduplicate_results_across_providers
 
 
@@ -52,41 +53,41 @@ def run_research_mode(
         return time_budget_seconds - (now() - start)
 
     # Submit providers (budget gate is sequential/deterministic); the actual
-    # provider HTTP calls run concurrently in the thread pool.
+    # provider HTTP calls run concurrently on daemon threads. Daemon threads —
+    # unlike ThreadPoolExecutor workers — are not joined at interpreter exit,
+    # so an overdue provider cannot stall CLI/subprocess shutdown either.
     pending: List[Tuple[int, str]] = []
-    futures: Dict[int, Any] = {}
+    tasks: Dict[int, DaemonTask] = {}
     workers = max_workers or max(1, len(research_providers))
-    executor = ThreadPoolExecutor(max_workers=workers)
-    try:
-        for index, provider in enumerate(research_providers):
-            remaining = remaining_budget()
-            if remaining is not None and remaining <= 0:
-                provider_errors.append({"provider": provider, "error": "skipped: research time budget exhausted"})
-                continue
-            futures[index] = executor.submit(execute_search, provider)
-            pending.append((index, provider))
+    gate = threading.Semaphore(workers)
 
-        results_by_index: Dict[int, Tuple[str, Dict[str, Any]]] = {}
-        for index, provider in pending:
-            future = futures[index]
-            remaining = remaining_budget()
-            if remaining is not None and remaining <= 0:
-                # Budget gone: give already-submitted calls a short real-time grace
-                # so finished futures are still harvested without blocking on slow ones.
-                timeout = _RESULT_GRACE_SECONDS
-            else:
-                timeout = remaining
-            try:
-                results_by_index[index] = (provider, future.result(timeout=timeout))
-            except FuturesTimeoutError:
-                future.cancel()
-                provider_errors.append({"provider": provider, "error": "timed out: research time budget exhausted"})
-            except Exception as e:
-                provider_errors.append({"provider": provider, "error": str(e)})
-    finally:
-        # Do not block on providers that overran the budget; their threads finish
-        # in the background bounded by the per-request HTTP timeout.
-        executor.shutdown(wait=False)
+    def run_gated(provider_name: str) -> Dict[str, Any]:
+        with gate:
+            return execute_search(provider_name)
+
+    for index, provider in enumerate(research_providers):
+        remaining = remaining_budget()
+        if remaining is not None and remaining <= 0:
+            provider_errors.append({"provider": provider, "error": "skipped: research time budget exhausted"})
+            continue
+        tasks[index] = DaemonTask(run_gated, provider)
+        pending.append((index, provider))
+
+    results_by_index: Dict[int, Tuple[str, Dict[str, Any]]] = {}
+    for index, provider in pending:
+        remaining = remaining_budget()
+        if remaining is not None and remaining <= 0:
+            # Budget gone: give already-submitted calls a short real-time grace
+            # so finished tasks are still harvested without blocking on slow ones.
+            timeout = _RESULT_GRACE_SECONDS
+        else:
+            timeout = remaining
+        try:
+            results_by_index[index] = (provider, tasks[index].result(timeout=timeout))
+        except FuturesTimeoutError:
+            provider_errors.append({"provider": provider, "error": "timed out: research time budget exhausted"})
+        except Exception as e:
+            provider_errors.append({"provider": provider, "error": str(e)})
 
     provider_results: List[Tuple[str, Dict[str, Any]]] = [
         results_by_index[index] for index in sorted(results_by_index)
@@ -107,20 +108,15 @@ def run_research_mode(
                 extraction_error = str(e)
                 extracted = {"provider": None, "results": []}
         else:
-            # Run extraction in a worker so the remaining budget bounds it too.
-            extract_executor = ThreadPoolExecutor(max_workers=1)
+            # Run extraction on a daemon thread so the remaining budget bounds it too.
             try:
-                extract_future = extract_executor.submit(extract_urls, urls)
-                extracted = extract_future.result(timeout=remaining) or {"provider": None, "results": []}
+                extracted = DaemonTask(extract_urls, urls).result(timeout=remaining) or {"provider": None, "results": []}
             except FuturesTimeoutError:
-                extract_future.cancel()
                 extraction_error = "timed out: research time budget exhausted"
                 extracted = {"provider": None, "results": []}
             except Exception as e:
                 extraction_error = str(e)
                 extracted = {"provider": None, "results": []}
-            finally:
-                extract_executor.shutdown(wait=False)
 
     routing = {
         "providers_queried": [p for p, _ in provider_results],

--- a/research.py
+++ b/research.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 import time
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Dict, List, Tuple
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from typing import Any, Dict, List, Optional, Tuple
 
 from quality import deduplicate_results_across_providers
+
+
+# Small real-time grace given to already-submitted provider calls once the
+# (possibly fake-clock) budget reads as exhausted, so completed futures can
+# still be harvested without blocking on slow ones.
+_RESULT_GRACE_SECONDS = 0.25
 
 
 def run_research_mode(
@@ -27,8 +34,10 @@ def run_research_mode(
     whole response. Provider searches run concurrently to keep the wall-clock cost
     close to the slowest single provider rather than the sum of all of them. The
     optional time budget gates which providers are launched (checked before each
-    submission, so a tight budget still skips later providers deterministically) and
-    whether extraction runs at all.
+    submission, so a tight budget still skips later providers deterministically),
+    bounds how long already-launched providers may run, and gates whether
+    extraction runs at all — so the budget caps total wall-clock time instead of
+    only limiting how many providers start.
 
     Result ordering is preserved by provider submission order regardless of which
     provider finishes first, so deduplication stays deterministic.
@@ -37,8 +46,10 @@ def run_research_mode(
     now = now_fn or time.monotonic
     start = now()
 
-    def budget_exhausted() -> bool:
-        return time_budget_seconds is not None and (now() - start) >= time_budget_seconds
+    def remaining_budget() -> Optional[float]:
+        if time_budget_seconds is None:
+            return None
+        return time_budget_seconds - (now() - start)
 
     # Submit providers (budget gate is sequential/deterministic); the actual
     # provider HTTP calls run concurrently in the thread pool.
@@ -48,7 +59,8 @@ def run_research_mode(
     executor = ThreadPoolExecutor(max_workers=workers)
     try:
         for index, provider in enumerate(research_providers):
-            if budget_exhausted():
+            remaining = remaining_budget()
+            if remaining is not None and remaining <= 0:
                 provider_errors.append({"provider": provider, "error": "skipped: research time budget exhausted"})
                 continue
             futures[index] = executor.submit(execute_search, provider)
@@ -56,12 +68,25 @@ def run_research_mode(
 
         results_by_index: Dict[int, Tuple[str, Dict[str, Any]]] = {}
         for index, provider in pending:
+            future = futures[index]
+            remaining = remaining_budget()
+            if remaining is not None and remaining <= 0:
+                # Budget gone: give already-submitted calls a short real-time grace
+                # so finished futures are still harvested without blocking on slow ones.
+                timeout = _RESULT_GRACE_SECONDS
+            else:
+                timeout = remaining
             try:
-                results_by_index[index] = (provider, futures[index].result())
+                results_by_index[index] = (provider, future.result(timeout=timeout))
+            except FuturesTimeoutError:
+                future.cancel()
+                provider_errors.append({"provider": provider, "error": "timed out: research time budget exhausted"})
             except Exception as e:
                 provider_errors.append({"provider": provider, "error": str(e)})
     finally:
-        executor.shutdown(wait=True)
+        # Do not block on providers that overran the budget; their threads finish
+        # in the background bounded by the per-request HTTP timeout.
+        executor.shutdown(wait=False)
 
     provider_results: List[Tuple[str, Dict[str, Any]]] = [
         results_by_index[index] for index in sorted(results_by_index)
@@ -72,14 +97,30 @@ def run_research_mode(
     extracted = {"provider": None, "results": []}
     extraction_error = None
     if urls:
-        if budget_exhausted():
+        remaining = remaining_budget()
+        if remaining is not None and remaining <= 0:
             extraction_error = "skipped: research time budget exhausted"
-        else:
+        elif remaining is None:
             try:
                 extracted = extract_urls(urls) or {"provider": None, "results": []}
             except Exception as e:
                 extraction_error = str(e)
                 extracted = {"provider": None, "results": []}
+        else:
+            # Run extraction in a worker so the remaining budget bounds it too.
+            extract_executor = ThreadPoolExecutor(max_workers=1)
+            try:
+                extract_future = extract_executor.submit(extract_urls, urls)
+                extracted = extract_future.result(timeout=remaining) or {"provider": None, "results": []}
+            except FuturesTimeoutError:
+                extract_future.cancel()
+                extraction_error = "timed out: research time budget exhausted"
+                extracted = {"provider": None, "results": []}
+            except Exception as e:
+                extraction_error = str(e)
+                extracted = {"provider": None, "results": []}
+            finally:
+                extract_executor.shutdown(wait=False)
 
     routing = {
         "providers_queried": [p for p, _ in provider_results],

--- a/search.py
+++ b/search.py
@@ -1310,7 +1310,7 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
                 break
         except Exception as e:
             error_msg = str(e)
-            cooldown_info = mark_provider_failure(current_provider, error_msg)
+            cooldown_info = mark_provider_failure(current_provider, error_msg, retry_after=getattr(e, "retry_after", None))
             errors.append({
                 "provider": current_provider,
                 "error": error_msg,

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -1,6 +1,13 @@
 import gzip
 import json
+import time
+from email.message import Message
+from email.utils import formatdate
+from io import BytesIO
 from unittest import mock
+from urllib.error import HTTPError
+
+import pytest
 
 import http_client
 
@@ -46,3 +53,49 @@ def test_http_client_provider_request_error_exports_retry_metadata():
 
 def test_default_user_agent_uses_release_version():
     assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.4.0"
+
+
+def _make_http_error(code: int, headers=None, body: bytes = b"{}") -> HTTPError:
+    msg = Message()
+    for name, value in (headers or {}).items():
+        msg[name] = value
+    return HTTPError("https://api.example.com/search", code, "error", msg, BytesIO(body))
+
+
+def test_parse_retry_after_supports_delta_seconds():
+    error = _make_http_error(429, {"Retry-After": "12"})
+    assert http_client._parse_retry_after(error) == 12.0
+
+
+def test_parse_retry_after_supports_http_date():
+    error = _make_http_error(429, {"Retry-After": formatdate(time.time() + 60, usegmt=True)})
+    parsed = http_client._parse_retry_after(error)
+    assert parsed is not None
+    assert 50 <= parsed <= 61
+
+
+def test_parse_retry_after_handles_missing_and_garbage_values():
+    assert http_client._parse_retry_after(_make_http_error(429)) is None
+    assert http_client._parse_retry_after(_make_http_error(429, {"Retry-After": "soonish"})) is None
+
+
+def test_rate_limit_error_carries_retry_after_metadata():
+    with mock.patch("http_client.urlopen", side_effect=_make_http_error(429, {"Retry-After": "7"})):
+        with pytest.raises(http_client.ProviderRequestError) as exc_info:
+            http_client.make_request("https://api.example.com/search", {}, {"q": "test"})
+
+    error = exc_info.value
+    assert error.status_code == 429
+    assert error.transient is True
+    assert error.retry_after == 7.0
+
+
+def test_service_unavailable_error_has_no_retry_after():
+    with mock.patch("http_client.urlopen", side_effect=_make_http_error(503, {"Retry-After": "7"})):
+        with pytest.raises(http_client.ProviderRequestError) as exc_info:
+            http_client.make_request("https://api.example.com/search", {}, {"q": "test"})
+
+    error = exc_info.value
+    assert error.status_code == 503
+    assert error.transient is True
+    assert error.retry_after is None

--- a/tests/test_linkup_provider.py
+++ b/tests/test_linkup_provider.py
@@ -1,7 +1,9 @@
 import os
+import time
 import unittest
 from unittest import mock
 
+import providers
 import search
 from search import get_api_key, validate_api_key
 
@@ -73,6 +75,31 @@ class LinkupProviderTests(unittest.TestCase):
         self.assertEqual(result["answer"], "The claim is supported by current studies.")
         self.assertEqual(result["results"][0]["title"], "Study source")
         self.assertEqual(result["results"][0]["snippet"], "A relevant study snippet")
+
+    def test_extract_linkup_batch_keeps_partial_results_when_one_fetch_hangs(self):
+        def fake_make_request(url, headers, body, timeout=30):
+            if body["url"] == "https://slow.test/page":
+                time.sleep(1.0)
+            return {"markdown": f"content for {body['url']}"}
+
+        start = time.monotonic()
+        with mock.patch.object(providers, "make_request", fake_make_request):
+            with mock.patch.object(providers, "_BATCH_TIMEOUT_GRACE_SECONDS", 0.3):
+                result = providers.extract_linkup(
+                    ["https://fast.test/page", "https://slow.test/page"],
+                    api_key="linkup-test-key-12345",
+                    timeout=0,
+                )
+        elapsed = time.monotonic() - start
+
+        # The batch must return within the bounded window with partial results
+        # instead of blocking on the hung fetch.
+        self.assertLess(elapsed, 0.9)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["url"], "https://fast.test/page")
+        self.assertFalse(result["results"][0].get("error"))
+        self.assertEqual(result["results"][1]["url"], "https://slow.test/page")
+        self.assertIn("timed out", result["results"][1]["error"])
 
     def test_auto_router_prefers_linkup_for_source_grounding_queries(self):
         config = {

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -658,7 +658,7 @@ def test_fixed_provider_mode_does_not_add_fallback_providers(monkeypatch, tmp_pa
 
     monkeypatch.setattr(search, "search_brave", fail_brave)
     monkeypatch.setattr(search, "search_tavily", should_not_fallback)
-    monkeypatch.setattr(search, "mark_provider_failure", lambda provider, error: {"cooldown_seconds": 60})
+    monkeypatch.setattr(search, "mark_provider_failure", lambda provider, error, retry_after=None: {"cooldown_seconds": 60})
 
     try:
         search.main()

--- a/tests/test_process_exit.py
+++ b/tests/test_process_exit.py
@@ -1,0 +1,105 @@
+"""Budget overruns must bound process lifetime, not just function return.
+
+``concurrent.futures`` joins its worker threads at interpreter exit, so a
+budget-bounded function could return on time while the CLI/subprocess
+invocation still hung at exit until the overdue worker finished. These tests
+run the real interpreter-exit path in a subprocess and assert the process
+terminates promptly while a worker is still sleeping.
+"""
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# The hung worker sleeps far longer than the asserted bounds: if worker
+# threads were joined at exit again, these tests would fail loudly.
+_RESEARCH_SCRIPT = """
+import json, time
+from research import run_research_mode
+
+def execute(provider):
+    if provider == "slow":
+        time.sleep(10.0)
+    return {"provider": provider, "results": [
+        {"url": "https://" + provider + ".test/a", "title": provider, "description": "x"},
+    ]}
+
+def extract(urls):
+    return {"provider": None, "results": []}
+
+start = time.monotonic()
+result = run_research_mode(
+    query="exit promptly",
+    research_providers=["fast", "slow"],
+    execute_search=execute,
+    extract_urls=extract,
+    max_results=5,
+    max_extract_urls=0,
+    time_budget_seconds=0.3,
+)
+print(json.dumps({
+    "function_elapsed": time.monotonic() - start,
+    "providers_queried": result["routing"]["providers_queried"],
+}))
+"""
+
+_LINKUP_SCRIPT = """
+import json, time
+import providers
+
+def fake_make_request(url, headers, body, timeout=30):
+    if body["url"] == "https://slow.test/page":
+        time.sleep(10.0)
+    return {"markdown": "content for " + body["url"]}
+
+providers.make_request = fake_make_request
+providers._BATCH_TIMEOUT_GRACE_SECONDS = 0.3
+
+start = time.monotonic()
+result = providers.extract_linkup(
+    ["https://fast.test/page", "https://slow.test/page"],
+    api_key="linkup-test-key-12345",
+    timeout=0,
+)
+print(json.dumps({
+    "function_elapsed": time.monotonic() - start,
+    "errors": [bool(r.get("error")) for r in result["results"]],
+}))
+"""
+
+
+def _run_in_subprocess(script: str) -> "tuple[float, dict]":
+    start = time.monotonic()
+    proc = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+    elapsed = time.monotonic() - start
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    return elapsed, payload
+
+
+def test_research_budget_overrun_does_not_stall_process_exit():
+    elapsed, payload = _run_in_subprocess(_RESEARCH_SCRIPT)
+
+    assert payload["function_elapsed"] < 3.0
+    assert payload["providers_queried"] == ["fast"]
+    # Includes interpreter startup; the overdue worker sleeps 10s, so a joined
+    # worker pool would keep the process alive well past this bound.
+    assert elapsed < 6.0
+
+
+def test_linkup_batch_timeout_does_not_stall_process_exit():
+    elapsed, payload = _run_in_subprocess(_LINKUP_SCRIPT)
+
+    assert payload["function_elapsed"] < 3.0
+    assert payload["errors"] == [False, True]
+    assert elapsed < 6.0

--- a/tests/test_provider_health.py
+++ b/tests/test_provider_health.py
@@ -1,0 +1,127 @@
+"""Cooldown escalation, failure decay, and rate-limit retry behavior."""
+
+import time
+from unittest import mock
+
+import pytest
+
+import provider_health
+from http_client import ProviderRequestError
+
+
+@pytest.fixture()
+def health_file(tmp_path, monkeypatch):
+    path = tmp_path / "provider_health.json"
+    monkeypatch.setattr(provider_health, "PROVIDER_HEALTH_FILE", path)
+    return path
+
+
+def test_first_failure_uses_shortest_cooldown_step(health_file):
+    info = provider_health.mark_provider_failure("serper", "boom")
+
+    assert info["failure_count"] == 1
+    assert info["cooldown_seconds"] == provider_health.COOLDOWN_STEPS_SECONDS[0]
+
+
+def test_consecutive_failures_escalate_cooldown(health_file):
+    provider_health.mark_provider_failure("serper", "boom")
+    info = provider_health.mark_provider_failure("serper", "boom again")
+
+    assert info["failure_count"] == 2
+    assert info["cooldown_seconds"] == provider_health.COOLDOWN_STEPS_SECONDS[1]
+
+
+def test_stale_failures_restart_escalation_ladder(health_file):
+    provider_health.mark_provider_failure("serper", "boom")
+    provider_health.mark_provider_failure("serper", "boom")
+
+    stale = time.time() + provider_health.FAILURE_DECAY_SECONDS + 10
+    with mock.patch.object(provider_health.time, "time", return_value=stale):
+        info = provider_health.mark_provider_failure("serper", "much later")
+
+    assert info["failure_count"] == 1
+    assert info["cooldown_seconds"] == provider_health.COOLDOWN_STEPS_SECONDS[0]
+
+
+def test_retry_after_raises_cooldown_floor_and_is_capped(health_file):
+    info = provider_health.mark_provider_failure("serper", "rate limited", retry_after=120.0)
+    assert info["cooldown_seconds"] == 120
+
+    info = provider_health.mark_provider_failure("serper", "rate limited", retry_after=99999.0)
+    assert info["cooldown_seconds"] == provider_health.COOLDOWN_STEPS_SECONDS[-1]
+
+
+def test_retry_after_shorter_than_ladder_step_keeps_ladder_step(health_file):
+    provider_health.mark_provider_failure("serper", "boom")
+    info = provider_health.mark_provider_failure("serper", "rate limited", retry_after=5.0)
+
+    assert info["cooldown_seconds"] == provider_health.COOLDOWN_STEPS_SECONDS[1]
+
+
+def test_rate_limited_provider_retries_only_once(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(provider_health.time, "sleep", sleeps.append)
+    attempts = []
+
+    def operation():
+        attempts.append(1)
+        raise ProviderRequestError("rate limited", status_code=429, transient=True)
+
+    with pytest.raises(ProviderRequestError):
+        provider_health.execute_provider_with_retry("serper", operation, max_attempts=3)
+
+    assert len(attempts) == provider_health.RATE_LIMIT_MAX_ATTEMPTS
+    assert len(sleeps) == provider_health.RATE_LIMIT_MAX_ATTEMPTS - 1
+
+
+def test_rate_limited_retry_honors_retry_after_delay(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(provider_health.time, "sleep", sleeps.append)
+    attempts = []
+
+    def operation():
+        attempts.append(1)
+        raise ProviderRequestError("rate limited", status_code=429, transient=True, retry_after=7.5)
+
+    with pytest.raises(ProviderRequestError):
+        provider_health.execute_provider_with_retry("serper", operation, max_attempts=3)
+
+    assert sleeps == [7.5]
+    assert len(attempts) == 2
+
+
+def test_rate_limited_retry_skips_wait_longer_than_cap(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(provider_health.time, "sleep", sleeps.append)
+    attempts = []
+
+    def operation():
+        attempts.append(1)
+        raise ProviderRequestError(
+            "rate limited",
+            status_code=429,
+            transient=True,
+            retry_after=provider_health.MAX_RETRY_AFTER_WAIT_SECONDS + 1,
+        )
+
+    with pytest.raises(ProviderRequestError):
+        provider_health.execute_provider_with_retry("serper", operation, max_attempts=3)
+
+    assert sleeps == []
+    assert len(attempts) == 1
+
+
+def test_other_transient_errors_keep_full_retry_budget(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr(provider_health.time, "sleep", sleeps.append)
+    attempts = []
+
+    def operation():
+        attempts.append(1)
+        raise ProviderRequestError("unavailable", status_code=503, transient=True)
+
+    with pytest.raises(ProviderRequestError):
+        provider_health.execute_provider_with_retry("serper", operation, max_attempts=3)
+
+    assert len(attempts) == 3
+    assert len(sleeps) == 2

--- a/tests/test_quality_research.py
+++ b/tests/test_quality_research.py
@@ -202,7 +202,8 @@ class ResearchModeTests(unittest.TestCase):
         ])
 
     def test_research_mode_respects_time_budget_between_providers_and_skips_extract(self):
-        ticks = iter([0.0, 0.0, 6.0, 6.0])
+        # start, submit-gate linkup, submit-gate tavily, collect linkup, extract gate
+        ticks = iter([0.0, 0.0, 6.0, 6.0, 6.0])
         calls = []
 
         def now():
@@ -232,6 +233,93 @@ class ResearchModeTests(unittest.TestCase):
         self.assertEqual(result["routing"]["provider_errors"], [{"provider": "tavily", "error": "skipped: research time budget exhausted"}])
         self.assertEqual(result["routing"]["extraction_error"], "skipped: research time budget exhausted")
         self.assertEqual(result["metadata"]["extracted_url_count"], 0)
+
+    def test_research_mode_time_budget_bounds_slow_providers_already_running(self):
+        import time as _time
+
+        def execute(provider):
+            if provider == "slowpoke":
+                _time.sleep(5.0)
+            return {"provider": provider, "results": [
+                {"url": f"https://{provider}.test/a", "title": provider, "description": "Result"},
+            ]}
+
+        def extract(urls):
+            raise AssertionError("extract should be skipped once budget is exhausted")
+
+        start = _time.monotonic()
+        result = search.run_research_mode(
+            query="budget bounds completion",
+            research_providers=["fast", "slowpoke"],
+            execute_search=execute,
+            extract_urls=extract,
+            max_results=5,
+            max_extract_urls=1,
+            time_budget_seconds=0.5,
+        )
+        elapsed = _time.monotonic() - start
+
+        # The budget must bound wall-clock time even though slowpoke was already
+        # submitted; without completion-side enforcement this would take ~5s.
+        self.assertLess(elapsed, 3.0)
+        self.assertEqual([r["url"] for r in result["results"]], ["https://fast.test/a"])
+        self.assertEqual(result["routing"]["providers_queried"], ["fast"])
+        slow_errors = [e for e in result["routing"]["provider_errors"] if e["provider"] == "slowpoke"]
+        self.assertEqual(slow_errors, [{"provider": "slowpoke", "error": "timed out: research time budget exhausted"}])
+
+    def test_research_mode_time_budget_bounds_slow_extraction(self):
+        import time as _time
+
+        def execute(provider):
+            return {"provider": provider, "results": [
+                {"url": "https://source.test/a", "title": "A", "description": "Alpha"},
+            ]}
+
+        def extract(urls):
+            _time.sleep(5.0)
+            return {"provider": "linkup", "results": [{"url": u, "content": "late"} for u in urls]}
+
+        start = _time.monotonic()
+        result = search.run_research_mode(
+            query="budget bounds extraction",
+            research_providers=["fast"],
+            execute_search=execute,
+            extract_urls=extract,
+            max_results=3,
+            max_extract_urls=1,
+            time_budget_seconds=0.5,
+        )
+        elapsed = _time.monotonic() - start
+
+        self.assertLess(elapsed, 3.0)
+        self.assertEqual(len(result["results"]), 1)
+        self.assertEqual(result["source_summaries"], [])
+        self.assertEqual(result["routing"]["extraction_error"], "timed out: research time budget exhausted")
+
+    def test_research_mode_without_budget_still_waits_for_all_providers(self):
+        import time as _time
+
+        def execute(provider):
+            if provider == "slow":
+                _time.sleep(0.2)
+            return {"provider": provider, "results": [
+                {"url": f"https://{provider}.test/a", "title": provider, "description": "x"},
+            ]}
+
+        def extract(urls):
+            return {"provider": None, "results": []}
+
+        result = search.run_research_mode(
+            query="no budget",
+            research_providers=["slow", "fast"],
+            execute_search=execute,
+            extract_urls=extract,
+            max_results=5,
+            max_extract_urls=0,
+        )
+
+        self.assertEqual(result["routing"]["providers_queried"], ["slow", "fast"])
+        self.assertEqual(result["routing"]["provider_errors"], [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes four reliability bugs found during a multi-perspective code review, plus a follow-up: budget overruns must bound **process lifetime**, not just function return.

(The adaptive-routing and result-filtering features were split out into #52, stacked on this PR.)

## 1. Research time budget now bounds completion, not just submission (`research.py`)

Previously the budget only gated which providers were *launched* — already-submitted providers could run indefinitely because results were awaited without a timeout. A single slow/hung provider could blow the entire `research_time_budget`.

Now:
- Pending provider calls are collected with the **remaining budget as timeout**; overdue providers are recorded as `timed out: research time budget exhausted` and the response returns with partial results.
- Once the budget reads as exhausted, already-submitted calls get only a short real-time grace window (0.25s) so finished calls are still harvested.
- The **extraction phase** is also bounded by the remaining budget instead of only being gated before it starts.

## 2. Concurrent Linkup batch extraction no longer hangs on one slow fetch (`providers.py`)

The batch previously waited without any timeout, so one hung URL stalled everything. The batch is now bounded by `per-request timeout × batches + grace`; timed-out URLs get explicit error entries and **partial results are kept**.

## 3. 429 handled distinctly from 503 (`http_client.py`, `provider_health.py`)

- `Retry-After` (delta-seconds and HTTP-date) is parsed on 429 responses and exposed as `ProviderRequestError.retry_after`.
- Rate-limited calls retry **at most once** (instead of burning the full 3-attempt budget against an exhausted quota) and honor `Retry-After` for the wait, capped at 30s — longer waits are left to the cooldown ladder.
- `mark_provider_failure` uses `retry_after` as a cooldown floor (capped at the 1h ladder max). Plumbed through both `search.py` and `extract.py` call sites.

## 4. Cooldown escalation ladder decays (`provider_health.py`)

Failure counts previously compounded forever between successes: a provider failing once every few hours would still climb toward the 1h cooldown cap. Failure history older than 30 minutes now restarts the ladder at the shortest step, so isolated transient failures can't black-hole a provider.

## 5. Budget overruns no longer stall interpreter exit (`daemon_tasks.py`)

Deeper smoke testing surfaced a real caveat with the first iteration: `ThreadPoolExecutor` workers are joined by a `concurrent.futures` atexit hook, so `shutdown(wait=False)` only unblocked the *function return* — a CLI/subprocess invocation still hung at process exit until the overdue worker finished:

```
# before                       # after
function_elapsed 0.2           function_elapsed 0.20
elapsed=2.04 rc=0              elapsed=0.24 rc=0
```

Since web-search-plus has a subprocess fallback, this matters. All budget-bounded calls now run on **daemon threads** via a small Future-like `DaemonTask` helper (`result(timeout)` semantics, stdlib-only):

- research provider fan-out (semaphore-gated to `max_workers`) and the budget-bounded extraction phase
- Linkup batch extraction (shared deadline, partial-result semantics unchanged)
- `__init__._call_with_timeout` (the in-process hard timeout had the same latent issue)

Abandoned tasks keep running in the background bounded by per-request HTTP timeouts, but no longer block the caller *or* interpreter shutdown.

## Tests

- New `tests/test_process_exit.py`: runs the real interpreter-exit path in a subprocess and asserts the process terminates promptly (bounded wall-clock) while a worker is still sleeping — for both research mode and Linkup batch extraction.
- New `tests/test_provider_health.py` (10 tests): ladder escalation, decay, `retry_after` floor/cap, 429 single-retry, `Retry-After` wait, wait cap, 503 keeping full retry budget.
- `tests/test_http_client_module.py`: `Retry-After` parsing (delta-seconds, HTTP-date, garbage), 429 metadata propagation, 503 without retry_after.
- `tests/test_quality_research.py`: budget bounds an already-running slow provider (wall-clock asserted), budget bounds slow extraction, no-budget mode still waits for all providers.
- `tests/test_linkup_provider.py`: batch extraction returns partial results within the bounded window when one fetch hangs.

`pytest`: 224 passed · `ruff check`: clean · CI compile list extended with `daemon_tasks.py`