### PR TITLE
Avoid cooldowns for provider config errors

### DIFF
--- a/search.py
+++ b/search.py
@@ -1410,6 +1410,15 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
             # Only continue collecting from lower-priority providers when fallback was needed.
             if not errors:
                 break
+        except ProviderConfigError as e:
+            # Missing/invalid local credentials are configuration errors, not
+            # provider health failures. Do not poison shared cooldown state for
+            # a provider the runtime never actually contacted.
+            errors.append({
+                "provider": current_provider,
+                "error": str(e),
+            })
+            continue
         except Exception as e:
             error_msg = str(e)
             cooldown_info = mark_provider_failure(current_provider, error_msg, retry_after=getattr(e, "retry_after", None))

--- a/tests/test_keenable_provider.py
+++ b/tests/test_keenable_provider.py
@@ -180,6 +180,12 @@ class KeenablePublicWarningTests(unittest.TestCase):
 
 
 class KeenableExtractTests(unittest.TestCase):
+    def setUp(self):
+        search.reset_provider_health("keenable")
+
+    def tearDown(self):
+        search.reset_provider_health("keenable")
+
     def test_keyless_fetches_via_public_endpoint(self):
         fake_response = {"url": "https://example.com", "title": "Example", "content": "# Page\nbody"}
         with mock.patch("search.make_get_request", return_value=fake_response) as mock_get:
@@ -234,6 +240,15 @@ class KeenableExtractTests(unittest.TestCase):
         self.assertEqual(result["provider"], "keenable")
         self.assertEqual(result["results"][0]["content"], "keenable body")
         self.assertEqual(result["routing"]["provider"], "keenable")
+
+    def test_explicit_search_missing_key_does_not_cooldown_keenable(self):
+        """Config errors should not poison provider health for later keyless extract tests."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            result = search.run_search_request(query="config smoke", provider="keenable", config={})
+
+        self.assertEqual(result["provider"], "keenable")
+        self.assertEqual(result["error"], "All providers failed")
+        self.assertEqual(search.provider_in_cooldown("keenable"), (False, 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Treat missing/invalid provider credentials as config errors, not provider health failures
- Keep Keenable extraction tests isolated from persistent provider-health cooldown state
- Add regression coverage proving explicit Keenable search without a key does not poison later keyless extraction

## Why
A live benchmark that explicitly called Keenable without a key wrote a cooldown into provider_health.json. That leaked into the Keenable keyless extraction unit test and made the suite flaky. Cooldown should represent transient provider/network/rate-limit health, not local config state.

## Verification
- python3 -m pytest tests/test_keenable_provider.py tests/test_provider_health.py -q
- python3 -m compileall -q .
- git diff --check
- python3 -m pytest tests/ -q
- ruff check .
- grep -RInE "API_KEY=|SECRET|tail8a9ea9|/root/\.hermes" -- search.py tests/test_keenable_provider.py || true

Andy gate: PASS for combined test isolation + config-error/no-cooldown production fix.