### PR TITLE
Adaptive routing with performance memory + spam/mirror result filtering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           config.py
           env_loader.py
           provider_health.py
+          provider_stats.py
           quality.py
           research.py
           routing.py

--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ KILOCODE_API_KEY=***
 
 ---
 
+## Result quality and adaptive routing
+
+- **Adaptive routing:** every real provider call records latency, error, and empty-result outcomes (rolling window, last 50 calls / 7 days). Routing blends a bounded adjustment (±1.0) into the scores, so providers that are currently fast and productive win close calls — strong query-class signals are never overridden. Disable with `auto_routing.adaptive_routing: false` in `config.json`; adjustments are visible in `quality_report.adaptive_adjustments`.
+- **Spam/mirror filter:** results from known Stack Overflow/GitHub content mirrors and SEO scrapers are removed (reported in `metadata.spam_filtered`). Extend via `quality.blocked_domains`, rescue a domain via `quality.allowed_domains`, or disable with `quality.filter_spam: false`.
+- **Domain diversity:** at most 2 results per domain keep their position; overflow is moved behind the diverse head (`quality.max_results_per_domain`, `0` disables).
+
 ## Reliability and cost controls
 
 - **Provider cooldowns:** failed providers are skipped for 1 hour before retry.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ KILOCODE_API_KEY=***
 - **Adaptive routing:** every real provider call records latency, error, and empty-result outcomes (rolling window, last 50 calls / 7 days). Routing blends a bounded adjustment (±1.0) into the scores, so providers that are currently fast and productive win close calls — strong query-class signals are never overridden. Disable with `auto_routing.adaptive_routing: false` in `config.json`; adjustments are visible in `quality_report.adaptive_adjustments`.
 - **Spam/mirror filter:** results from known Stack Overflow/GitHub content mirrors and SEO scrapers are removed (reported in `metadata.spam_filtered`). Extend via `quality.blocked_domains`, rescue a domain via `quality.allowed_domains`, or disable with `quality.filter_spam: false`.
 - **Domain diversity:** at most 2 results per domain keep their position; overflow is moved behind the diverse head (`quality.max_results_per_domain`, `0` disables).
+- **Explicit intent wins:** queries with `site:` operators or `include_domains` are exempt — constrained domains bypass the spam filter and the diversity rerank is skipped entirely.
 
 ## Reliability and cost controls
 

--- a/provider_stats.py
+++ b/provider_stats.py
@@ -1,0 +1,161 @@
+"""Rolling provider performance memory for adaptive routing.
+
+Routing v2 scores are benchmarked but static: a provider that has been slow
+or returning empty results for days keeps its full score. This module records
+the real outcome of every provider call (latency, result count, errors) in a
+small rolling window and turns it into a bounded score adjustment, so routing
+gently prefers providers that are currently fast and productive — without
+ever overriding strong query-class signals.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import tempfile
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+from cache import CACHE_DIR
+
+
+PROVIDER_STATS_FILE = CACHE_DIR / "provider_stats.json"
+# Rolling window: keep this many most-recent samples per provider.
+MAX_SAMPLES_PER_PROVIDER = 50
+# Ignore samples older than this; stale history should not steer routing.
+SAMPLE_MAX_AGE_SECONDS = 7 * 24 * 3600
+# Providers need this many fresh samples before stats influence routing.
+MIN_SAMPLES_FOR_ADJUSTMENT = 5
+# Hard bound on routing-score influence. Query-class signals weigh 1.0-4.0
+# per match, so performance can break ties and nudge close calls but never
+# overrule a clear content-based winner.
+MAX_SCORE_ADJUSTMENT = 1.0
+# Median latency at or above this counts as fully slow (speed factor 0).
+LATENCY_CEILING_SECONDS = 8.0
+# Neutral point: providers performing at this combined level get adjustment 0.
+PERFORMANCE_BASELINE = 0.75
+
+_STATS_LOCK = threading.Lock()
+
+
+def _load_stats() -> Dict[str, Any]:
+    if not PROVIDER_STATS_FILE.exists():
+        return {}
+    try:
+        with open(PROVIDER_STATS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, IOError):
+        return {}
+
+
+def _save_stats(state: Dict[str, Any]) -> None:
+    PROVIDER_STATS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=PROVIDER_STATS_FILE.name + ".",
+        suffix=".tmp",
+        dir=str(PROVIDER_STATS_FILE.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(state, f, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmp_name, PROVIDER_STATS_FILE)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def record_provider_outcome(
+    provider: str,
+    latency_seconds: float,
+    result_count: int,
+    error: bool,
+    now: Optional[float] = None,
+) -> None:
+    """Append one provider-call outcome to the rolling window.
+
+    Best-effort: stats must never break a search, so persistence errors are
+    swallowed.
+    """
+    sample = {
+        "t": int(now if now is not None else time.time()),
+        "lat": round(max(0.0, float(latency_seconds)), 3),
+        "n": int(max(0, result_count)),
+        "err": bool(error),
+    }
+    try:
+        with _STATS_LOCK:
+            state = _load_stats()
+            samples = state.get(provider)
+            if not isinstance(samples, list):
+                samples = []
+            samples.append(sample)
+            state[provider] = samples[-MAX_SAMPLES_PER_PROVIDER:]
+            _save_stats(state)
+    except Exception:
+        pass
+
+
+def _fresh_samples(samples: Any, now: float) -> List[Dict[str, Any]]:
+    if not isinstance(samples, list):
+        return []
+    cutoff = now - SAMPLE_MAX_AGE_SECONDS
+    return [
+        sample for sample in samples
+        if isinstance(sample, dict) and int(sample.get("t", 0) or 0) >= cutoff
+    ]
+
+
+def get_provider_performance(provider: str, now: Optional[float] = None) -> Optional[Dict[str, Any]]:
+    """Return summarized fresh performance for one provider, or None."""
+    now_ts = now if now is not None else time.time()
+    samples = _fresh_samples(_load_stats().get(provider), now_ts)
+    if not samples:
+        return None
+    successes = [s for s in samples if not s.get("err")]
+    empty = [s for s in successes if int(s.get("n", 0) or 0) == 0]
+    latencies = [float(s.get("lat", 0.0) or 0.0) for s in successes]
+    return {
+        "samples": len(samples),
+        "success_rate": round(len(successes) / len(samples), 3),
+        "empty_rate": round(len(empty) / len(successes), 3) if successes else 0.0,
+        "median_latency_seconds": round(statistics.median(latencies), 3) if latencies else None,
+    }
+
+
+def performance_adjustment(provider: str, now: Optional[float] = None) -> float:
+    """Bounded routing-score adjustment from recent real-world performance.
+
+    Combines reliability (success rate, discounted by empty-result rate) and
+    speed (median latency vs. LATENCY_CEILING_SECONDS) into
+    [-MAX_SCORE_ADJUSTMENT, +MAX_SCORE_ADJUSTMENT]. Returns 0.0 until
+    MIN_SAMPLES_FOR_ADJUSTMENT fresh samples exist.
+    """
+    perf = get_provider_performance(provider, now=now)
+    if not perf or perf["samples"] < MIN_SAMPLES_FOR_ADJUSTMENT:
+        return 0.0
+    reliability = perf["success_rate"] * (1.0 - 0.5 * perf["empty_rate"])
+    median_latency = perf["median_latency_seconds"]
+    if median_latency is None:
+        speed = 0.0
+    else:
+        speed = max(0.0, min(1.0, 1.0 - median_latency / LATENCY_CEILING_SECONDS))
+    combined = 0.6 * reliability + 0.4 * speed
+    adjustment = (combined - PERFORMANCE_BASELINE) * 2 * MAX_SCORE_ADJUSTMENT
+    return round(max(-MAX_SCORE_ADJUSTMENT, min(MAX_SCORE_ADJUSTMENT, adjustment)), 3)
+
+
+def performance_adjustments(providers: List[str], now: Optional[float] = None) -> Dict[str, float]:
+    """Adjustments for several providers; providers without impact are omitted."""
+    adjustments = {}
+    for provider in providers:
+        value = performance_adjustment(provider, now=now)
+        if value != 0.0:
+            adjustments[provider] = value
+    return adjustments

--- a/quality.py
+++ b/quality.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import re
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 
@@ -111,6 +111,87 @@ CANONICAL_DOMAIN_RULES: Dict[str, Dict[str, List[str]]] = {
 
 def _domain_matches_rule(domain: str, rule: str) -> bool:
     return domain == rule or domain.endswith(f".{rule}") or domain.startswith(rule)
+
+
+# Known content mirrors and SEO scraper sites that republish Stack Overflow,
+# GitHub, and documentation content. These add no information over the
+# canonical source and frequently outrank it; they are removed from results
+# rather than merely demoted. Operators can extend via config
+# quality.blocked_domains or rescue a domain via quality.allowed_domains.
+SPAM_MIRROR_DOMAINS: List[str] = [
+    # Stack Overflow / Q&A scrapers
+    "newbedev.com",
+    "stackoom.com",
+    "stackovergo.com",
+    "syntaxfix.com",
+    "copyprogramming.com",
+    "devcodef1.com",
+    "exceptionshub.com",
+    "code-examples.net",
+    "i-harness.com",
+    # GitHub issue/readme mirrors
+    "githubmemory.com",
+    "gitmemory.com",
+    "issueexplorer.com",
+    "bleepcoder.com",
+    "gitanswer.com",
+    # Generic AI/SEO content farms already demoted by the intent reranker
+    "aizolo.com",
+]
+
+
+def filter_spam_results(
+    results: List[Dict[str, Any]],
+    extra_blocked: Optional[List[str]] = None,
+    allowed: Optional[List[str]] = None,
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Drop results from known mirror/SEO-spam domains.
+
+    Returns the kept results and the sorted unique domains that were removed.
+    ``allowed`` rescues a domain from both the builtin and extra blocklists.
+    """
+    blocked_rules = SPAM_MIRROR_DOMAINS + [d.lower().strip() for d in (extra_blocked or []) if d and d.strip()]
+    allowed_rules = [d.lower().strip() for d in (allowed or []) if d and d.strip()]
+    kept: List[Dict[str, Any]] = []
+    removed_domains: List[str] = []
+    for item in results:
+        domain = _result_domain(item.get("url", ""))
+        if (
+            domain
+            and not any(_domain_matches_rule(domain, rule) for rule in allowed_rules)
+            and any(_domain_matches_rule(domain, rule) for rule in blocked_rules)
+        ):
+            removed_domains.append(domain)
+            continue
+        kept.append(item)
+    return kept, sorted(set(removed_domains))
+
+
+def rerank_domain_diversity(
+    results: List[Dict[str, Any]],
+    max_per_domain: int = 2,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Stable rerank that stops one domain from crowding out the result list.
+
+    The first ``max_per_domain`` results per domain keep their original order;
+    overflow results are moved behind the diverse head (also in original
+    order) instead of being dropped. Returns the reranked list and how many
+    results were demoted.
+    """
+    if max_per_domain < 1 or len(results) < 3:
+        return results, 0
+    head: List[Dict[str, Any]] = []
+    overflow: List[Dict[str, Any]] = []
+    per_domain: Dict[str, int] = {}
+    for item in results:
+        domain = _result_domain(item.get("url", ""))
+        count = per_domain.get(domain, 0)
+        if domain and count >= max_per_domain:
+            overflow.append(item)
+            continue
+        per_domain[domain] = count + 1
+        head.append(item)
+    return head + overflow, len(overflow)
 
 
 def _url_matches_rule(url: str, rule: str) -> bool:
@@ -272,6 +353,7 @@ def build_quality_report(
         "extract_recommended": bool(extract_reasons),
         "extract_reasons": extract_reasons,
         "scores": routing_info.get("scores", {}),
+        "adaptive_adjustments": routing_info.get("adaptive_adjustments", {}),
         "authority_signals": authority_signals,
     }
 

--- a/quality.py
+++ b/quality.py
@@ -129,15 +129,47 @@ SPAM_MIRROR_DOMAINS: List[str] = [
     "exceptionshub.com",
     "code-examples.net",
     "i-harness.com",
+    "fixmycodeerror.com",
+    "stacklesson.com",
     # GitHub issue/readme mirrors
     "githubmemory.com",
     "gitmemory.com",
     "issueexplorer.com",
     "bleepcoder.com",
     "gitanswer.com",
+    # Documentation mirrors
+    "w3cub.com",
     # Generic AI/SEO content farms already demoted by the intent reranker
     "aizolo.com",
 ]
+
+
+def _blocked_domain_matches(domain: str, rule: str) -> bool:
+    """Strict matcher for domain block/allow lists.
+
+    Only the exact domain or true subdomains match (``newbedev.com``,
+    ``de.newbedev.com``). Unlike ``_domain_matches_rule`` there is no
+    ``startswith`` clause, so look-alike registrations such as
+    ``newbedev.com.evil.example`` do NOT match.
+    """
+    return domain == rule or domain.endswith(f".{rule}")
+
+
+_SITE_OPERATOR_RE = re.compile(r"\bsite:([a-z0-9][a-z0-9.-]*)", re.IGNORECASE)
+
+
+def extract_domain_constraints(query: str, include_domains: Optional[List[str]] = None) -> List[str]:
+    """Domains the user explicitly constrained the search to.
+
+    Collects ``site:`` operators from the query plus ``include_domains``.
+    Explicit constraints express intent: constrained domains are exempt from
+    spam filtering, and domain-diversity reranking is skipped entirely.
+    """
+    domains = [d.lower().rstrip(".") for d in _SITE_OPERATOR_RE.findall(query or "")]
+    for entry in include_domains or []:
+        if entry and entry.strip():
+            domains.append(entry.lower().strip())
+    return sorted(set(domains))
 
 
 def filter_spam_results(
@@ -158,8 +190,8 @@ def filter_spam_results(
         domain = _result_domain(item.get("url", ""))
         if (
             domain
-            and not any(_domain_matches_rule(domain, rule) for rule in allowed_rules)
-            and any(_domain_matches_rule(domain, rule) for rule in blocked_rules)
+            and not any(_blocked_domain_matches(domain, rule) for rule in allowed_rules)
+            and any(_blocked_domain_matches(domain, rule) for rule in blocked_rules)
         ):
             removed_domains.append(domain)
             continue

--- a/routing.py
+++ b/routing.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from config import DEFAULT_CONFIG, get_api_key
 from provider_registry import DEFAULT_PROVIDER_PRIORITY
+from provider_stats import performance_adjustments
 from quality import _choose_tie_winner
 
 
@@ -925,6 +926,19 @@ class QueryAnalyzer:
                 "auto_allow_excluded": auto_excluded,
             }
 
+        # Adaptive routing: blend in bounded, learned performance adjustments
+        # (latency / success / empty-result history of real calls). Only when
+        # query-class signals matched at all — performance memory breaks close
+        # calls but never invents a winner out of silence.
+        adaptive_adjustments: Dict[str, float] = {}
+        if max(available.values()) > 0 and self.auto_config.get("adaptive_routing", True):
+            adaptive_adjustments = performance_adjustments(list(available))
+            if adaptive_adjustments:
+                available = {
+                    p: max(0.0, s + adaptive_adjustments.get(p, 0.0))
+                    for p, s in available.items()
+                }
+
         # Find the winner
         max_score = max(available.values())
 
@@ -994,6 +1008,7 @@ class QueryAnalyzer:
             "routing_policy": ROUTING_POLICY,
             "exa_depth": exa_depth,
             "scores": {p: round(s, 2) for p, s in available.items()},
+            "adaptive_adjustments": adaptive_adjustments,
             "winning_score": round(max_score, 2),
             "top_signals": [
                 {"matched": s["matched"], "weight": s["weight"]}

--- a/search.py
+++ b/search.py
@@ -73,6 +73,7 @@ from quality import (  # noqa: F401 - re-exported for backward-compatible tests/
     build_authority_signals,
     build_quality_report,
     deduplicate_results_across_providers,
+    extract_domain_constraints,
     filter_spam_results,
     rerank_domain_diversity,
     rerank_results_for_intent,
@@ -947,8 +948,18 @@ def main():
         sys.exit(1)
 
 
-def _apply_result_quality_pipeline(result: Dict[str, Any], config: Dict[str, Any]) -> None:
+def _apply_result_quality_pipeline(
+    result: Dict[str, Any],
+    config: Dict[str, Any],
+    query: str = "",
+    include_domains: Optional[List[str]] = None,
+) -> None:
     """Filter mirror/SEO-spam domains and cap per-domain dominance, in place.
+
+    Explicit domain constraints (``site:`` operators, ``include_domains``)
+    express user intent and win: constrained domains are exempt from the spam
+    filter, and the diversity rerank is skipped entirely — a deliberately
+    one-domain query must not have its order shuffled.
 
     Both steps are truthful: removals and demotions are reported in
     ``result["metadata"]`` so quality reports and callers can see what changed.
@@ -957,11 +968,13 @@ def _apply_result_quality_pipeline(result: Dict[str, Any], config: Dict[str, Any
     if not isinstance(results, list) or not results:
         return
     quality_config = config.get("quality") if isinstance(config.get("quality"), dict) else {}
+    constrained_domains = extract_domain_constraints(query, include_domains)
     if quality_config.get("filter_spam", True):
+        allowed = list(quality_config.get("allowed_domains") or []) + constrained_domains
         kept, removed_domains = filter_spam_results(
             results,
             extra_blocked=quality_config.get("blocked_domains"),
-            allowed=quality_config.get("allowed_domains"),
+            allowed=allowed,
         )
         if removed_domains:
             result["results"] = kept
@@ -970,6 +983,8 @@ def _apply_result_quality_pipeline(result: Dict[str, Any], config: Dict[str, Any
                 "domains": removed_domains,
             }
             results = kept
+    if constrained_domains:
+        return
     try:
         max_per_domain = int(quality_config.get("max_results_per_domain", 2))
     except (TypeError, ValueError):
@@ -1309,7 +1324,7 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
         routing_info["mode"] = "research"
         routing_info["provider"] = "research"
         result["routing"].update(routing_info)
-        _apply_result_quality_pipeline(result, config)
+        _apply_result_quality_pipeline(result, config, query=args.query or "", include_domains=args.include_domains)
         result["quality_report"] = build_quality_report(
             query=args.query,
             result=result,
@@ -1408,7 +1423,7 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
             result["results"] = reranked
             if rerank_metadata.get("reranked"):
                 result.setdefault("metadata", {})["intent_rerank"] = rerank_metadata
-            _apply_result_quality_pipeline(result, config)
+            _apply_result_quality_pipeline(result, config, query=args.query or "", include_domains=args.include_domains)
 
         result["routing"] = routing_info
 

--- a/search.py
+++ b/search.py
@@ -66,12 +66,15 @@ from provider_health import (  # noqa: F401 - re-exported for backward-compatibl
     provider_in_cooldown,
     reset_provider_health,
 )
+from provider_stats import record_provider_outcome
 from quality import (  # noqa: F401 - re-exported for backward-compatible tests/imports
     _choose_tie_winner,
     _domain_matches_rule,
     build_authority_signals,
     build_quality_report,
     deduplicate_results_across_providers,
+    filter_spam_results,
+    rerank_domain_diversity,
     rerank_results_for_intent,
     select_research_providers,
 )
@@ -944,6 +947,40 @@ def main():
         sys.exit(1)
 
 
+def _apply_result_quality_pipeline(result: Dict[str, Any], config: Dict[str, Any]) -> None:
+    """Filter mirror/SEO-spam domains and cap per-domain dominance, in place.
+
+    Both steps are truthful: removals and demotions are reported in
+    ``result["metadata"]`` so quality reports and callers can see what changed.
+    """
+    results = result.get("results")
+    if not isinstance(results, list) or not results:
+        return
+    quality_config = config.get("quality") if isinstance(config.get("quality"), dict) else {}
+    if quality_config.get("filter_spam", True):
+        kept, removed_domains = filter_spam_results(
+            results,
+            extra_blocked=quality_config.get("blocked_domains"),
+            allowed=quality_config.get("allowed_domains"),
+        )
+        if removed_domains:
+            result["results"] = kept
+            result.setdefault("metadata", {})["spam_filtered"] = {
+                "removed_count": len(results) - len(kept),
+                "domains": removed_domains,
+            }
+            results = kept
+    try:
+        max_per_domain = int(quality_config.get("max_results_per_domain", 2))
+    except (TypeError, ValueError):
+        max_per_domain = 2
+    if max_per_domain > 0:
+        reranked, demoted = rerank_domain_diversity(results, max_per_domain=max_per_domain)
+        if demoted:
+            result["results"] = reranked
+            result.setdefault("metadata", {})["domain_diversity_demoted"] = demoted
+
+
 def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
     """Run the search/research pipeline for parsed args.
 
@@ -1188,7 +1225,21 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
             raise ValueError(f"Unknown provider: {prov}")
 
     def execute_with_retry(prov: str) -> Dict[str, Any]:
-        return execute_provider_with_retry(prov, lambda: execute_search(prov))
+        started = time.monotonic()
+        try:
+            provider_result = execute_provider_with_retry(prov, lambda: execute_search(prov))
+        except ProviderRequestError:
+            # Only real provider interactions count as performance signal;
+            # config/validation errors (e.g. missing keys) are not recorded.
+            record_provider_outcome(prov, latency_seconds=time.monotonic() - started, result_count=0, error=True)
+            raise
+        record_provider_outcome(
+            prov,
+            latency_seconds=time.monotonic() - started,
+            result_count=len(provider_result.get("results", []) or []),
+            error=False,
+        )
+        return provider_result
 
     cache_context = {
         "locale": f"{args.country}:{args.language}",
@@ -1258,6 +1309,7 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
         routing_info["mode"] = "research"
         routing_info["provider"] = "research"
         result["routing"].update(routing_info)
+        _apply_result_quality_pipeline(result, config)
         result["quality_report"] = build_quality_report(
             query=args.query,
             result=result,
@@ -1356,6 +1408,7 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
             result["results"] = reranked
             if rerank_metadata.get("reranked"):
                 result.setdefault("metadata", {})["intent_rerank"] = rerank_metadata
+            _apply_result_quality_pipeline(result, config)
 
         result["routing"] = routing_info
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+import provider_stats
+
+
+@pytest.fixture(autouse=True)
+def _isolate_provider_stats(tmp_path, monkeypatch):
+    """Keep adaptive-routing stats out of the real cache dir during tests.
+
+    Search tests record outcomes for mocked providers; without isolation those
+    samples would pollute the operator's provider_stats.json and, worse, feed
+    back into routing decisions and make routing tests order-dependent.
+    """
+    monkeypatch.setattr(provider_stats, "PROVIDER_STATS_FILE", tmp_path / "provider_stats.json")

--- a/tests/test_provider_stats.py
+++ b/tests/test_provider_stats.py
@@ -1,0 +1,136 @@
+"""Rolling performance stats and adaptive routing adjustments."""
+
+import os
+import time
+from unittest import mock
+
+import pytest
+
+import provider_stats
+import routing
+
+
+@pytest.fixture()
+def stats_file(tmp_path, monkeypatch):
+    path = tmp_path / "provider_stats.json"
+    monkeypatch.setattr(provider_stats, "PROVIDER_STATS_FILE", path)
+    return path
+
+
+def _seed(provider, samples, latency, result_count, error=False, now=None):
+    now = now if now is not None else time.time()
+    for _ in range(samples):
+        provider_stats.record_provider_outcome(
+            provider, latency_seconds=latency, result_count=result_count, error=error, now=now,
+        )
+
+
+def test_rolling_window_keeps_most_recent_samples(stats_file):
+    for i in range(provider_stats.MAX_SAMPLES_PER_PROVIDER + 10):
+        provider_stats.record_provider_outcome("serper", latency_seconds=float(i), result_count=5, error=False)
+
+    perf = provider_stats.get_provider_performance("serper")
+    assert perf["samples"] == provider_stats.MAX_SAMPLES_PER_PROVIDER
+
+
+def test_no_adjustment_below_min_samples(stats_file):
+    _seed("serper", provider_stats.MIN_SAMPLES_FOR_ADJUSTMENT - 1, latency=0.5, result_count=5)
+
+    assert provider_stats.performance_adjustment("serper") == 0.0
+
+
+def test_stale_samples_are_ignored(stats_file):
+    stale = time.time() - provider_stats.SAMPLE_MAX_AGE_SECONDS - 60
+    _seed("serper", 20, latency=0.5, result_count=5, now=stale)
+
+    assert provider_stats.get_provider_performance("serper") is None
+    assert provider_stats.performance_adjustment("serper") == 0.0
+
+
+def test_fast_reliable_provider_gets_bounded_positive_adjustment(stats_file):
+    _seed("serper", 10, latency=0.4, result_count=8)
+
+    adjustment = provider_stats.performance_adjustment("serper")
+    assert 0.0 < adjustment <= provider_stats.MAX_SCORE_ADJUSTMENT
+
+
+def test_slow_flaky_provider_gets_bounded_negative_adjustment(stats_file):
+    _seed("brave", 5, latency=7.5, result_count=0)
+    _seed("brave", 5, latency=7.5, result_count=0, error=True)
+
+    adjustment = provider_stats.performance_adjustment("brave")
+    assert -provider_stats.MAX_SCORE_ADJUSTMENT <= adjustment < 0.0
+
+
+def test_performance_adjustments_omits_unknown_providers(stats_file):
+    _seed("serper", 10, latency=0.4, result_count=8)
+
+    adjustments = provider_stats.performance_adjustments(["serper", "tavily"])
+    assert "serper" in adjustments
+    assert "tavily" not in adjustments
+
+
+def test_record_outcome_is_best_effort(stats_file, monkeypatch):
+    def broken_save(state):
+        raise IOError("disk full")
+
+    monkeypatch.setattr(provider_stats, "_save_stats", broken_save)
+    # Must not raise: stats persistence can never break a search.
+    provider_stats.record_provider_outcome("serper", latency_seconds=0.5, result_count=5, error=False)
+
+
+class TestAdaptiveRouting:
+    QUERY = "find credible sources and citations to verify this claim"
+    ENV = {"LINKUP_API_KEY": "linkup-test-key", "TAVILY_API_KEY": "tavily-test-key"}
+
+    def test_adaptive_adjustments_blend_into_routing_scores(self, stats_file):
+        _seed("tavily", 10, latency=0.4, result_count=8)
+        _seed("linkup", 5, latency=7.5, result_count=0)
+        _seed("linkup", 5, latency=7.5, result_count=0, error=True)
+
+        config = {"auto_routing": {"provider_priority": ["linkup", "tavily"]}}
+        with mock.patch.dict(os.environ, self.ENV, clear=False):
+            result = routing.auto_route_provider(self.QUERY, config)
+
+        adjustments = result["adaptive_adjustments"]
+        assert adjustments["tavily"] > 0.0
+        assert adjustments["linkup"] < 0.0
+
+    def test_adaptive_adjustment_can_flip_a_close_call(self, stats_file):
+        config_off = {"auto_routing": {"provider_priority": ["linkup", "tavily"], "adaptive_routing": False}}
+        with mock.patch.dict(os.environ, self.ENV, clear=False):
+            baseline = routing.auto_route_provider(self.QUERY, config_off)
+        assert baseline["provider"] == "linkup"
+        margin = baseline["scores"]["linkup"] - baseline["scores"].get("tavily", 0.0)
+
+        config_on = {"auto_routing": {"provider_priority": ["linkup", "tavily"]}}
+        with mock.patch.object(
+            routing, "performance_adjustments",
+            lambda providers, now=None: {"tavily": margin + 0.5},
+        ):
+            with mock.patch.dict(os.environ, self.ENV, clear=False):
+                result = routing.auto_route_provider(self.QUERY, config_on)
+
+        assert result["provider"] == "tavily"
+
+    def test_adaptive_routing_can_be_disabled_via_config(self, stats_file):
+        _seed("tavily", 10, latency=0.4, result_count=8)
+
+        config = {"auto_routing": {"provider_priority": ["linkup", "tavily"], "adaptive_routing": False}}
+        with mock.patch.dict(os.environ, self.ENV, clear=False):
+            result = routing.auto_route_provider(self.QUERY, config)
+
+        assert result["adaptive_adjustments"] == {}
+
+    def test_zero_signal_queries_are_not_steered_by_performance(self, stats_file):
+        _seed("tavily", 10, latency=0.4, result_count=8)
+
+        def must_not_be_called(providers, now=None):
+            raise AssertionError("adaptive adjustments must not apply without query signals")
+
+        config = {"auto_routing": {"provider_priority": ["linkup", "tavily"]}}
+        with mock.patch.object(routing, "performance_adjustments", must_not_be_called):
+            with mock.patch.dict(os.environ, self.ENV, clear=False):
+                result = routing.auto_route_provider("zzqx", config)
+
+        assert result["adaptive_adjustments"] == {}

--- a/tests/test_result_quality_filters.py
+++ b/tests/test_result_quality_filters.py
@@ -1,0 +1,162 @@
+"""Spam/mirror-domain filtering and domain-diversity reranking."""
+
+import quality
+import search
+
+
+def _result(url, title="t"):
+    return {"url": url, "title": title, "description": "snippet text"}
+
+
+class TestFilterSpamResults:
+    def test_removes_known_mirror_domains(self):
+        results = [
+            _result("https://stackoverflow.com/q/1"),
+            _result("https://newbedev.com/some-copied-answer"),
+            _result("https://githubmemory.com/repo/issue"),
+        ]
+
+        kept, removed = quality.filter_spam_results(results)
+
+        assert [r["url"] for r in kept] == ["https://stackoverflow.com/q/1"]
+        assert removed == ["githubmemory.com", "newbedev.com"]
+
+    def test_matches_www_and_subdomains(self):
+        results = [
+            _result("https://www.newbedev.com/x"),
+            _result("https://de.newbedev.com/x"),
+        ]
+
+        kept, removed = quality.filter_spam_results(results)
+
+        assert kept == []
+        assert removed == ["de.newbedev.com", "newbedev.com"]
+
+    def test_extra_blocked_domains_from_config(self):
+        results = [_result("https://content-farm.example/post")]
+
+        kept, removed = quality.filter_spam_results(results, extra_blocked=["content-farm.example"])
+
+        assert kept == []
+        assert removed == ["content-farm.example"]
+
+    def test_allowed_domains_rescue_blocked_entries(self):
+        results = [_result("https://newbedev.com/x")]
+
+        kept, removed = quality.filter_spam_results(results, allowed=["newbedev.com"])
+
+        assert len(kept) == 1
+        assert removed == []
+
+    def test_clean_results_pass_through_unchanged(self):
+        results = [_result("https://docs.python.org/3/"), _result("https://github.com/x/y")]
+
+        kept, removed = quality.filter_spam_results(results)
+
+        assert kept == results
+        assert removed == []
+
+
+class TestRerankDomainDiversity:
+    def test_third_result_from_same_domain_is_demoted(self):
+        results = [
+            _result("https://a.example/1"),
+            _result("https://a.example/2"),
+            _result("https://a.example/3"),
+            _result("https://b.example/1"),
+        ]
+
+        reranked, demoted = quality.rerank_domain_diversity(results, max_per_domain=2)
+
+        assert [r["url"] for r in reranked] == [
+            "https://a.example/1",
+            "https://a.example/2",
+            "https://b.example/1",
+            "https://a.example/3",
+        ]
+        assert demoted == 1
+
+    def test_short_lists_are_untouched(self):
+        results = [_result("https://a.example/1"), _result("https://a.example/2")]
+
+        reranked, demoted = quality.rerank_domain_diversity(results, max_per_domain=1)
+
+        assert reranked == results
+        assert demoted == 0
+
+    def test_diverse_lists_keep_order(self):
+        results = [
+            _result("https://a.example/1"),
+            _result("https://b.example/1"),
+            _result("https://c.example/1"),
+        ]
+
+        reranked, demoted = quality.rerank_domain_diversity(results)
+
+        assert reranked == results
+        assert demoted == 0
+
+
+class TestResultQualityPipeline:
+    def test_pipeline_filters_and_reports_metadata(self):
+        result = {"results": [
+            _result("https://stackoverflow.com/q/1"),
+            _result("https://newbedev.com/copy"),
+            _result("https://docs.python.org/3/"),
+        ]}
+
+        search._apply_result_quality_pipeline(result, config={})
+
+        assert [r["url"] for r in result["results"]] == [
+            "https://stackoverflow.com/q/1",
+            "https://docs.python.org/3/",
+        ]
+        assert result["metadata"]["spam_filtered"] == {
+            "removed_count": 1,
+            "domains": ["newbedev.com"],
+        }
+
+    def test_pipeline_applies_domain_diversity_cap(self):
+        result = {"results": [
+            _result("https://a.example/1"),
+            _result("https://a.example/2"),
+            _result("https://a.example/3"),
+            _result("https://b.example/1"),
+        ]}
+
+        search._apply_result_quality_pipeline(result, config={})
+
+        assert [r["url"] for r in result["results"]][:3] == [
+            "https://a.example/1", "https://a.example/2", "https://b.example/1",
+        ]
+        assert result["metadata"]["domain_diversity_demoted"] == 1
+
+    def test_spam_filter_can_be_disabled_via_config(self):
+        result = {"results": [_result("https://newbedev.com/copy")]}
+
+        search._apply_result_quality_pipeline(result, config={"quality": {"filter_spam": False}})
+
+        assert len(result["results"]) == 1
+        assert "metadata" not in result
+
+    def test_diversity_cap_can_be_disabled_via_config(self):
+        result = {"results": [
+            _result("https://a.example/1"),
+            _result("https://a.example/2"),
+            _result("https://a.example/3"),
+        ]}
+
+        search._apply_result_quality_pipeline(result, config={"quality": {"max_results_per_domain": 0}})
+
+        assert [r["url"] for r in result["results"]] == [
+            "https://a.example/1", "https://a.example/2", "https://a.example/3",
+        ]
+
+    def test_allowed_domains_config_rescues_domain(self):
+        result = {"results": [_result("https://newbedev.com/copy")]}
+
+        search._apply_result_quality_pipeline(
+            result, config={"quality": {"allowed_domains": ["newbedev.com"]}},
+        )
+
+        assert len(result["results"]) == 1

--- a/tests/test_result_quality_filters.py
+++ b/tests/test_result_quality_filters.py
@@ -32,6 +32,34 @@ class TestFilterSpamResults:
         assert kept == []
         assert removed == ["de.newbedev.com", "newbedev.com"]
 
+    def test_lookalike_registrations_are_not_false_positives(self):
+        # A blocked domain used as a prefix of an unrelated registration must
+        # NOT match: only the exact domain or true subdomains are blocked.
+        results = [
+            _result("https://newbedev.com.evil.example/post"),
+            _result("https://newbedev.community/post"),
+        ]
+
+        kept, removed = quality.filter_spam_results(results)
+
+        assert [r["url"] for r in kept] == [
+            "https://newbedev.com.evil.example/post",
+            "https://newbedev.community/post",
+        ]
+        assert removed == []
+
+    def test_blocklist_covers_live_sighted_mirrors(self):
+        results = [
+            _result("https://fixmycodeerror.com/q"),
+            _result("https://stacklesson.com/q"),
+            _result("https://docs.w3cub.com/python~3/library/ssl"),
+        ]
+
+        kept, removed = quality.filter_spam_results(results)
+
+        assert kept == []
+        assert removed == ["docs.w3cub.com", "fixmycodeerror.com", "stacklesson.com"]
+
     def test_extra_blocked_domains_from_config(self):
         results = [_result("https://content-farm.example/post")]
 
@@ -160,3 +188,79 @@ class TestResultQualityPipeline:
         )
 
         assert len(result["results"]) == 1
+
+    def test_site_query_skips_domain_diversity_rerank(self):
+        # A deliberately one-domain query must keep its provider order.
+        result = {"results": [
+            _result("https://github.com/x/1"),
+            _result("https://github.com/x/2"),
+            _result("https://github.com/x/3"),
+            _result("https://randomblog.example/post"),
+        ]}
+
+        search._apply_result_quality_pipeline(
+            result, config={}, query="site:github.com fastapi upload example",
+        )
+
+        assert [r["url"] for r in result["results"]] == [
+            "https://github.com/x/1",
+            "https://github.com/x/2",
+            "https://github.com/x/3",
+            "https://randomblog.example/post",
+        ]
+        assert "metadata" not in result
+
+    def test_include_domains_skip_diversity_rerank(self):
+        result = {"results": [
+            _result("https://arxiv.org/abs/1"),
+            _result("https://arxiv.org/abs/2"),
+            _result("https://arxiv.org/abs/3"),
+            _result("https://other.example/x"),
+        ]}
+
+        search._apply_result_quality_pipeline(
+            result, config={}, query="attention is all you need", include_domains=["arxiv.org"],
+        )
+
+        assert [r["url"] for r in result["results"]][:3] == [
+            "https://arxiv.org/abs/1",
+            "https://arxiv.org/abs/2",
+            "https://arxiv.org/abs/3",
+        ]
+
+    def test_site_query_for_blocked_domain_wins_over_blocklist(self):
+        # Explicitly searching a blocked domain expresses intent: keep it.
+        result = {"results": [_result("https://newbedev.com/copy")]}
+
+        search._apply_result_quality_pipeline(
+            result, config={}, query="site:newbedev.com some query",
+        )
+
+        assert len(result["results"]) == 1
+
+    def test_unconstrained_queries_still_get_diversity_rerank(self):
+        result = {"results": [
+            _result("https://a.example/1"),
+            _result("https://a.example/2"),
+            _result("https://a.example/3"),
+            _result("https://b.example/1"),
+        ]}
+
+        search._apply_result_quality_pipeline(
+            result, config={}, query="fastapi upload file example",
+        )
+
+        assert result["metadata"]["domain_diversity_demoted"] == 1
+
+
+class TestExtractDomainConstraints:
+    def test_collects_site_operators_and_include_domains(self):
+        constraints = quality.extract_domain_constraints(
+            "site:github.com site:Docs.Python.org asyncio", include_domains=["arxiv.org"],
+        )
+
+        assert constraints == ["arxiv.org", "docs.python.org", "github.com"]
+
+    def test_plain_queries_have_no_constraints(self):
+        assert quality.extract_domain_constraints("fastapi upload file example") == []
+        assert quality.extract_domain_constraints("", include_domains=None) == []


### PR DESCRIPTION
Result hygiene and routing robustness: adaptive provider scoring plus defensive spam/mirror filtering. Stacked on #51 (reliability fixes) — the diff shows only the feature changes; once #51 merges this retargets to `main` automatically.

**Honest framing:** live A/B testing (5 queries × 2 providers) showed results mostly identical to base — the spam filter only acts when providers actually return mirror domains, and adaptive routing only shifts close calls after enough samples. This is **defensive hygiene that helps in specific cases**, not a proven general quality win. Treat it as a robustness PR.

## 1. Adaptive routing with performance memory (`provider_stats.py`)

Routing v2 scores were benchmarked but static. Now every real provider call records **latency, error, and empty-result outcome** in a rolling window (50 samples per provider, 7-day freshness, atomic writes in the cache dir). Routing blends a **bounded adjustment (±1.0)** into provider scores:

- reliability (success rate, discounted by empty-result rate) weighted 60%, speed (median latency vs. 8s ceiling) weighted 40%
- needs ≥5 fresh samples before influencing anything
- **zero-signal queries are untouched**, and strong query-class signals are never overridden — confirmed in simulation: a provider with a large query-signal lead stays in front despite bad history; performance memory only breaks close calls
- config/validation errors (e.g. missing keys) are *not* counted as provider performance
- toggle: `auto_routing.adaptive_routing` (default on); adjustments surface in routing info and `quality_report.adaptive_adjustments`

## 2. Spam/mirror filter + domain-diversity rerank (`quality.py`)

- Results from known Stack Overflow/GitHub **content mirrors and SEO scrapers** are removed rather than merely demoted, truthfully reported in `metadata.spam_filtered`. Extensible via `quality.blocked_domains`, rescuable via `quality.allowed_domains`, off via `quality.filter_spam: false`.
- **Strict domain matching:** only the exact domain or true subdomains match (`de.newbedev.com` ✓). Look-alike registrations such as `newbedev.com.evil.example` do **not** match — the loose `startswith` matcher remains only for the intent reranker's prefix rules (`docs.`, `investor.`, …) where it is intentional.
- A **stable domain-diversity rerank** caps per-domain dominance at 2 results (`quality.max_results_per_domain`, `0` disables); overflow moves behind the diverse head instead of being dropped.
- **Explicit intent wins:** `site:` operators and `include_domains` exempt those domains from the spam filter and skip the diversity rerank entirely, so deliberately one-domain queries (`site:github.com …`) keep their provider order.
- Blocklist includes mirrors sighted in live testing: `fixmycodeerror.com`, `stacklesson.com`, `w3cub.com`.

## Test isolation note

`tests/conftest.py` redirects the stats file into a tmp dir per test (autouse). Without this, tests recording outcomes for mocked providers would pollute the operator's real `provider_stats.json` and feed back into routing decisions, making routing tests order-dependent.

## Tests

- `tests/test_provider_stats.py` (11): rolling window cap, freshness cutoff, min-samples gate, bounded adjustments, best-effort persistence, adaptive routing integration (blend, close-call flip, config disable, zero-signal guard).
- `tests/test_result_quality_filters.py` (21): mirror filtering incl. www/subdomains, **look-alike false-positive regression**, live-sighted mirrors, config block/allow lists, diversity rerank stability, **site:/include_domains constraint exemptions**, pipeline metadata, disable toggles, `extract_domain_constraints` parsing.

`pytest`: 256 passed · `ruff check`: clean · CI compile list extended with `provider_stats.py` · README documents the new config switches and the constraint exemption