### PR TITLE
chore: prepare v2.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## [Unreleased]
 
+## [v2.6.0] — 2026-06-26
+
+### Credits
+- #56 by @IlyaGusev — Keenable search and extraction provider with keyed endpoints plus an opt-in keyless public tier.
+
 ### ✨ Added
-- Keenable as a search and extraction provider, using Keenable's independent web index. Setting `KEENABLE_API_KEY` (or `keenable.api_key` in `config.json`) uses the authenticated endpoints (with an `X-API-Key` header). It can also run keyless against the `/v1/search/public` and `/v1/fetch/public` endpoints, but this is **opt-in and off by default** — enable it with `keenable.allow_public: true` in `config.json` or `KEENABLE_ALLOW_PUBLIC=1`, since the public tier routes queries and fetched URLs to an unauthenticated service (~1000 req/hour, 10 req/sec per-IP limits, no SLA) and emits a one-time warning when first used. Once configured (keyed or opted-in), Keenable is available via `provider="keenable"` and as the lowest-priority auto-routing/extraction fallback, so it never displaces a configured keyed provider. Key status stays truthful — keyless providers report `key=no` with a distinct keyless badge in `doctor`.
+- Added Keenable as a search and extraction provider, using Keenable's independent web index. Setting `KEENABLE_API_KEY` (or `keenable.api_key` in `config.json`) uses the authenticated endpoints (with an `X-API-Key` header). It can also run keyless against the `/v1/search/public` and `/v1/fetch/public` endpoints, but this is **opt-in and off by default** — enable it with `keenable.allow_public: true` in `config.json` or `KEENABLE_ALLOW_PUBLIC=1`, since the public tier routes queries and fetched URLs to an unauthenticated service (~1000 req/hour, 10 req/sec per-IP limits, no SLA) and emits a one-time warning when first used. Once configured (keyed or opted-in), Keenable is available via `provider="keenable"` and as the lowest-priority auto-routing/extraction fallback, so it never displaces a configured keyed provider. Key status stays truthful — keyless providers report `key=no` with a distinct keyless badge in `doctor`. (#56)
 
 ## [v2.5.1] — 2026-06-16
 

--- a/__init__.py
+++ b/__init__.py
@@ -5,7 +5,7 @@ Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API
 """
 from __future__ import annotations
 
-__version__ = "2.5.1"
+__version__ = "2.6.0"
 
 import argparse
 import getpass

--- a/http_client.py
+++ b/http_client.py
@@ -13,7 +13,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.5.1"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.6.0"
 
 
 class ProviderRequestError(Exception):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "2.5.1"
+version: "2.6.0"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/search.py
+++ b/search.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 2.5.1
+Version: 2.6.0
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
-Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG.
-Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com.
+Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG, Keenable.
+Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable.
 
 Smart Routing uses multi-signal analysis:
   - Routing v2 language/script and query-class detection

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -52,7 +52,7 @@ def test_http_client_provider_request_error_exports_retry_metadata():
 
 
 def test_default_user_agent_uses_release_version():
-    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.5.1"
+    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.6.0"
 
 
 def _make_http_error(code: int, headers=None, body: bytes = b"{}") -> HTTPError:

--- a/tests/test_plugin_package_import.py
+++ b/tests/test_plugin_package_import.py
@@ -35,7 +35,7 @@ def test_plugin_loads_with_hermes_package_style_import():
 
         spec.loader.exec_module(module)
 
-        assert module.__version__ == "2.5.1"
+        assert module.__version__ == "2.6.0"
         assert module._get_provider_catalog()
     finally:
         sys.modules.pop(module_name, None)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "2.5.1"
+EXPECTED_VERSION = "2.6.0"
 
 
 def _load_plugin_module():


### PR DESCRIPTION
## Summary
- Bumps Web Search Plus release metadata to v2.6.0 after #56 landed.
- Moves the Keenable provider entry from Unreleased into a dated v2.6.0 changelog section.
- Adds explicit Credits attribution for @IlyaGusev / #56.

## Verification
- `python3 -m compileall -q .`
- `python3 -m pytest tests/ -q` — 284 passed
- `ruff check .`
- `git diff --check`

## Release notes draft
Keenable is now available as a search and extraction provider. Authenticated use is via `KEENABLE_API_KEY` / `keenable.api_key`; the keyless public tier is opt-in and off by default, with strict true-ish parsing for public egress (`1/true/yes/on`).
