### PR TITLE
fix(extract): respect disabled_providers from config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v2.5.1] — 2026-06-16
+
+### 🐛 Fixed
+- `extract_plus` now respects `disabled_providers` from `config.json`. Previously only search routing honored the disabled-provider list; extraction used a hardcoded provider order, causing disabled providers to still be called during URL extraction. Explicit provider selection still tries the requested provider first, matching search semantics.
+
+### 🔧 Improved
+- Added tests covering auto-mode extraction skip and explicit-provider fallback behavior when providers are disabled in config.
+
 ## [v2.5.0] — 2026-06-16
 
 ### Credits

--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API
 """
 from __future__ import annotations
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 
 import argparse
 import getpass

--- a/extract.py
+++ b/extract.py
@@ -45,7 +45,10 @@ def extract_plus(
             "error": f"Invalid URL(s) — must start with http:// or https://: {invalid}",
             "requested_provider": selected,
         }
-    providers = EXTRACT_PROVIDER_PRIORITY if selected == "auto" else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
+    auto_config = config.get("auto_routing", {})
+    disabled_providers = set(auto_config.get("disabled_providers", []))
+    base_providers = EXTRACT_PROVIDER_PRIORITY if selected == "auto" else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
+    providers = [p for p in base_providers if p == selected or p not in disabled_providers]
     errors = []
     cooldown_skips = []
     for prov in providers:

--- a/http_client.py
+++ b/http_client.py
@@ -13,7 +13,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.5.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.5.1"
 
 
 class ProviderRequestError(Exception):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "2.5.0"
+version: "2.5.1"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 2.5.0
+Version: 2.5.1
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com.

--- a/tests/test_extract_plus.py
+++ b/tests/test_extract_plus.py
@@ -169,6 +169,38 @@ class ExtractPlusCoreTests(unittest.TestCase):
         self.assertEqual(result["provider"], "exa")
         mock_exa.assert_called_once()
 
+    def test_extract_plus_auto_skips_disabled_providers(self):
+        config = {
+            "auto_routing": {
+                "disabled_providers": ["firecrawl"],
+                "provider_priority": ["tavily", "exa", "linkup", "parallel", "firecrawl", "you"],
+            }
+        }
+        with mock.patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test", "FIRECRAWL_API_KEY": "fc-test"}, clear=True):
+            with mock.patch("search.extract_tavily", return_value={"provider": "tavily", "results": []}) as mock_tavily:
+                with mock.patch("search.extract_firecrawl") as mock_firecrawl:
+                    result = search.extract_plus(["https://example.com"], provider="auto", config=config)
+
+        self.assertEqual(result["provider"], "tavily")
+        mock_tavily.assert_called_once()
+        mock_firecrawl.assert_not_called()
+
+    def test_extract_plus_explicit_disabled_provider_is_still_tried(self):
+        config = {
+            "auto_routing": {
+                "disabled_providers": ["firecrawl"],
+                "provider_priority": ["tavily", "exa", "linkup", "parallel", "firecrawl", "you"],
+            }
+        }
+        with mock.patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test", "LINKUP_API_KEY": "linkup-test"}, clear=True):
+            with mock.patch("search.extract_firecrawl", return_value={"provider": "firecrawl", "results": [{"url": "https://example.com", "error": "fetch failed"}]}) as mock_firecrawl:
+                with mock.patch("search.extract_linkup", return_value={"provider": "linkup", "results": [{"url": "https://example.com", "content": "fallback"}]}) as mock_linkup:
+                    result = search.extract_plus(["https://example.com"], provider="firecrawl", config=config)
+
+        self.assertEqual(result["provider"], "linkup")
+        mock_firecrawl.assert_called_once()
+        mock_linkup.assert_called_once()
+
     def test_extract_provider_priority_prefers_fast_clean_extractors(self):
         self.assertEqual(search.EXTRACT_PROVIDER_PRIORITY, ["tavily", "exa", "linkup", "parallel", "firecrawl", "you"])
 

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -52,7 +52,7 @@ def test_http_client_provider_request_error_exports_retry_metadata():
 
 
 def test_default_user_agent_uses_release_version():
-    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.5.0"
+    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.5.1"
 
 
 def _make_http_error(code: int, headers=None, body: bytes = b"{}") -> HTTPError:

--- a/tests/test_plugin_package_import.py
+++ b/tests/test_plugin_package_import.py
@@ -35,7 +35,7 @@ def test_plugin_loads_with_hermes_package_style_import():
 
         spec.loader.exec_module(module)
 
-        assert module.__version__ == "2.5.0"
+        assert module.__version__ == "2.5.1"
         assert module._get_provider_catalog()
     finally:
         sys.modules.pop(module_name, None)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "2.5.0"
+EXPECTED_VERSION = "2.5.1"
 
 
 def _load_plugin_module():


### PR DESCRIPTION
## Problem
extract_plus used the hardcoded EXTRACT_PROVIDER_IDS order regardless of config.json auto_routing.disabled_providers. Search routing already honored the list, so disabled providers could still be called during URL extraction.

## Fix
Filter the extract fallback list against disabled_providers while still trying an explicitly requested provider first. This matches search.py semantics and keeps the default extract order unchanged.

## Test coverage
- Added test for auto-mode extraction skipping disabled providers.
- Added test for explicit-provider selection still trying the requested provider before falling back to non-disabled ones.

## Version
Bumps to v2.5.1.