### PR TITLE
feat(setup): add WSP fast-path doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Added
+- Added `setup.py fastpath`, a dependency-free advisory doctor that checks whether Web Search Plus is installed for direct Hermes tool registration and whether current public-Hermes config (`agent.disabled_toolsets: [web]`) is present for lower-latency routing without requiring Hermes core patches.
 - The setup wizard now offers the keyless public tier for keyless providers (currently Keenable): skip the key prompt and it asks whether to enable the no-key public endpoint, writing `<provider>.allow_public: true` to `config.json`. Add `--keyless-public` to skip that confirmation prompt and opt in directly. The mechanism is driven by the registry's keyless flag, so it covers future keyless providers automatically.
 
 ### 🐛 Fixed
@@ -11,6 +12,7 @@
 - Corrected the Querit provider `signup_url` from the dead `querit.com` to `querit.ai`.
 
 ### 📚 Docs
+- Documented the current public-Hermes fast-path config and the new `setup.py fastpath` checker for users who want lower perceived latency without local Hermes core patches.
 - Refreshed the README hero graphic to v2.6.1 (13 search / 7 extract providers, with search+extract dual-capability markings).
 
 ## [v2.6.1] — 2026-06-26

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ python ~/.hermes/plugins/web-search-plus/setup.py setup
 # 4) Optional shell smoke test
 cd ~/.hermes/plugins/web-search-plus
 python3 search.py --query "Hermes Agent latest release" --provider auto --quality-report
+
+# 5) Optional Hermes fast-path check
+python ~/.hermes/plugins/web-search-plus/setup.py fastpath
 ```
 
 Notes:
@@ -64,6 +67,28 @@ Notes:
 - Plugin install clones into `~/.hermes/plugins/web-search-plus`.
 - Keys are written to the active Hermes environment file by the setup helper; they should never be committed to the repo.
 - Python 3.8+ is required. Runtime code is stdlib-only; manual development can still run `python3 -m pip install -r requirements.txt` safely before installing dev tools like `pytest` and `ruff`.
+
+### Fast-path performance setup
+
+Web Search Plus is most reliably routed when Hermes can call `web_search_plus` and `web_extract_plus` as registered plugin tools instead of falling back to legacy web tools. This feature intentionally targets **current public Hermes behavior** and does not require local Hermes core patches.
+
+Recommended current-Hermes config:
+
+```yaml
+agent:
+  disabled_toolsets: [web]
+```
+
+That keeps the old built-in web toolset from competing with Web Search Plus in installations that use WSP as their preferred web layer. It is the only Hermes-side config Web Search Plus recommends here because it exists in current Hermes builds.
+
+Run the dependency-free checker to see whether the local install is likely on the fast path:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py fastpath
+python ~/.hermes/plugins/web-search-plus/setup.py fastpath --json
+```
+
+The checker is advisory. If `agent.disabled_toolsets` is not configured, the plugin still works; Hermes may simply have more tool choices before it settles on WSP. Some forks/local builds may offer extra tool-pinning options, but this feature does not document or require them.
 
 ---
 
@@ -94,6 +119,7 @@ The setup wizard is intentionally nicer than “paste keys and pray”:
 ```bash
 python ~/.hermes/plugins/web-search-plus/setup.py status
 python ~/.hermes/plugins/web-search-plus/setup.py list
+python ~/.hermes/plugins/web-search-plus/setup.py fastpath
 python ~/.hermes/plugins/web-search-plus/setup.py setup
 python ~/.hermes/plugins/web-search-plus/setup.py setup --preset starter --open
 python ~/.hermes/plugins/web-search-plus/setup.py setup you linkup --env-path ~/.hermes/.env

--- a/__init__.py
+++ b/__init__.py
@@ -13,6 +13,7 @@ import importlib.util
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -162,6 +163,163 @@ def _get_plugin_config_path() -> Path:
     if override:
         return Path(override)
     return Path(__file__).parent.parent / "config.json"
+
+
+def _get_hermes_config_path() -> Path:
+    """Return the default Hermes config path inspected by the fast-path doctor."""
+    return Path(os.environ.get("HERMES_CONFIG", Path.home() / ".hermes" / "config.yaml"))
+
+
+def _yamlish_has_list_item(text: str, key: str, item: str) -> bool:
+    """Tiny dependency-free YAML-ish list checker for Hermes config hints.
+
+    This intentionally avoids PyYAML because the setup helper is stdlib-only. It
+    handles the two forms users normally write in config.yaml:
+
+    - key: [a, b]
+    - key:
+      - a
+      - b
+    """
+    escaped_key = re.escape(key)
+    escaped_item = re.escape(item)
+    inline = re.search(rf"(?m)^\s*{escaped_key}\s*:\s*\[[^\]]*\b{escaped_item}\b", text)
+    if inline:
+        return True
+
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        match = re.match(rf"^(\s*){escaped_key}\s*:\s*$", line)
+        if not match:
+            continue
+        base_indent = len(match.group(1))
+        for child in lines[idx + 1:]:
+            if not child.strip() or child.lstrip().startswith("#"):
+                continue
+            indent = len(child) - len(child.lstrip())
+            is_list_item = child.lstrip().startswith("-")
+            if indent < base_indent or (indent == base_indent and not is_list_item):
+                break
+            if re.match(rf"^\s*-\s*{escaped_item}\s*(?:#.*)?$", child):
+                return True
+    return False
+
+
+def _yamlish_nested_list_item(text: str, parent: str, key: str, item: str) -> bool:
+    """Best-effort check for parent.key containing item in simple YAML config."""
+    escaped_parent = re.escape(parent)
+    escaped_key = re.escape(key)
+    escaped_item = re.escape(item)
+    lines = text.splitlines()
+    for idx, line in enumerate(lines):
+        match = re.match(rf"^(\s*){escaped_parent}\s*:\s*$", line)
+        if not match:
+            continue
+        parent_indent = len(match.group(1))
+        block: List[str] = []
+        for child in lines[idx + 1:]:
+            if not child.strip() or child.lstrip().startswith("#"):
+                block.append(child)
+                continue
+            indent = len(child) - len(child.lstrip())
+            if indent <= parent_indent:
+                break
+            block.append(child[parent_indent + 1:] if len(child) > parent_indent else child)
+        block_text = "\n".join(block)
+        if _yamlish_has_list_item(block_text, key, item):
+            return True
+        if re.search(rf"(?m)^\s*{escaped_key}\s*:\s*\[[^\]]*\b{escaped_item}\b", block_text):
+            return True
+    return False
+
+
+def _build_fastpath_report(config_path: Optional[Path] = None) -> Dict[str, Any]:
+    """Inspect local plugin/Hermes hints that affect perceived WSP latency."""
+    config_path = config_path or _get_hermes_config_path()
+    plugin_yaml = Path(__file__).resolve().parent / "plugin.yaml"
+    setup_script = Path(__file__).resolve().parent / "setup.py"
+    checks: List[Dict[str, Any]] = []
+
+    plugin_text = ""
+    try:
+        plugin_text = plugin_yaml.read_text()
+    except OSError:
+        pass
+    checks.append({
+        "id": "plugin_tools_declared",
+        "ok": all(name in plugin_text for name in ["provides_tools", "web_search_plus", "web_extract_plus"]),
+        "detail": "plugin.yaml declares both WSP tools for direct Hermes registration",
+    })
+    checks.append({
+        "id": "standalone_setup_available",
+        "ok": setup_script.exists(),
+        "detail": "setup.py works without unreleased Hermes core plugin-CLI support",
+    })
+
+    config_text = ""
+    config_exists = config_path.exists()
+    if config_exists:
+        try:
+            config_text = config_path.read_text()
+        except OSError:
+            config_text = ""
+    legacy_web_disabled = _yamlish_nested_list_item(config_text, "agent", "disabled_toolsets", "web")
+
+    checks.extend([
+        {
+            "id": "hermes_config_found",
+            "ok": config_exists,
+            "detail": f"Hermes config inspected at {config_path}",
+        },
+        {
+            "id": "legacy_web_toolset_disabled",
+            "ok": legacy_web_disabled,
+            "detail": "agent.disabled_toolsets includes web, reducing legacy web-tool ambiguity on current Hermes builds",
+            "recommendation": "On current public Hermes builds, set agent.disabled_toolsets: [web] when you want Web Search Plus to be the preferred web path.",
+        },
+    ])
+    ok = all(check["ok"] for check in checks if check["id"] in {"plugin_tools_declared", "standalone_setup_available"})
+    preferred = ok and legacy_web_disabled
+    return {
+        "ok": ok,
+        "preferred_web_path_configured": preferred,
+        "hermes_config": str(config_path),
+        "checks": checks,
+        "recommended_hermes_config": {
+            "agent.disabled_toolsets": ["web"],
+        },
+        "notes": [
+            "Current public Hermes builds can register plugin tools directly, but may still route large tool catalogs through Tool Search when enabled.",
+            "Provider latency still depends on keys, cache, provider health, and whether the agent chooses normal search or research/extract mode.",
+            "No local Hermes core patches are required; this doctor only recommends config that exists in current Hermes.",
+        ],
+    }
+
+
+def _render_fastpath_report(report: Mapping[str, Any]) -> str:
+    lines = [
+        "Web Search Plus Fast-Path Doctor",
+        f"Status: {'preferred web path configured' if report.get('preferred_web_path_configured') else 'plugin ok; Hermes config can improve routing'}",
+        f"Hermes config: {report.get('hermes_config')}",
+        "",
+        "Checks:",
+    ]
+    for check in report.get("checks", []):
+        marker = "✓" if check.get("ok") else "•"
+        lines.append(f"  {marker} {check.get('id')}: {check.get('detail')}")
+        if not check.get("ok") and check.get("recommendation"):
+            lines.append(f"    Tip: {check.get('recommendation')}")
+    lines.extend([
+        "",
+        "Recommended Hermes config for current public Hermes builds:",
+        "  agent:",
+        "    disabled_toolsets: [web]",
+        "",
+        "Note: this plugin does not require local Hermes core patches. If your Hermes build",
+        "supports additional tool-pinning options, those may further reduce routing latency,",
+        "but they are not required for this doctor or the plugin to work.",
+    ])
+    return "\n".join(lines)
 
 
 def _keyless_public_opted_in(provider: str, config_path: Optional[Path] = None) -> bool:
@@ -612,6 +770,10 @@ def _web_search_plus_cli_setup(parser: argparse.ArgumentParser) -> None:
     list_cmd = subs.add_parser("list", help="List supported providers, capabilities, and signup URLs")
     list_cmd.add_argument("--json", action="store_true", help="Print provider catalog as JSON")
 
+    fastpath = subs.add_parser("fastpath", help="Inspect WSP setup and Hermes config hints for low-latency tool routing")
+    fastpath.add_argument("--json", action="store_true", help="Print fast-path report as JSON")
+    fastpath.add_argument("--config-path", help="Hermes config.yaml path to inspect")
+
     config_cmd = subs.add_parser("config", help="Inspect or change routing preferences")
     config_subs = config_cmd.add_subparsers(dest="config_command")
     show = config_subs.add_parser("show", help="Show routing config")
@@ -755,6 +917,15 @@ def _web_search_plus_cli_command(args: Any) -> None:
     command = getattr(args, "web_search_plus_command", None) or "status"
     if command == "list":
         print(_render_provider_catalog(json_output=getattr(args, "json", False)))
+        return
+
+    if command == "fastpath":
+        config_arg = getattr(args, "config_path", None)
+        report = _build_fastpath_report(Path(config_arg) if config_arg else None)
+        if getattr(args, "json", False):
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(_render_fastpath_report(report))
         return
 
     if command == "config":

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -40,6 +40,22 @@ cd ~/.hermes/plugins/web-search-plus
 python3 search.py --query "Hermes Agent latest release" --provider auto --quality-report --compact
 ```
 
+Inspect whether the install is likely to hit the low-latency Hermes fast path:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py fastpath
+python ~/.hermes/plugins/web-search-plus/setup.py fastpath --json
+```
+
+The fast-path checker is intentionally advisory and stdlib-only. It verifies that the plugin declares both tools for direct registration, that the standalone setup helper is available, and whether your Hermes `config.yaml` contains the current public-Hermes hint below. It does not require Hermes core patches.
+
+```yaml
+agent:
+  disabled_toolsets: [web]
+```
+
+Use this when Web Search Plus should be the preferred web layer. Without it, Web Search Plus still works; Hermes may simply have more web-capable tools to choose from. Some forks/local builds may expose additional tool-pinning config, but this guide only documents options available in current public Hermes.
+
 ## Provider setup
 
 Keys live in the active Hermes environment file, normally `~/.hermes/.env`. The setup helper preserves existing entries and does not print secret values.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -26,6 +26,7 @@ provides_hooks:
 onboarding:
   setup_command: "python ~/.hermes/plugins/web-search-plus/setup.py setup"
   status_command: "python ~/.hermes/plugins/web-search-plus/setup.py status"
+  fastpath_status_command: "python ~/.hermes/plugins/web-search-plus/setup.py fastpath"
   routing_status_command: "python ~/.hermes/plugins/web-search-plus/setup.py config show"
   routing_config_commands:
     fixed_provider: "python ~/.hermes/plugins/web-search-plus/setup.py config set-default you"
@@ -37,7 +38,7 @@ onboarding:
     reset: "python ~/.hermes/plugins/web-search-plus/setup.py config reset --yes"
   config_file: "~/.hermes/plugins/config.json"
   env_override: "WEB_SEARCH_PLUS_CONFIG"
-  note: "No single provider key is globally required. Add at least one search-capable provider for web_search_plus; add Linkup or another extraction-capable provider for web_extract_plus. Setup keys live in .env; routing preferences live in config.json and can choose fixed-provider mode or tuned auto-routing without relying on unreleased Hermes core plugin-CLI support."
+  note: "No single provider key is globally required. Add at least one search-capable provider for web_search_plus; add Linkup or another extraction-capable provider for web_extract_plus. Setup keys live in .env; routing preferences live in config.json and can choose fixed-provider mode or tuned auto-routing without relying on unreleased Hermes core plugin-CLI support. Use setup.py fastpath to inspect advisory Hermes config hints for lower-latency direct tool routing."
   recommended_env:
     - name: YOU_API_KEY
       description: "You.com — fast Routing v2 core provider"

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -824,3 +824,73 @@ def test_routing_rewrite_preserves_non_routing_provider_sections(tmp_path):
     assert data["searxng"] == {"instance_url": "https://x"}
     assert data["auto_routing"]["provider_priority"][:2] == ["keenable", "brave"]
     assert not list(tmp_path.glob("config.json.broken-*"))
+
+
+def test_fastpath_report_detects_recommended_hermes_config(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "agent:\n"
+        "  disabled_toolsets: [web]\n"
+    )
+
+    report = wsp._build_fastpath_report(config_path)
+
+    assert report["ok"] is True
+    assert report["preferred_web_path_configured"] is True
+    checks = {check["id"]: check for check in report["checks"]}
+    assert checks["plugin_tools_declared"]["ok"] is True
+    assert checks["legacy_web_toolset_disabled"]["ok"] is True
+
+
+def test_fastpath_report_requires_disabled_toolsets_under_agent(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        "other:\n"
+        "  disabled_toolsets: [web]\n"
+    )
+
+    report = wsp._build_fastpath_report(config_path)
+
+    assert report["preferred_web_path_configured"] is False
+    checks = {check["id"]: check for check in report["checks"]}
+    assert checks["legacy_web_toolset_disabled"]["ok"] is False
+
+
+def test_fastpath_report_is_advisory_when_hermes_config_lacks_hints(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("agent:\n  disabled_toolsets: []\n")
+
+    report = wsp._build_fastpath_report(config_path)
+
+    assert report["ok"] is True
+    assert report["preferred_web_path_configured"] is False
+    checks = {check["id"]: check for check in report["checks"]}
+    assert checks["legacy_web_toolset_disabled"]["ok"] is False
+    assert "agent.disabled_toolsets" in checks["legacy_web_toolset_disabled"]["recommendation"]
+
+
+def test_fastpath_cli_outputs_json_without_core_patch_dependency(tmp_path, capsys):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("agent:\n  disabled_toolsets: [web]\n")
+    parser = wsp.argparse.ArgumentParser()
+    wsp._web_search_plus_cli_setup(parser)
+    args = parser.parse_args(["fastpath", "--json", "--config-path", str(config_path)])
+
+    args.func(args)
+
+    data = json.loads(capsys.readouterr().out)
+    assert data["ok"] is True
+    assert data["recommended_hermes_config"] == {"agent.disabled_toolsets": ["web"]}
+    assert "never_defer" not in json.dumps(data)
+
+
+def test_fastpath_report_handles_missing_hermes_config(tmp_path):
+    config_path = tmp_path / "missing-config.yaml"
+
+    report = wsp._build_fastpath_report(config_path)
+
+    assert report["ok"] is True
+    assert report["preferred_web_path_configured"] is False
+    checks = {check["id"]: check for check in report["checks"]}
+    assert checks["hermes_config_found"]["ok"] is False
+    assert checks["legacy_web_toolset_disabled"]["ok"] is False


### PR DESCRIPTION
## Summary
- add `setup.py fastpath`, a dependency-free advisory doctor for Web Search Plus routing setup
- document the current public-Hermes config hint `agent.disabled_toolsets: [web]`
- expose the fast-path checker in `plugin.yaml` onboarding metadata
- cover inline/block YAML config detection and advisory missing-hint behavior with tests

## What “fast path” means here
This does **not** patch Hermes core and does **not** claim provider latency magic. It checks whether WSP is installed as directly registered plugin tools and whether the old built-in `web` toolset is disabled when WSP should be the preferred web layer. That reduces tool ambiguity before Hermes chooses `web_search_plus` / `web_extract_plus`.

## Verification
- `python3 -m compileall -q .`
- `python3 -m pytest tests/test_onboarding.py tests/test_provider_registry.py tests/test_doctor_command.py -q` → 70 passed
- `python3 -m pytest tests/ -q` → 324 passed
- `ruff check .`
- `git diff --check`
- `python3 setup.py fastpath`
- `python3 setup.py fastpath --json | python3 -m json.tool`
- `setup.py fastpath --config-path` smoke with inline list, block list, and missing hint
- changed-file secret scan: README examples/test fixtures only; no real secrets
