### PR TITLE
docs: document GroktoCrawl as local Firecrawl backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,26 @@
 
 ## [Unreleased]
 
+## [v2.6.1] — 2026-06-26
+
+### Credits
+- #57 by @robbyczgw-cla — GroktoCrawl / local Firecrawl-compatible backend documentation and endpoint override tests.
+
+### 📚 Docs
+- Documented using Firecrawl-v2-compatible local backends such as GroktoCrawl by overriding the existing Firecrawl search and scrape URLs in `config.json`.
+- Corrected the v2.6.0 changelog history to include #55 and #56 attribution after the GitHub Release notes were also fixed.
+
+### 🧪 Tests
+- Added Firecrawl provider tests covering custom search and scrape endpoint overrides so local-compatible backends stay on the same wire path as Firecrawl cloud.
+
 ## [v2.6.0] — 2026-06-26
 
 ### Credits
+- #55 by @maksym-mishchenko — in-process loader fix for `sys.modules` name collisions with host packages.
 - #56 by @IlyaGusev — Keenable search and extraction provider with keyed endpoints plus an opt-in keyless public tier.
+
+### 🐛 Fixed
+- Fixed in-process loading when the host runtime already has top-level modules such as `providers` in `sys.modules`, preventing host/package name collisions from forcing the plugin onto the subprocess fallback path. (#55)
 
 ### ✨ Added
 - Added Keenable as a search and extraction provider, using Keenable's independent web index. Setting `KEENABLE_API_KEY` (or `keenable.api_key` in `config.json`) uses the authenticated endpoints (with an `X-API-Key` header). It can also run keyless against the `/v1/search/public` and `/v1/fetch/public` endpoints, but this is **opt-in and off by default** — enable it with `keenable.allow_public: true` in `config.json` or `KEENABLE_ALLOW_PUBLIC=1`, since the public tier routes queries and fetched URLs to an unauthenticated service (~1000 req/hour, 10 req/sec per-IP limits, no SLA) and emits a one-time warning when first used. Once configured (keyed or opted-in), Keenable is available via `provider="keenable"` and as the lowest-priority auto-routing/extraction fallback, so it never displaces a configured keyed provider. Key status stays truthful — keyless providers report `key=no` with a distinct keyless badge in `doctor`. (#56)

--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ Notes:
 - `setup.py --config-path /path/to/config.json` points the helper at a custom config; `WEB_SEARCH_PLUS_CONFIG=/path/to/config.json` points `search.py` at the same file.
 - `config reset --yes` backs up the existing file before writing fresh defaults.
 
+### GroktoCrawl / local Firecrawl-compatible backends
+
+The Firecrawl provider can target a local Firecrawl-v2-compatible backend by overriding its search and scrape URLs in `config.json`. For example, a local [GroktoCrawl](https://github.com/groktopus/groktocrawl) instance listening on `127.0.0.1:8080` can be used without adding a separate provider:
+
+```json
+{
+  "firecrawl": {
+    "api_url": "http://127.0.0.1:8080/v2/search",
+    "scrape_url": "http://127.0.0.1:8080/v2/scrape"
+  }
+}
+```
+
+Keep `FIRECRAWL_API_KEY` configured if your backend enforces bearer authentication; local development instances may ignore the header. This recipe has been smoke-tested for Firecrawl-style search and URL scrape responses, including GitHub repository extraction through GroktoCrawl's adapter layer. It does not make GroktoCrawl the default, and it does not claim coverage for every Firecrawl endpoint, pagination edge case, or provider-specific error shape.
+
 ---
 
 ## Capability model

--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API
 """
 from __future__ import annotations
 
-__version__ = "2.6.0"
+__version__ = "2.6.1"
 
 import argparse
 import getpass

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -116,6 +116,21 @@ Preview config changes without writing:
 python ~/.hermes/plugins/web-search-plus/setup.py config set-default you --dry-run
 ```
 
+### GroktoCrawl / local Firecrawl-compatible backends
+
+Firecrawl search and extraction use configurable endpoint URLs. If you run a local Firecrawl-v2-compatible service such as [GroktoCrawl](https://github.com/groktopus/groktocrawl), point the existing `firecrawl` provider at that service instead of adding a new provider name:
+
+```json
+{
+  "firecrawl": {
+    "api_url": "http://127.0.0.1:8080/v2/search",
+    "scrape_url": "http://127.0.0.1:8080/v2/scrape"
+  }
+}
+```
+
+The backend still receives the same bearer header WSP sends for Firecrawl, so set `FIRECRAWL_API_KEY` when the local service requires authentication. This is an operator-controlled override: WSP keeps the default Firecrawl cloud URLs unless you set these config values. The GroktoCrawl path has been smoke-tested for search and scrape/extract response compatibility, but monitor your own timeout, pagination, and rate-limit behavior before relying on it for production crawls.
+
 ### Routing debug walkthrough
 
 When a query does not use the provider you expected, ask for routing diagnostics instead of guessing:

--- a/http_client.py
+++ b/http_client.py
@@ -13,7 +13,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.6.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.6.1"
 
 
 class ProviderRequestError(Exception):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "2.6.0"
+version: "2.6.1"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 2.6.0
+Version: 2.6.1
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable.

--- a/tests/test_firecrawl_provider.py
+++ b/tests/test_firecrawl_provider.py
@@ -53,6 +53,53 @@ class FirecrawlProviderTests(unittest.TestCase):
         self.assertEqual(body["country"], "US")
         self.assertEqual(body["tbs"], "qdr:w")
 
+    def test_search_firecrawl_uses_custom_compatible_backend_url(self):
+        fake_response = {
+            "success": True,
+            "data": {
+                "web": [
+                    {
+                        "title": "Local backend result",
+                        "url": "https://example.com/local",
+                        "description": "Local compatible backend snippet",
+                    }
+                ]
+            },
+        }
+        with mock.patch("search.make_request", return_value=fake_response) as mock_request:
+            result = search.search_firecrawl(
+                query="local backend",
+                api_key="fc-test-key-12345",
+                api_url="http://127.0.0.1:8080/v2/search",
+            )
+
+        url, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(url, "http://127.0.0.1:8080/v2/search")
+        self.assertEqual(headers["Authorization"], "Bearer fc-test-key-12345")
+        self.assertEqual(body["query"], "local backend")
+        self.assertEqual(result["results"][0]["title"], "Local backend result")
+
+    def test_extract_firecrawl_uses_custom_compatible_backend_url(self):
+        fake_response = {
+            "success": True,
+            "data": {
+                "markdown": "# Local backend\nClean content",
+                "metadata": {"title": "Local backend page"},
+            },
+        }
+        with mock.patch("search.make_request", return_value=fake_response) as mock_request:
+            result = search.extract_firecrawl(
+                urls=["https://example.com"],
+                api_key="fc-test-key-12345",
+                api_url="http://127.0.0.1:8080/v2/scrape",
+            )
+
+        url, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(url, "http://127.0.0.1:8080/v2/scrape")
+        self.assertEqual(headers["Authorization"], "Bearer fc-test-key-12345")
+        self.assertEqual(body["url"], "https://example.com")
+        self.assertEqual(result["results"][0]["content"], "# Local backend\nClean content")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -52,7 +52,7 @@ def test_http_client_provider_request_error_exports_retry_metadata():
 
 
 def test_default_user_agent_uses_release_version():
-    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.6.0"
+    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.6.1"
 
 
 def _make_http_error(code: int, headers=None, body: bytes = b"{}") -> HTTPError:

--- a/tests/test_plugin_package_import.py
+++ b/tests/test_plugin_package_import.py
@@ -35,7 +35,7 @@ def test_plugin_loads_with_hermes_package_style_import():
 
         spec.loader.exec_module(module)
 
-        assert module.__version__ == "2.6.0"
+        assert module.__version__ == "2.6.1"
         assert module._get_provider_catalog()
     finally:
         sys.modules.pop(module_name, None)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "2.6.0"
+EXPECTED_VERSION = "2.6.1"
 
 
 def _load_plugin_module():


### PR DESCRIPTION
## Summary
- Document using **GroktoCrawl** as a Firecrawl-v2-compatible local backend through the existing `firecrawl.api_url` and `firecrawl.scrape_url` settings.
- Clarify that this is an operator-controlled config override, not a new provider or default backend.
- Add tests proving the Firecrawl provider honors custom search and scrape endpoint URLs.
- Prepare corrective v2.6.1 release metadata so #57 ships cleanly after v2.6.0.
- Correct the v2.6.0 changelog section to credit #55 by @maksym-mishchenko alongside #56 by @IlyaGusev.

## Why no new provider?
GroktoCrawl speaks the Firecrawl-v2 wire shape for the tested search/scrape paths, so WSP can use it through the existing Firecrawl provider. A separate `groktocrawl` provider would mostly duplicate Firecrawl code and create avoidable maintenance drift.

## Test Plan
- `python3 -m compileall -q .`
- `python3 -m pytest tests/ -q` → 286 passed
- `ruff check .`
- `git diff --check`
- Changed-file privacy scan

## Compatibility Notes
- Local smoke confirmed Firecrawl-style search and scrape/extract response compatibility against a local GroktoCrawl instance.
- This PR intentionally does not add a first-class GroktoCrawl provider or hardcoded local defaults.
- Docs avoid claiming coverage for every Firecrawl endpoint, pagination edge case, timeout behavior, or provider-specific error shape.

## Release Hygiene
- Existing GitHub Release v2.6.0 notes were corrected to include #55 attribution and the loader fix summary.
- v2.6.1 will include #57 and the corrected changelog history.
