### PR TITLE
feat(web_extract_plus): truncate and store large extracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### ✨ Added
+- `web_extract_plus` now uses truncate-and-store output handling for large extracted pages: short pages are returned in full, while long pages return a head/tail window plus a page-on-demand footer pointing to the full cleaned text stored under `cache/web`. Configure the inline budget with `web.extract_char_limit` (default `15000`).
+
+### 🔧 Improved
+- Inline base64 image data in extracted Markdown is replaced with `[IMAGE: alt]` placeholders before measuring/storing content, preventing data-URI token bombs while preserving normal `http(s)` image links.
+
 ## [v2.7.0] — 2026-06-30
 
 ### Credits

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Auto extraction currently tries Tavily, then Exa, Linkup, Parallel, Firecrawl, a
 
 Large extracted pages use **truncate-and-store** output handling instead of dumping the full provider markdown into the agent context. By default, each result returns up to `web.extract_char_limit` cleaned characters (`15000`) as a head/tail preview. The full cleaned text is stored under `cache/web/<sha256-url>.md`, and the footer includes a concrete `read_file(path=..., offset=..., limit=500)` call so the agent can page into the omitted middle on demand. Inline base64 image data is replaced with `[IMAGE: alt]`; normal `http(s)` image links are preserved.
 
+The full-text store is local plaintext cache data. It can contain the complete cleaned contents of URLs you extracted, grows until you clear it, and has no automatic TTL or total-size eviction yet. Monitor it with `python3 search.py --cache-stats` and purge it with `python3 search.py --clear-cache`; normal provider-health state is preserved. If you do not want extracted pages retained, clear the cache after extraction-heavy sessions or point `WSP_CACHE_DIR` at a disposable directory.
+
 ```json
 {
   "web": {

--- a/README.md
+++ b/README.md
@@ -262,6 +262,16 @@ web_extract_plus(urls=["https://docs.linkup.so"], provider="linkup", render_js=F
 
 Auto extraction currently tries Tavily, then Exa, Linkup, Parallel, Firecrawl, and You.com when keys are available, then Keenable as the last resort **only if it is configured** (a `KEENABLE_API_KEY`, or the opted-in keyless public endpoint). Tavily is the fast reliable default; Exa is the fast docs/academic backup; Linkup stays the clean long-form/RAG fallback; Parallel is the excerpt-heavy LLM-ready backup; Firecrawl remains the robust scraper safety net; You.com is a fallback; Keenable is the lowest-priority fallback. The keyless public tier is off by default — see [Keenable keyless public access](#keenable-keyless-public-access) — so `web_extract_plus` is available only when at least one extraction provider is configured.
 
+Large extracted pages use **truncate-and-store** output handling instead of dumping the full provider markdown into the agent context. By default, each result returns up to `web.extract_char_limit` cleaned characters (`15000`) as a head/tail preview. The full cleaned text is stored under `cache/web/<sha256-url>.md`, and the footer includes a concrete `read_file(path=..., offset=..., limit=500)` call so the agent can page into the omitted middle on demand. Inline base64 image data is replaced with `[IMAGE: alt]`; normal `http(s)` image links are preserved.
+
+```json
+{
+  "web": {
+    "extract_char_limit": 15000
+  }
+}
+```
+
 Parameters:
 
 | Parameter | Type | Default | Description |

--- a/__init__.py
+++ b/__init__.py
@@ -1488,6 +1488,7 @@ def _format_extract_results(data: dict) -> str:
         return f"Extract error: {data['error']}"
     provider = data.get("provider", "unknown")
     lines = [f"[Provider: {provider}]"]
+    limit = _extract_char_limit()
     for i, r in enumerate(data.get("results", []), 1):
         title = r.get("title") or "No title"
         url = r.get("url", "")
@@ -1498,7 +1499,7 @@ def _format_extract_results(data: dict) -> str:
         if r.get("error"):
             lines.append(f"Error: {r['error']}")
         elif content:
-            lines.append(_format_truncated_extract_content(content, url, _extract_char_limit()))
+            lines.append(_format_truncated_extract_content(content, url, limit))
     return "\n".join(lines).strip()
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -38,6 +38,8 @@ try:  # Package load path used by Hermes plugin discovery.
         plugin_catalog,
     )
     from .env_loader import clean_env_value as _shared_clean_env_value, get_hermes_env_path, is_truthy, load_env_files
+    from .cache import MAX_STORED_TEXT_CHARS, store_web_text
+    from .config import load_config
 except ImportError:  # Direct script/test imports from the plugin directory.
     from provider_registry import (
         DEFAULT_AUTO_ALLOW,
@@ -51,6 +53,8 @@ except ImportError:  # Direct script/test imports from the plugin directory.
         plugin_catalog,
     )
     from env_loader import clean_env_value as _shared_clean_env_value, get_hermes_env_path, is_truthy, load_env_files
+    from cache import MAX_STORED_TEXT_CHARS, store_web_text
+    from config import load_config
 
 try:
     from .daemon_tasks import DaemonTask
@@ -1402,6 +1406,82 @@ def _format_results(data: dict) -> str:
     return "\n".join(lines).strip()
 
 
+
+
+_BASE64_MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(\s*data:image/[^)]+\)", re.IGNORECASE)
+_BASE64_HTML_IMAGE_RE = re.compile(r"<img\b(?=[^>]*\bsrc=[\"']data:image/)[^>]*(?:\balt=[\"']([^\"']*)[\"'])?[^>]*>", re.IGNORECASE)
+_DEFAULT_EXTRACT_CHAR_LIMIT = 15000
+
+
+def _sanitize_extract_content(content: str) -> str:
+    """Remove inline base64 image bombs while preserving normal http(s) images."""
+    def markdown_repl(match: re.Match[str]) -> str:
+        alt = (match.group(1) or "image").strip() or "image"
+        return f"[IMAGE: {alt}]"
+
+    def html_repl(match: re.Match[str]) -> str:
+        tag = match.group(0)
+        alt_match = re.search(r"\balt=[\"']([^\"']*)[\"']", tag, re.IGNORECASE)
+        alt = (alt_match.group(1) if alt_match else "image").strip() or "image"
+        return f"[IMAGE: {alt}]"
+
+    content = _BASE64_MARKDOWN_IMAGE_RE.sub(markdown_repl, content)
+    content = _BASE64_HTML_IMAGE_RE.sub(html_repl, content)
+    return content
+
+
+def _extract_char_limit() -> int:
+    """Read web.extract_char_limit with a safe default for old configs."""
+    try:
+        config = load_config()
+        limit = int(((config.get("web") or {}).get("extract_char_limit")) or _DEFAULT_EXTRACT_CHAR_LIMIT)
+    except Exception:
+        return _DEFAULT_EXTRACT_CHAR_LIMIT
+    return max(1000, limit)
+
+
+def _split_extract_content(content: str, limit: int) -> tuple[str, str, int, int]:
+    """Return head, tail, omitted-start line, and omitted char count."""
+    head_chars = min(max(1, int(limit * 2 / 3)), max(1, limit - 1))
+    tail_chars = min(max(1, int(limit * 0.2)), max(1, limit - head_chars))
+    if head_chars + tail_chars >= len(content):
+        return content, "", content.count("\n") + 1, 0
+    head = content[:head_chars].rstrip()
+    tail = content[-tail_chars:].lstrip()
+    omitted_start_line = head.count("\n") + 1
+    omitted_chars = max(0, len(content) - len(head) - len(tail))
+    return head, tail, omitted_start_line, omitted_chars
+
+
+def _format_truncated_extract_content(content: str, url: str, limit: int) -> str:
+    """Return inline-safe extract content, storing full text when truncated."""
+    cleaned = _sanitize_extract_content(content)
+    if len(cleaned) <= limit:
+        return cleaned
+
+    store_meta = store_web_text(url or "unknown-url", cleaned, max_chars=MAX_STORED_TEXT_CHARS)
+    head, tail, omitted_start_line, omitted_chars = _split_extract_content(cleaned, limit)
+    footer = [
+        "",
+        "---",
+        f"[Content truncated: original {len(cleaned)} chars; omitted middle {omitted_chars} chars; showing head and tail.]",
+    ]
+    if store_meta.get("stored"):
+        footer.append(f"Full cleaned text stored at: {store_meta['path']}")
+        footer.append(
+            "Page omitted middle with Hermes file tool: "
+            f"read_file(path=\"{store_meta['path']}\", offset={omitted_start_line}, limit=500)"
+        )
+        footer.append("For more of the omitted middle, repeat read_file with the next offset; the stored path contains the cleaned text for page-on-demand.")
+        if store_meta.get("capped"):
+            footer.append(
+                f"Stored file capped at {MAX_STORED_TEXT_CHARS} characters; cleaned text was {store_meta.get('original_chars')} chars."
+            )
+    else:
+        footer.append(f"Full-text store failed for path: {store_meta.get('path')} ({store_meta.get('error', 'unknown error')})")
+    return f"{head}\n\n[... omitted middle; see footer for page-on-demand ...]\n\n{tail}" + "\n" + "\n".join(footer)
+
+
 def _format_extract_results(data: dict) -> str:
     """Format extracted URL content for LLM consumption."""
     if "error" in data and not data.get("results"):
@@ -1418,7 +1498,7 @@ def _format_extract_results(data: dict) -> str:
         if r.get("error"):
             lines.append(f"Error: {r['error']}")
         elif content:
-            lines.append(content)
+            lines.append(_format_truncated_extract_content(content, url, _extract_char_limit()))
     return "\n".join(lines).strip()
 
 

--- a/cache.py
+++ b/cache.py
@@ -15,6 +15,65 @@ DEFAULT_CACHE_TTL = 3600  # 1 hour in seconds
 PROVIDER_HEALTH_FILENAME = "provider_health.json"
 
 
+WEB_TEXT_CACHE_DIRNAME = "web"
+MAX_STORED_TEXT_CHARS = 2_000_000
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Write text through a temp file and atomic replace to avoid torn cache reads."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def _get_web_text_cache_path(url: str) -> Path:
+    """Return the stable full-text cache path for an extracted URL."""
+    key = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    return CACHE_DIR / WEB_TEXT_CACHE_DIRNAME / f"{key}.md"
+
+
+def store_web_text(url: str, text: str, max_chars: int = MAX_STORED_TEXT_CHARS) -> Dict[str, Any]:
+    """Store cleaned extracted text under cache/web and return storage metadata.
+
+    The write is intentionally separate from the search-result JSON cache so
+    cache_clear() does not collide with page-on-demand full-text files.
+    """
+    path = _get_web_text_cache_path(url)
+    original_chars = len(text)
+    capped = original_chars > max_chars
+    stored_text = text[:max_chars] if capped else text
+    if capped:
+        stored_text = stored_text.rstrip() + f"\n\n[TRUNCATED: stored text capped at {max_chars} characters]\n"
+    try:
+        _atomic_write_text(path, stored_text)
+    except IOError as e:
+        print(json.dumps({"web_text_cache_write_error": str(e)}), file=sys.stderr)
+        return {
+            "stored": False,
+            "path": str(path),
+            "capped": capped,
+            "original_chars": original_chars,
+            "stored_chars": len(stored_text),
+            "error": str(e),
+        }
+    return {
+        "stored": True,
+        "path": str(path),
+        "capped": capped,
+        "original_chars": original_chars,
+        "stored_chars": len(stored_text),
+    }
+
+
 def _build_cache_payload(query: str, provider: str, max_results: int, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     """Build normalized payload used for cache key hashing."""
     payload = {

--- a/cache.py
+++ b/cache.py
@@ -41,6 +41,32 @@ def _get_web_text_cache_path(url: str) -> Path:
     return CACHE_DIR / WEB_TEXT_CACHE_DIRNAME / f"{key}.md"
 
 
+def _iter_web_text_cache_files():
+    """Yield stored web full-text files, tolerating a missing web cache dir."""
+    web_dir = CACHE_DIR / WEB_TEXT_CACHE_DIRNAME
+    if not web_dir.exists():
+        return iter(())
+    return web_dir.glob("*.md")
+
+
+def _web_text_cache_stats() -> Dict[str, Any]:
+    """Return count and size stats for page-on-demand full-text files."""
+    entries = []
+    total_size = 0
+    for web_file in _iter_web_text_cache_files():
+        try:
+            total_size += web_file.stat().st_size
+            entries.append(web_file)
+        except IOError:
+            pass
+    return {
+        "web_text_entries": len(entries),
+        "web_text_size_bytes": total_size,
+        "web_text_size_kb": round(total_size / 1024, 2),
+        "web_text_cache_dir": str(CACHE_DIR / WEB_TEXT_CACHE_DIRNAME),
+    }
+
+
 def store_web_text(url: str, text: str, max_chars: int = MAX_STORED_TEXT_CHARS) -> Dict[str, Any]:
     """Store cleaned extracted text under cache/web and return storage metadata.
 
@@ -189,16 +215,28 @@ def cache_put(query: str, provider: str, max_results: int, result: Dict[str, Any
 
 def cache_clear() -> Dict[str, Any]:
     """
-    Clear all cached results.
+    Clear cached search results and page-on-demand full-text files.
+
+    Provider health is intentionally preserved.
 
     Returns:
         Stats about what was cleared
     """
     if not CACHE_DIR.exists():
-        return {"cleared": 0, "message": "Cache directory does not exist"}
+        return {
+            "cleared": 0,
+            "web_text_cleared": 0,
+            "web_text_errors": 0,
+            "size_freed_bytes": 0,
+            "size_freed_kb": 0,
+            "message": "Cache directory does not exist",
+        }
 
     count = 0
     size_freed = 0
+    web_text_count = 0
+    web_text_errors = 0
+    web_text_size_freed = 0
 
     for cache_file in CACHE_DIR.glob("*.json"):
         if cache_file.name == PROVIDER_HEALTH_FILENAME:
@@ -210,11 +248,25 @@ def cache_clear() -> Dict[str, Any]:
         except IOError:
             pass
 
+    for web_file in _iter_web_text_cache_files():
+        try:
+            file_size = web_file.stat().st_size
+            web_file.unlink()
+            web_text_size_freed += file_size
+            web_text_count += 1
+        except IOError:
+            web_text_errors += 1
+
+    total_size_freed = size_freed + web_text_size_freed
     return {
         "cleared": count,
-        "size_freed_bytes": size_freed,
-        "size_freed_kb": round(size_freed / 1024, 2),
-        "message": f"Cleared {count} cached entries"
+        "web_text_cleared": web_text_count,
+        "web_text_errors": web_text_errors,
+        "size_freed_bytes": total_size_freed,
+        "size_freed_kb": round(total_size_freed / 1024, 2),
+        "json_size_freed_bytes": size_freed,
+        "web_text_size_freed_bytes": web_text_size_freed,
+        "message": f"Cleared {count} cached entries and {web_text_count} web text files",
     }
 
 
@@ -230,10 +282,16 @@ def cache_stats() -> Dict[str, Any]:
             "total_entries": 0,
             "total_size_bytes": 0,
             "total_size_kb": 0,
+            "total_size_bytes_including_web": 0,
+            "total_size_kb_including_web": 0,
+            "web_text_entries": 0,
+            "web_text_size_bytes": 0,
+            "web_text_size_kb": 0,
+            "web_text_cache_dir": str(CACHE_DIR / WEB_TEXT_CACHE_DIRNAME),
             "oldest": None,
             "newest": None,
             "cache_dir": str(CACHE_DIR),
-            "exists": False
+            "exists": False,
         }
 
     entries = [p for p in CACHE_DIR.glob("*.json") if p.name != PROVIDER_HEALTH_FILENAME]
@@ -267,10 +325,15 @@ def cache_stats() -> Dict[str, Any]:
         except (json.JSONDecodeError, IOError):
             pass
 
+    web_stats = _web_text_cache_stats()
+    total_with_web = total_size + web_stats["web_text_size_bytes"]
     return {
         "total_entries": len(entries),
         "total_size_bytes": total_size,
         "total_size_kb": round(total_size / 1024, 2),
+        "total_size_bytes_including_web": total_with_web,
+        "total_size_kb_including_web": round(total_with_web / 1024, 2),
+        **web_stats,
         "providers": provider_counts,
         "oldest": {
             "timestamp": oldest_time,
@@ -283,5 +346,5 @@ def cache_stats() -> Dict[str, Any]:
             "query": newest_query
         } if newest_time else None,
         "cache_dir": str(CACHE_DIR),
-        "exists": True
+        "exists": True,
     }

--- a/cache.py
+++ b/cache.py
@@ -49,6 +49,14 @@ def _iter_web_text_cache_files():
     return web_dir.glob("*.md")
 
 
+def _iter_web_text_temp_files():
+    """Yield orphaned atomic-write temp files from the web full-text store."""
+    web_dir = CACHE_DIR / WEB_TEXT_CACHE_DIRNAME
+    if not web_dir.exists():
+        return iter(())
+    return web_dir.glob("*.tmp")
+
+
 def _web_text_cache_stats() -> Dict[str, Any]:
     """Return count and size stats for page-on-demand full-text files."""
     entries = []
@@ -226,9 +234,13 @@ def cache_clear() -> Dict[str, Any]:
         return {
             "cleared": 0,
             "web_text_cleared": 0,
+            "web_text_tmp_cleared": 0,
             "web_text_errors": 0,
             "size_freed_bytes": 0,
             "size_freed_kb": 0,
+            "json_size_freed_bytes": 0,
+            "web_text_size_freed_bytes": 0,
+            "web_text_tmp_size_freed_bytes": 0,
             "message": "Cache directory does not exist",
         }
 
@@ -237,6 +249,8 @@ def cache_clear() -> Dict[str, Any]:
     web_text_count = 0
     web_text_errors = 0
     web_text_size_freed = 0
+    web_text_tmp_count = 0
+    web_text_tmp_size_freed = 0
 
     for cache_file in CACHE_DIR.glob("*.json"):
         if cache_file.name == PROVIDER_HEALTH_FILENAME:
@@ -257,15 +271,26 @@ def cache_clear() -> Dict[str, Any]:
         except IOError:
             web_text_errors += 1
 
-    total_size_freed = size_freed + web_text_size_freed
+    for tmp_file in _iter_web_text_temp_files():
+        try:
+            file_size = tmp_file.stat().st_size
+            tmp_file.unlink()
+            web_text_tmp_size_freed += file_size
+            web_text_tmp_count += 1
+        except IOError:
+            web_text_errors += 1
+
+    total_size_freed = size_freed + web_text_size_freed + web_text_tmp_size_freed
     return {
         "cleared": count,
         "web_text_cleared": web_text_count,
+        "web_text_tmp_cleared": web_text_tmp_count,
         "web_text_errors": web_text_errors,
         "size_freed_bytes": total_size_freed,
         "size_freed_kb": round(total_size_freed / 1024, 2),
         "json_size_freed_bytes": size_freed,
         "web_text_size_freed_bytes": web_text_size_freed,
+        "web_text_tmp_size_freed_bytes": web_text_tmp_size_freed,
         "message": f"Cleared {count} cached entries and {web_text_count} web text files",
     }
 

--- a/config.py
+++ b/config.py
@@ -48,6 +48,11 @@ DEFAULT_CONFIG = {
         "auto_allow": dict(DEFAULT_AUTO_ALLOW),
         "confidence_threshold": 0.3,  # Below this, note low confidence
     },
+    "web": {
+        # Maximum cleaned characters returned inline per extracted result before
+        # truncate-and-store keeps the full text on disk for page-on-demand.
+        "extract_char_limit": 15000,
+    },
     "extract": {
         # Target URLs supplied to extract_plus are blocked when they resolve to
         # private/internal networks. Operators can opt in for trusted intranet use.

--- a/docs/TRUNCATE_AND_STORE_EVAL.md
+++ b/docs/TRUNCATE_AND_STORE_EVAL.md
@@ -1,0 +1,13 @@
+# Truncate-and-store output eval
+
+Local eval for `web_extract_plus` output-layer truncation. This uses a direct fetch of a large public documentation page to isolate formatter behavior; provider fetch logic is intentionally unchanged.
+
+- URL: `https://docs.python.org/3/library/asyncio-task.html`
+- Config: `web.extract_char_limit = 15000`
+- Previous inline output chars: `171862`
+- New inline output chars: `13696`
+- Reduction: `92.0%`
+- Stored full-text chars: `171750`
+- Stored path shape: `<WSP_CACHE_DIR>/web/8648139190e534786d6204dff7161d395d89e1688db509a72c2f161c4389e645.md`
+
+The new output includes a head/tail preview plus a concrete `read_file(path=..., offset=..., limit=500)` footer for page-on-demand access to the omitted middle.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -259,6 +259,18 @@ web_extract_plus(urls=["https://docs.linkup.so"], provider="linkup", render_js=F
 
 Auto extraction currently tries Tavily, Exa, Linkup, Firecrawl, Parallel, and You.com when keys are available. Tavily is the fast reliable default; Exa is the fast docs/academic backup; Linkup stays the clean long-form fallback; Firecrawl remains the robust scraper safety net.
 
+Large extracted pages are not returned as raw token bombs. `web_extract_plus` sanitizes inline base64 images, stores the full cleaned text under `cache/web`, and returns a bounded head/tail preview with a footer containing the stored file path plus an exact `read_file(path=..., offset=..., limit=500)` call for paging into the omitted middle. Configure the inline budget in `config.json`:
+
+```json
+{
+  "web": {
+    "extract_char_limit": 15000
+  }
+}
+```
+
+If the stored full text exceeds 2,000,000 characters, the stored file and footer both mark that cap explicitly.
+
 ## Reliability and cost controls
 
 The plugin is designed to fail visibly rather than invent confidence.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -271,6 +271,8 @@ Large extracted pages are not returned as raw token bombs. `web_extract_plus` sa
 
 If the stored full text exceeds 2,000,000 characters, the stored file and footer both mark that cap explicitly.
 
+The stored full text is local plaintext cache data. It may contain the complete cleaned contents of extracted pages, persists until cleared, and currently has no automatic TTL or total-size eviction. Use `python3 search.py --cache-stats` to inspect `web_text_entries`, `web_text_size_bytes`, and the combined cache size; use `python3 search.py --clear-cache` to remove both normal JSON cache entries and `cache/web/*.md` full-text files while preserving provider-health state. For privacy-sensitive or throwaway extraction runs, set `WSP_CACHE_DIR` to a disposable directory or clear the cache afterward.
+
 ## Reliability and cost controls
 
 The plugin is designed to fail visibly rather than invent confidence.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,92 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import cache
+
+
+class CacheLifecycleTests(unittest.TestCase):
+    def test_cache_stats_counts_json_and_web_text_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            with mock.patch.object(cache, "CACHE_DIR", cache_dir):
+                cache.cache_put("query", "linkup", 3, {"results": ["ok"]})
+                first = cache.store_web_text("https://example.com/one", "alpha")
+                second = cache.store_web_text("https://example.com/two", "bravo!")
+
+                stats = cache.cache_stats()
+                expected_web_bytes = Path(first["path"]).stat().st_size + Path(second["path"]).stat().st_size
+
+        self.assertEqual(stats["total_entries"], 1)
+        self.assertEqual(stats["web_text_entries"], 2)
+        self.assertEqual(stats["web_text_size_bytes"], expected_web_bytes)
+        self.assertEqual(stats["total_size_bytes_including_web"], stats["total_size_bytes"] + expected_web_bytes)
+        self.assertTrue(stats["web_text_cache_dir"].endswith(f"{cache.WEB_TEXT_CACHE_DIRNAME}"))
+
+    def test_cache_clear_removes_json_and_web_text_but_preserves_provider_health(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            with mock.patch.object(cache, "CACHE_DIR", cache_dir):
+                cache.cache_put("query", "linkup", 3, {"results": ["ok"]})
+                first = cache.store_web_text("https://example.com/one", "alpha")
+                second = cache.store_web_text("https://example.com/two", "bravo!")
+                provider_health = cache_dir / cache.PROVIDER_HEALTH_FILENAME
+                provider_health.write_text('{"keep": true}\n', encoding="utf-8")
+
+                result = cache.cache_clear()
+
+                self.assertEqual(result["cleared"], 1)
+                self.assertEqual(result["web_text_cleared"], 2)
+                self.assertEqual(result["web_text_errors"], 0)
+                self.assertGreater(result["size_freed_bytes"], 0)
+                self.assertFalse(Path(first["path"]).exists())
+                self.assertFalse(Path(second["path"]).exists())
+                self.assertEqual(list(cache_dir.glob("*.json")), [provider_health])
+                self.assertTrue(provider_health.exists())
+                self.assertFalse(list((cache_dir / cache.WEB_TEXT_CACHE_DIRNAME).glob("*.md")))
+
+    def test_cache_stats_absent_cache_dir_includes_web_text_zeros(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = Path(tmpdir) / "missing-cache"
+            with mock.patch.object(cache, "CACHE_DIR", missing):
+                stats = cache.cache_stats()
+
+        self.assertFalse(stats["exists"])
+        self.assertEqual(stats["total_entries"], 0)
+        self.assertEqual(stats["web_text_entries"], 0)
+        self.assertEqual(stats["web_text_size_bytes"], 0)
+        self.assertEqual(stats["total_size_bytes_including_web"], 0)
+        self.assertTrue(stats["web_text_cache_dir"].endswith(f"{cache.WEB_TEXT_CACHE_DIRNAME}"))
+
+    def test_missing_web_subdir_stats_and_clear_are_zero(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            with mock.patch.object(cache, "CACHE_DIR", cache_dir):
+                cache_dir.mkdir(exist_ok=True)
+                stats = cache.cache_stats()
+                result = cache.cache_clear()
+
+        self.assertTrue(stats["exists"])
+        self.assertEqual(stats["web_text_entries"], 0)
+        self.assertEqual(stats["web_text_size_bytes"], 0)
+        self.assertEqual(result["web_text_cleared"], 0)
+        self.assertEqual(result["web_text_errors"], 0)
+
+    def test_web_text_stats_ignore_orphan_tmp_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            web_dir = cache_dir / cache.WEB_TEXT_CACHE_DIRNAME
+            web_dir.mkdir(parents=True)
+            (web_dir / "abc.md.tmp").write_text("orphan", encoding="utf-8")
+            with mock.patch.object(cache, "CACHE_DIR", cache_dir):
+                stats = cache.cache_stats()
+                result = cache.cache_clear()
+
+        self.assertEqual(stats["web_text_entries"], 0)
+        self.assertEqual(stats["web_text_size_bytes"], 0)
+        self.assertEqual(result["web_text_cleared"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -73,12 +73,13 @@ class CacheLifecycleTests(unittest.TestCase):
         self.assertEqual(result["web_text_cleared"], 0)
         self.assertEqual(result["web_text_errors"], 0)
 
-    def test_web_text_stats_ignore_orphan_tmp_files(self):
+    def test_web_text_stats_ignore_but_clear_orphan_tmp_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_dir = Path(tmpdir)
             web_dir = cache_dir / cache.WEB_TEXT_CACHE_DIRNAME
             web_dir.mkdir(parents=True)
-            (web_dir / "abc.md.tmp").write_text("orphan", encoding="utf-8")
+            orphan = web_dir / "abc.md.tmp"
+            orphan.write_text("orphan", encoding="utf-8")
             with mock.patch.object(cache, "CACHE_DIR", cache_dir):
                 stats = cache.cache_stats()
                 result = cache.cache_clear()
@@ -86,6 +87,8 @@ class CacheLifecycleTests(unittest.TestCase):
         self.assertEqual(stats["web_text_entries"], 0)
         self.assertEqual(stats["web_text_size_bytes"], 0)
         self.assertEqual(result["web_text_cleared"], 0)
+        self.assertEqual(result["web_text_tmp_cleared"], 1)
+        self.assertFalse(orphan.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_extract_plus.py
+++ b/tests/test_extract_plus.py
@@ -2,10 +2,13 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import search
+import cache
 import __init__ as plugin
 
 
@@ -382,6 +385,83 @@ class ExtractPlusPluginTests(unittest.TestCase):
         self.assertIn("markdown", cmd)
         self.assertIn("--extract-images", cmd)
         self.assertIn("--render-js", cmd)
+
+
+    def test_format_extract_results_short_content_returns_full_without_store(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.object(cache, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": 15000}}):
+                    output = plugin._format_extract_results({
+                        "provider": "linkup",
+                        "results": [{"title": "Short", "url": "https://example.com/short", "content": "short page\nall here"}],
+                    })
+
+            self.assertIn("short page\nall here", output)
+            self.assertNotIn("Content truncated", output)
+            self.assertFalse((Path(tmpdir) / "web").exists())
+
+    def test_format_extract_results_long_content_truncates_stores_and_reports_line_offset(self):
+        lines = [f"line {i:04d} " + ("x" * 90) for i in range(350)]
+        content = "\n".join(lines)
+        limit = 15000
+        expected_head = content[: int(limit * 2 / 3)].rstrip()
+        expected_offset = expected_head.count("\n") + 1
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.object(cache, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": limit}}):
+                    output = plugin._format_extract_results({
+                        "provider": "linkup",
+                        "results": [{"title": "Long", "url": "https://example.com/long", "content": content}],
+                    })
+            stored_files = list((Path(tmpdir) / "web").glob("*.md"))
+            self.assertEqual(len(stored_files), 1)
+            stored = stored_files[0].read_text(encoding="utf-8")
+
+        self.assertIn("Content truncated", output)
+        self.assertIn(str(stored_files[0]), output)
+        self.assertIn(f"offset={expected_offset}", output)
+        self.assertIn("limit=500", output)
+        self.assertIn("[... omitted middle; see footer for page-on-demand ...]", output)
+        self.assertEqual(stored, content)
+        self.assertLess(len(output), len(content))
+
+    def test_format_extract_results_stored_text_cap_sets_marker(self):
+        content = "A" * (cache.MAX_STORED_TEXT_CHARS + 1234)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.object(cache, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": 2000}}):
+                    output = plugin._format_extract_results({
+                        "provider": "linkup",
+                        "results": [{"title": "Huge", "url": "https://example.com/huge", "content": content}],
+                    })
+            stored_files = list((Path(tmpdir) / "web").glob("*.md"))
+            self.assertEqual(len(stored_files), 1)
+            stored = stored_files[0].read_text(encoding="utf-8")
+
+        self.assertIn("Stored file capped at 2000000 characters", output)
+        self.assertIn("[TRUNCATED: stored text capped at 2000000 characters]", stored)
+        self.assertLess(len(stored), len(content) + 100)
+
+    def test_format_extract_results_replaces_base64_images_but_keeps_https_images(self):
+        content = (
+            "Intro\n"
+            "![Tiny](data:image/png;base64," + ("a" * 80) + ")\n"
+            "![Hero](https://example.com/hero.png)\n"
+            "<img alt=\"Inline\" src=\"data:image/jpeg;base64,bbbb\">"
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.object(cache, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": 15000}}):
+                    output = plugin._format_extract_results({
+                        "provider": "linkup",
+                        "results": [{"title": "Images", "url": "https://example.com/images", "content": content}],
+                    })
+
+        self.assertIn("[IMAGE: Tiny]", output)
+        self.assertIn("[IMAGE: Inline]", output)
+        self.assertIn("![Hero](https://example.com/hero.png)", output)
+        self.assertNotIn("data:image", output)
 
     def test_register_exposes_web_extract_plus_tool(self):
         registered = {}

--- a/tests/test_extract_plus.py
+++ b/tests/test_extract_plus.py
@@ -463,6 +463,125 @@ class ExtractPlusPluginTests(unittest.TestCase):
         self.assertIn("![Hero](https://example.com/hero.png)", output)
         self.assertNotIn("data:image", output)
 
+    def test_extract_char_limit_invalid_config_falls_back_and_small_limit_floors(self):
+        with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": "nope"}}):
+            self.assertEqual(plugin._extract_char_limit(), 15000)
+
+        with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": 12}}):
+            self.assertEqual(plugin._extract_char_limit(), 1000)
+
+        with mock.patch.object(plugin, "load_config", side_effect=RuntimeError("bad config")):
+            self.assertEqual(plugin._extract_char_limit(), 15000)
+
+    def test_store_web_text_path_is_deterministic_and_separate_from_json_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.object(cache, "CACHE_DIR", Path(tmpdir)):
+                first = cache.store_web_text("https://example.com/same", "alpha")
+                second = cache.store_web_text("https://example.com/same", "beta")
+                other = cache.store_web_text("https://example.com/other", "gamma")
+
+                self.assertEqual(first["path"], second["path"])
+                self.assertNotEqual(first["path"], other["path"])
+                self.assertIn(f"{os.sep}web{os.sep}", first["path"])
+                self.assertTrue(first["path"].endswith(".md"))
+                self.assertEqual(Path(first["path"]).read_text(encoding="utf-8"), "beta")
+                self.assertFalse(list(Path(tmpdir).glob("*.json")))
+
+    def test_format_extract_results_store_failure_preserves_preview_and_reports_path(self):
+        content = "\n".join(f"line {i} " + ("x" * 80) for i in range(80))
+        with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": 1000}}):
+            with mock.patch.object(plugin, "store_web_text", return_value={
+                "stored": False,
+                "path": "/tmp/unwritable/web/example.md",
+                "capped": False,
+                "original_chars": len(content),
+                "stored_chars": 0,
+                "error": "permission denied",
+            }):
+                output = plugin._format_extract_results({
+                    "provider": "linkup",
+                    "results": [{"title": "Fail", "url": "https://example.com/fail", "content": content}],
+                })
+
+        self.assertIn("Content truncated", output)
+        self.assertIn("Full-text store failed", output)
+        self.assertIn("permission denied", output)
+        self.assertIn("line 0", output)
+
+    def test_format_extract_results_uses_raw_content_when_content_missing(self):
+        content = "raw " * 500
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.object(cache, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": 1000}}):
+                    output = plugin._format_extract_results({
+                        "provider": "firecrawl",
+                        "results": [{"title": "Raw", "url": "https://example.com/raw", "raw_content": content}],
+                    })
+
+        self.assertIn("Raw", output)
+        self.assertIn("Content truncated", output)
+        self.assertIn("read_file(path=", output)
+
+    def test_format_extract_results_multiline_base64_and_html_http_image(self):
+        content = (
+            "before\n"
+            "![Wrapped](data:image/png;base64,aaaa\nbbbb\ncccc)\n"
+            '<img src="https://example.com/ok.jpg" alt="Remote">\n'
+            "after"
+        )
+        with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": 15000}}):
+            output = plugin._format_extract_results({
+                "provider": "linkup",
+                "results": [{"title": "Wrapped", "url": "https://example.com/wrapped", "content": content}],
+            })
+
+        self.assertIn("[IMAGE: Wrapped]", output)
+        self.assertIn('src="https://example.com/ok.jpg"', output)
+        self.assertNotIn("data:image", output)
+
+    def test_format_extract_results_read_file_offset_lands_in_omitted_middle(self):
+        lines = [f"headline {i:03d} " + ("x" * 40) for i in range(140)]
+        content = "\n".join(lines)
+        limit = 1000
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.object(cache, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": limit}}):
+                    output = plugin._format_extract_results({
+                        "provider": "linkup",
+                        "results": [{"title": "Offset", "url": "https://example.com/offset", "content": content}],
+                    })
+                stored_file = next((Path(tmpdir) / "web").glob("*.md"))
+                stored_lines = stored_file.read_text(encoding="utf-8").splitlines()
+
+        expected_head = content[: int(limit * 2 / 3)].rstrip()
+        expected_offset = expected_head.count("\n") + 1
+        self.assertIn(f"offset={expected_offset}", output)
+        self.assertGreaterEqual(expected_offset, 1)
+        self.assertLessEqual(expected_offset, len(stored_lines))
+        first_paged_line = stored_lines[expected_offset - 1]
+        self.assertNotIn(first_paged_line, expected_head.splitlines()[:-1])
+        self.assertIn(first_paged_line, content)
+
+    def test_format_extract_results_two_long_results_store_two_files(self):
+        one = "one\n" * 800
+        two = "two\n" * 800
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with mock.patch.object(cache, "CACHE_DIR", Path(tmpdir)):
+                with mock.patch.object(plugin, "load_config", return_value={"web": {"extract_char_limit": 1000}}):
+                    output = plugin._format_extract_results({
+                        "provider": "linkup",
+                        "results": [
+                            {"title": "One", "url": "https://example.com/one", "content": one},
+                            {"title": "Two", "url": "https://example.com/two", "content": two},
+                        ],
+                    })
+                stored_files = list((Path(tmpdir) / "web").glob("*.md"))
+
+        self.assertEqual(len(stored_files), 2)
+        self.assertEqual(output.count("Content truncated"), 2)
+        self.assertIn("1. One", output)
+        self.assertIn("2. Two", output)
+
     def test_register_exposes_web_extract_plus_tool(self):
         registered = {}
 


### PR DESCRIPTION
## Summary

This PR makes `web_extract_plus` safer and more useful for large pages by replacing full inline token dumps with deterministic truncate-and-store output handling.

Short extracted pages are still returned in full. Large pages return a bounded head/tail preview, while the full cleaned text is stored locally under `cache/web/<sha256-url>.md`. The response includes a concrete Hermes `read_file(path=..., offset=..., limit=500)` footer so the agent can page into the omitted middle on demand.

## What changed

- Add truncate-and-store formatting for large `web_extract_plus` results.
- Keep provider extraction logic untouched; truncation happens only in the output layer.
- Add `web.extract_char_limit` config with safe fallback and floor handling.
- Store full cleaned text in `cache/web` using deterministic SHA-256 URL filenames.
- Emit exact 1-indexed `read_file(...)` offsets for page-on-demand access.
- Replace inline base64 Markdown/HTML images while preserving normal `http(s)` image links.
- Cap stored text per file at 2,000,000 characters with an explicit marker.
- Handle store failures gracefully by returning the preview and reporting the failure.
- Expose full-text cache size and count through `cache_stats()`.
- Clear full-text files through `cache_clear()` while preserving provider health state.
- Clean orphan atomic-write `web/*.tmp` files during cache clear.
- Document plaintext retention, cache growth, manual clearing, and disposable `WSP_CACHE_DIR` use.

## Why this is better

Large URL extraction results used to be able to flood the agent context with huge provider markdown. The usual alternative — LLM summarization — is slower, costs more, and can lose or distort facts.

This approach is deterministic: the agent sees a compact preview, the full text remains locally available, and the omitted middle can be loaded explicitly only when needed. That keeps context pressure down without throwing away source material.

## Cache and privacy behavior

The full-text store is intentionally local plaintext cache data. It can contain the complete cleaned contents of extracted pages and currently persists until cleared. This PR makes that behavior visible and reclaimable:

- `python3 search.py --cache-stats` reports `web_text_entries`, `web_text_size_bytes`, `web_text_cache_dir`, and combined cache size.
- `python3 search.py --clear-cache` removes normal JSON cache entries plus `cache/web/*.md` full-text files.
- `provider_health.json` is preserved during cache clear.
- Privacy-sensitive runs can use a disposable `WSP_CACHE_DIR` or clear the cache afterward.

Automatic total-size/LRU eviction is intentionally left as a follow-up. Manual clear plus visible stats and a 2M-character per-file cap are enough for this first PR; eviction policy should be a separate, focused hardening change.

## Local real-provider soak

- `example.com` via Tavily: 167 chars, not truncated, no full-text store.
- Python asyncio docs via Tavily: 5,584 chars, truncated and stored; footer offset valid.
- PEP 8 via Tavily: 57,552 chars, truncated and stored; footer offset valid.
- Wikipedia HTTP via Linkup: 134,686 chars, truncated and stored; footer offset valid.
- Before clear: 3 web text files, 198,442 bytes.
- After clear: 0 web text files, combined cache size 0; provider health preserved.

## Tests

- [x] `python3 -m compileall -q .`
- [x] `python3 -m pytest tests/ -q` → 341 passed
- [x] `ruff check .`
- [x] `git diff --check`
