### PR TITLE
fix(load): stash colliding sys.modules around in-process search engine load

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -843,6 +843,30 @@ def _load_search_module() -> Any:
         if plugin_dir not in sys.path:
             sys.path.insert(0, plugin_dir)
             inserted = True
+        # Stash any top-level modules whose names collide with this plugin's
+        # flat sibling imports (providers, extract, routing, research, etc.).
+        # If hermes-agent's `providers` package is already in sys.modules,
+        # `from providers import extract_exa` inside extract.py resolves
+        # to the wrong module. Pop them for the duration of the load,
+        # restore afterward.
+        _COLLIDING_MODULES = (
+            "providers",
+            "extract",
+            "routing",
+            "research",
+            "search",
+            "config",
+            "cache",
+            "quality",
+            "http_client",
+            "env_loader",
+            "provider_health",
+            "provider_registry",
+        )
+        stashed: dict[str, Any] = {}
+        for _name in _COLLIDING_MODULES:
+            if _name in sys.modules:
+                stashed[_name] = sys.modules.pop(_name)
         try:
             spec = importlib.util.spec_from_file_location("_wsp_search_engine", _SEARCH_SCRIPT)
             if spec is None or spec.loader is None:
@@ -856,6 +880,12 @@ def _load_search_module() -> Any:
             _search_import_failed = True
             return None
         finally:
+            # Restore the original top-level modules so unrelated code that
+            # imported `providers` etc. still sees what it expects.
+            for _name in _COLLIDING_MODULES:
+                sys.modules.pop(_name, None)
+            for _name, _mod in stashed.items():
+                sys.modules[_name] = _mod
             if inserted:
                 try:
                     sys.path.remove(plugin_dir)


### PR DESCRIPTION
## Symptom

```
ERROR hermes_plugins.web_search_plus: web-search-plus: in-process search import failed; using subprocess fallback
Traceback (most recent call last):
  File ".../web-search-plus/__init__.py", line 848, in _load_search_module
    spec.loader.exec_module(_search)
  File ".../web-search-plus/search.py", line 83, in <module>
    import extract as _extract
  File ".../web-search-plus/extract.py", line 12, in <module>
    from providers import (
ImportError: cannot import name 'extract_exa' from 'providers' (.../hermes-agent/providers/__init__.py)
```

Fires on every `web_search` / `web_extract` call, forcing the slow subprocess fallback path.

## Root cause

The plugin's `search.py` and `extract.py` use flat sibling imports (`import providers as _providers`, `from providers import extract_exa`, etc.). They were written assuming `providers` resolves to the plugin's local `providers.py` because the plugin dir was on `sys.path` at load time.

But hermes-agent itself imports its own top-level `providers` package at startup, so by the time the plugin's lazy `_load_search_module()` runs, `sys.modules['providers']` is already populated with hermes-agent's module. Python's import machinery returns the cached module instead of loading the plugin's local file — and hermes-agent's `providers` package doesn't export `extract_exa`, so the import fails.

`search.py` happens to dodge this because it's loaded via `spec_from_file_location` under a private name (`_wsp_search_engine`). But its sibling `extract.py` is imported by `search.py` via regular `import extract`, which can't bypass `sys.modules` the same way.

## Fix

Before `exec_module(_search)`, pop the names that collide with hermes-agent's top-level modules (`providers`, `extract`, `routing`, `research`, `search`, `config`, `cache`, `quality`, `http_client`, `env_loader`, `provider_health`, `provider_registry`) out of `sys.modules` and stash them. The plugin's flat imports now resolve to its own local files. Restore the originals in the `finally` block so any unrelated code that imports those names afterwards still sees the hermes-agent versions it expected.

## Verification

Reproduced the failure with hermes-agent's `providers` package pre-loaded into `sys.modules`, confirmed the patched loader succeeds in-process AND leaves `sys.modules['providers']` pointing at the hermes-agent module afterward.

```
$ pytest tests/test_extract_plus.py tests/test_provider_contracts.py
40 passed
```

## Risk

Low. Stash/restore is scoped to the one-time lazy load of the plugin's search engine. The list of colliding names is conservative (only flat sibling imports actually present in `search.py` / `extract.py`). Other modules in `sys.modules` are untouched.