### PR TITLE
fix: block private extract target URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - The setup wizard now offers the keyless public tier for keyless providers (currently Keenable): skip the key prompt and it asks whether to enable the no-key public endpoint, writing `<provider>.allow_public: true` to `config.json`. Add `--keyless-public` to skip that confirmation prompt and opt in directly. The mechanism is driven by the registry's keyless flag, so it covers future keyless providers automatically.
 
 ### 🐛 Fixed
+- `web_extract_plus` now rejects private/internal extraction target URLs by default before provider dispatch, blocking loopback, RFC1918, CGNAT/shared-address ranges, IPv6 ULA/link-local/mapped-private addresses, multicast, cloud metadata, and hostnames that resolve to private IPs. Operator-configured provider endpoints (for example a local Firecrawl-compatible backend) remain allowed; trusted intranet extraction can be opted into with `extract.allow_private_urls: true` in `config.json`.
 - A routing-config rewrite (e.g. `config set-priority`, `config reset`) no longer drops non-routing provider sections from `config.json` (e.g. `keenable.allow_public`, `keenable.search_url`, `searxng.instance_url`); the writer now merges routing keys onto the existing file instead of rebuilding it from routing defaults.
 - Corrected the Querit provider `signup_url` from the dead `querit.com` to `querit.ai`.
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ When enabled, queries and fetched URLs are sent to an **unauthenticated** public
 
 ## Reliability and cost controls
 
+- **Safe extraction targets:** `web_extract_plus` rejects private/internal target URLs by default before provider dispatch, including loopback, RFC1918, CGNAT/shared-address ranges, IPv6 ULA/link-local/mapped-private addresses, multicast, cloud metadata, and hostnames that resolve to private IPs. This protects local/self-hosted extraction backends from being used to fetch internal resources. Operator-configured provider endpoints such as a local Firecrawl-compatible `firecrawl.scrape_url` are not blocked; if you intentionally need trusted intranet target extraction, set `{ "extract": { "allow_private_urls": true } }` in `config.json`. This guard validates the initial extraction target before dispatch; redirect-follow hardening belongs in provider fetch layers and should be treated as a follow-up for local backends.
 - **Provider cooldowns:** failed providers are skipped for 1 hour before retry.
 - **Research budget:** `mode="research"` checks the wall-clock budget between provider calls and extraction steps.
 - **Partial results:** search results already collected are preserved if extraction fails or times out.

--- a/config.py
+++ b/config.py
@@ -48,6 +48,11 @@ DEFAULT_CONFIG = {
         "auto_allow": dict(DEFAULT_AUTO_ALLOW),
         "confidence_threshold": 0.3,  # Below this, note low confidence
     },
+    "extract": {
+        # Target URLs supplied to extract_plus are blocked when they resolve to
+        # private/internal networks. Operators can opt in for trusted intranet use.
+        "allow_private_urls": False,
+    },
     "serper": {
         "country": "us",
         "language": "en",

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -133,6 +133,18 @@ Firecrawl search and extraction use configurable endpoint URLs. If you run a loc
 
 The backend still receives the same bearer header WSP sends for Firecrawl, so set `FIRECRAWL_API_KEY` when the local service requires authentication. This is an operator-controlled override: WSP keeps the default Firecrawl cloud URLs unless you set these config values. The GroktoCrawl path has been smoke-tested for search and scrape/extract response compatibility, but monitor your own timeout, pagination, and rate-limit behavior before relying on it for production crawls.
 
+This local endpoint override is separate from the safety check on extraction **target** URLs. `web_extract_plus` rejects private/internal targets by default, including CGNAT/shared-address ranges, IPv6 ULA/link-local/mapped-private addresses, multicast, cloud metadata, and DNS answers that point inward. It still allows the operator-configured local `firecrawl.scrape_url` above. If you intentionally want to extract trusted intranet pages, opt in explicitly:
+
+```json
+{
+  "extract": {
+    "allow_private_urls": true
+  }
+}
+```
+
+The guard validates the initial extraction target before provider dispatch. If a local/self-hosted backend follows redirects itself, re-validating post-redirect targets is a provider-layer hardening follow-up.
+
 ### Routing debug walkthrough
 
 When a query does not use the provider you expected, ask for routing diagnostics instead of guessing:

--- a/extract.py
+++ b/extract.py
@@ -1,6 +1,9 @@
 """Extraction orchestrator for Web Search Plus."""
 
+import ipaddress
+import socket
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
 
 from config import get_api_key, keyless_public_allowed, load_config
 from provider_health import (
@@ -24,6 +27,73 @@ from provider_registry import EXTRACT_PROVIDER_IDS
 EXTRACT_PROVIDER_PRIORITY = list(EXTRACT_PROVIDER_IDS)
 
 
+class ExtractUrlSecurityError(ValueError):
+    """Raised when an extraction target URL points at an internal resource."""
+
+
+_BLOCKED_EXTRACT_HOSTS = {
+    "localhost",
+    "metadata.google.internal",
+    "metadata.internal",
+}
+
+
+def _extract_allows_private_urls(config: Dict[str, Any]) -> bool:
+    extract_config = config.get("extract", {}) if isinstance(config, dict) else {}
+    if not isinstance(extract_config, dict):
+        return False
+    return extract_config.get("allow_private_urls") is True
+
+
+def _is_private_or_internal_ip(value: str) -> bool:
+    ip = ipaddress.ip_address(value)
+    return (not ip.is_global) or ip.is_multicast
+
+
+def _validate_extract_urls(urls: List[str], config: Optional[Dict[str, Any]] = None) -> List[str]:
+    """Validate extraction target URLs before handing them to remote/local fetchers.
+
+    Provider endpoint URLs are operator-controlled config and are intentionally
+    not checked here. This guard only covers user/agent-controlled target URLs.
+    """
+    config = config or {}
+    invalid = [u for u in urls if not (isinstance(u, str) and u.startswith(("http://", "https://")))]
+    if invalid:
+        raise ValueError(f"Invalid URL(s) — must start with http:// or https://: {invalid}")
+    if _extract_allows_private_urls(config):
+        return urls
+
+    for url in urls:
+        parsed = urlparse(url)
+        hostname = (parsed.hostname or "").strip().lower().rstrip(".")
+        if not hostname:
+            raise ValueError(f"Invalid URL — hostname is required: {url}")
+        if hostname in _BLOCKED_EXTRACT_HOSTS:
+            raise ExtractUrlSecurityError(f"Extraction URL blocked: {hostname} is private/internal")
+
+        try:
+            ipaddress.ip_address(hostname)
+        except ValueError:
+            pass
+        else:
+            if _is_private_or_internal_ip(hostname):
+                raise ExtractUrlSecurityError(f"Extraction URL blocked: {hostname} is private/internal")
+            continue
+
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        try:
+            resolved_ips = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
+        except socket.gaierror as exc:
+            raise ExtractUrlSecurityError(f"Extraction URL blocked: cannot resolve hostname {hostname}") from exc
+        for _family, _type, _proto, _canonname, sockaddr in resolved_ips:
+            ip = ipaddress.ip_address(sockaddr[0])
+            if _is_private_or_internal_ip(str(ip)):
+                raise ExtractUrlSecurityError(
+                    f"Extraction URL blocked: {hostname} resolves to private/internal IP {ip}"
+                )
+    return urls
+
+
 def extract_plus(
     urls: List[str],
     provider: str = "auto",
@@ -38,12 +108,13 @@ def extract_plus(
     selected = provider or "auto"
     if not urls:
         return {"provider": selected, "results": [], "error": "No URLs provided", "requested_provider": selected}
-    invalid = [u for u in urls if not (isinstance(u, str) and u.startswith(("http://", "https://")))]
-    if invalid:
+    try:
+        urls = _validate_extract_urls(urls, config)
+    except (ValueError, ExtractUrlSecurityError) as exc:
         return {
             "provider": selected,
             "results": [],
-            "error": f"Invalid URL(s) — must start with http:// or https://: {invalid}",
+            "error": str(exc),
             "requested_provider": selected,
         }
     auto_config = config.get("auto_routing", {})

--- a/tests/test_extract_url_safety.py
+++ b/tests/test_extract_url_safety.py
@@ -1,0 +1,100 @@
+from unittest import mock
+
+import pytest
+
+import extract
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1:8080/admin",
+        "http://LOCALHOST.:8080/admin",
+        "http://localhost:8080/admin",
+        "http://0.0.0.0/admin",
+        "http://10.0.0.5/private",
+        "http://172.16.0.5/private",
+        "http://192.168.1.5/private",
+        "http://100.64.0.1/private",
+        "http://100.100.100.100/private",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://224.0.0.1/private",
+        "http://[::1]/admin",
+        "http://[::ffff:127.0.0.1]/admin",
+        "http://[::ffff:169.254.169.254]/latest/meta-data/",
+        "http://[fe80::1]/admin",
+        "http://[fc00::1]/admin",
+        "http://[fd12:3456:789a::1]/admin",
+        "http://[ff02::1]/multicast",
+        "http://[::]/unspecified",
+        "http://[2001:db8::1]/doc",
+        "https://PUBLIC.example.test@127.0.0.1/admin",
+        "http://2130706433/admin",
+    ],
+)
+def test_extract_urls_reject_private_internal_targets(url):
+    with pytest.raises(extract.ExtractUrlSecurityError):
+        extract._validate_extract_urls([url], config={})
+
+
+def test_extract_urls_reject_hostname_that_resolves_to_private_ip():
+    with mock.patch(
+        "extract.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("192.168.1.20", 443))],
+    ):
+        with pytest.raises(extract.ExtractUrlSecurityError):
+            extract._validate_extract_urls(["https://internal.example.test/page"], config={})
+
+
+def test_extract_urls_reject_hostname_if_any_dns_answer_is_private():
+    with mock.patch(
+        "extract.socket.getaddrinfo",
+        return_value=[
+            (None, None, None, None, ("93.184.216.34", 443)),
+            (None, None, None, None, ("127.0.0.1", 443)),
+        ],
+    ):
+        with pytest.raises(extract.ExtractUrlSecurityError):
+            extract._validate_extract_urls(["https://rebinding.example.test/page"], config={})
+
+
+def test_extract_urls_allow_public_targets():
+    with mock.patch(
+        "extract.socket.getaddrinfo",
+        return_value=[(None, None, None, None, ("93.184.216.34", 443))],
+    ):
+        assert extract._validate_extract_urls(["https://example.com/page"], config={}) == ["https://example.com/page"]
+
+
+def test_extract_private_url_escape_hatch_is_explicit():
+    config = {"extract": {"allow_private_urls": True}}
+    assert extract._validate_extract_urls(["http://127.0.0.1:8080/admin"], config=config) == ["http://127.0.0.1:8080/admin"]
+
+
+def test_extract_plus_rejects_private_url_before_provider_dispatch():
+    with mock.patch("extract.extract_firecrawl") as mock_extract:
+        result = extract.extract_plus(
+            ["http://169.254.169.254/latest/meta-data/"],
+            provider="firecrawl",
+            config={"firecrawl": {"api_key": "fc-test-key"}},
+        )
+
+    mock_extract.assert_not_called()
+    assert result["results"] == []
+    assert "private/internal" in result["error"]
+
+
+def test_local_provider_endpoint_remains_allowed_for_public_target():
+    with mock.patch("extract._validate_extract_urls", return_value=["https://example.com/page"]), \
+         mock.patch("extract.get_api_key", return_value="fc-test-key"), \
+         mock.patch("extract.provider_in_cooldown", return_value=(False, 0)), \
+         mock.patch("extract.reset_provider_health"), \
+         mock.patch("extract.extract_firecrawl", return_value={"provider": "firecrawl", "results": []}) as mock_extract:
+        result = extract.extract_plus(
+            ["https://example.com/page"],
+            provider="firecrawl",
+            config={"firecrawl": {"scrape_url": "http://127.0.0.1:8080/v2/scrape"}},
+        )
+
+    assert result["provider"] == "firecrawl"
+    assert mock_extract.call_args.kwargs["api_url"] == "http://127.0.0.1:8080/v2/scrape"


### PR DESCRIPTION
## Summary
- Add a central safety check for `web_extract_plus` target URLs before provider dispatch.
- Block loopback, RFC1918/private, CGNAT/shared-address ranges, IPv6 ULA/link-local/mapped-private addresses, multicast/unspecified/reserved ranges, metadata hostnames, and hostnames that resolve to private/internal IPs.
- Reject a hostname when any DNS answer points inward, while still allowing normal public targets.
- Keep operator-configured provider endpoints allowed, so local Firecrawl-compatible backends such as GroktoCrawl can still be used.
- Document the explicit trusted-intranet escape hatch: `extract.allow_private_urls: true`.

## Why
`web_extract_plus(urls=...)` accepts user/agent-controlled URLs. Before this patch, the only validation was `http://` / `https://`, so internal targets such as loopback or cloud metadata addresses could be handed to extraction providers. That is especially risky when the configured extraction backend is local/self-hosted.

The new guard applies only to the extraction target URLs, not to operator-controlled provider endpoint config like `firecrawl.scrape_url`.

## Residual scope
This patch validates the initial extraction target before provider dispatch. If a local/self-hosted backend follows redirects itself, post-redirect target re-validation belongs in the provider/fetch layer and should be treated as a follow-up hardening item rather than silently assumed covered here.

## Test Plan
- `python3 /tmp/wsp-pr61-edge-matrix.py`
- `python3 /tmp/wsp-local-ssrf-smoke.py`
- `python3 -m compileall -q .`
- `python3 -m pytest tests/test_extract_url_safety.py -q`
- `python3 -m pytest tests/ -q`
- `ruff check .`
- `git diff --check`

Local result: `319 passed`, `28 passed` in URL-safety tests, local-provider smoke passed, Ruff clean.
