### PR TITLE
fix: classify decode errors and Python 3.8/3.9 read timeouts as provider errors

### DIFF
--- a/config.py
+++ b/config.py
@@ -259,7 +259,7 @@ def load_config() -> Dict[str, Any]:
 
     if config_path.exists():
         try:
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 user_config = json.load(f)
                 for key, value in user_config.items():
                     if isinstance(value, dict) and key in config:

--- a/env_loader.py
+++ b/env_loader.py
@@ -78,7 +78,7 @@ def load_env_files(anchor_file: Union[str, Path], environ: Optional[MutableMappi
         if not env_path.exists():
             continue
         loaded.append(env_path)
-        for raw_line in env_path.read_text().splitlines():
+        for raw_line in env_path.read_text(encoding="utf-8").splitlines():
             line = raw_line.strip()
             if not line or line.startswith("#") or "=" not in line:
                 continue

--- a/http_client.py
+++ b/http_client.py
@@ -6,6 +6,7 @@ from email.utils import parsedate_to_datetime
 from http.client import IncompleteRead
 import gzip
 import json
+import socket
 import time
 import zlib
 from urllib.error import HTTPError, URLError
@@ -56,13 +57,25 @@ def _read_response_body(response) -> bytes:
     encoding = _response_header(response, "Content-Encoding").strip().lower()
 
     if encoding in {"gzip", "x-gzip"} or raw.startswith(b"\x1f\x8b"):
-        return gzip.decompress(raw)
+        try:
+            return gzip.decompress(raw)
+        except (OSError, EOFError, zlib.error):
+            raise ProviderRequestError(
+                "Provider sent a corrupted gzip response body. Please retry.",
+                transient=True,
+            )
     if encoding == "deflate":
         try:
             return zlib.decompress(raw)
         except zlib.error:
             # Some servers send raw deflate without the zlib wrapper.
-            return zlib.decompress(raw, -zlib.MAX_WBITS)
+            try:
+                return zlib.decompress(raw, -zlib.MAX_WBITS)
+            except zlib.error:
+                raise ProviderRequestError(
+                    "Provider sent a corrupted deflate response body. Please retry.",
+                    transient=True,
+                )
     if encoding == "br":
         raise ProviderRequestError(
             "Brotli-compressed response received, but web-search-plus does not bundle brotli support. "
@@ -74,7 +87,21 @@ def _read_response_body(response) -> bytes:
 
 def _read_json_response(response) -> dict:
     """Read an urllib response as UTF-8 JSON with Content-Encoding handling."""
-    return json.loads(_read_response_body(response).decode("utf-8"))
+    body = _read_response_body(response)
+    try:
+        text = body.decode("utf-8")
+    except UnicodeDecodeError:
+        raise ProviderRequestError(
+            "Provider sent a non-UTF-8 response body. Please retry.",
+            transient=True,
+        )
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        raise ProviderRequestError(
+            "Provider sent an invalid JSON response. Please retry.",
+            transient=True,
+        )
 
 
 def _friendly_http_error(code: int, error_detail: str) -> str:
@@ -89,7 +116,11 @@ def _friendly_http_error(code: int, error_detail: str) -> str:
 
 
 def _extract_http_error_detail(error: HTTPError) -> str:
-    error_body = _read_response_body(error).decode("utf-8") if error.fp else str(error)
+    try:
+        error_body = _read_response_body(error).decode("utf-8", errors="replace") if error.fp else str(error)
+    except (ProviderRequestError, OSError):
+        # A corrupted error body must not mask the HTTP status we are reporting.
+        return str(error)
     try:
         error_json = json.loads(error_body)
         return error_json.get("error") or error_json.get("message") or error_body
@@ -142,7 +173,7 @@ def make_request(url: str, headers: dict, body: dict, timeout: int = 30) -> dict
         raise
     except URLError as e:
         reason = str(getattr(e, "reason", e))
-        is_timeout = "timed out" in reason.lower()
+        is_timeout = isinstance(getattr(e, "reason", None), socket.timeout) or "timed out" in reason.lower()
         raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
     except IncompleteRead as e:
         partial_len = len(getattr(e, "partial", b"") or b"")
@@ -150,7 +181,9 @@ def make_request(url: str, headers: dict, body: dict, timeout: int = 30) -> dict
             f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
             transient=True,
         )
-    except TimeoutError:
+    except (TimeoutError, socket.timeout):
+        # socket.timeout only becomes a TimeoutError alias in Python 3.10;
+        # catching both keeps read timeouts transient on 3.8/3.9.
         raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)
 
 
@@ -168,7 +201,7 @@ def make_get_request(url: str, headers: dict, timeout: int = 30) -> dict:
         raise
     except URLError as e:
         reason = str(getattr(e, "reason", e))
-        is_timeout = "timed out" in reason.lower()
+        is_timeout = isinstance(getattr(e, "reason", None), socket.timeout) or "timed out" in reason.lower()
         raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
     except IncompleteRead as e:
         partial_len = len(getattr(e, "partial", b"") or b"")
@@ -176,5 +209,7 @@ def make_get_request(url: str, headers: dict, timeout: int = 30) -> dict:
             f"Connection interrupted while reading response ({partial_len} bytes received). Please retry.",
             transient=True,
         )
-    except TimeoutError:
+    except (TimeoutError, socket.timeout):
+        # socket.timeout only becomes a TimeoutError alias in Python 3.10;
+        # catching both keeps read timeouts transient on 3.8/3.9.
         raise ProviderRequestError(f"Request timed out after {timeout}s. Try again or reduce max_results.", transient=True)

--- a/providers.py
+++ b/providers.py
@@ -3,6 +3,7 @@
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 import json
 import re
+import socket
 import sys
 import threading
 import time
@@ -1329,9 +1330,9 @@ def search_you(
         raise ProviderRequestError(f"{friendly_msg} (HTTP {e.code})", status_code=e.code, transient=e.code in TRANSIENT_HTTP_CODES)
     except URLError as e:
         reason = str(getattr(e, "reason", e))
-        is_timeout = "timed out" in reason.lower()
+        is_timeout = isinstance(getattr(e, "reason", None), socket.timeout) or "timed out" in reason.lower()
         raise ProviderRequestError(f"Network error: {reason}. Check your internet connection.", transient=is_timeout)
-    except TimeoutError:
+    except (TimeoutError, socket.timeout):
         raise ProviderRequestError("You.com request timed out after 30s.", transient=True)
 
     # Parse results
@@ -1488,9 +1489,9 @@ def search_searxng(
         raise ProviderRequestError(f"{friendly_msg} (HTTP {e.code})", status_code=e.code, transient=e.code in TRANSIENT_HTTP_CODES)
     except URLError as e:
         reason = str(getattr(e, "reason", e))
-        is_timeout = "timed out" in reason.lower()
+        is_timeout = isinstance(getattr(e, "reason", None), socket.timeout) or "timed out" in reason.lower()
         raise ProviderRequestError(f"Cannot reach SearXNG instance at {instance_url}. Error: {reason}", transient=is_timeout)
-    except TimeoutError:
+    except (TimeoutError, socket.timeout):
         raise ProviderRequestError("SearXNG request timed out after 30s. Check instance health.", transient=True)
 
     # Parse results

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -1,11 +1,12 @@
 import gzip
 import json
+import socket
 import time
 from email.message import Message
 from email.utils import formatdate
 from io import BytesIO
 from unittest import mock
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 import pytest
 
@@ -99,3 +100,71 @@ def test_service_unavailable_error_has_no_retry_after():
     assert error.status_code == 503
     assert error.transient is True
     assert error.retry_after is None
+
+
+def test_socket_timeout_is_classified_transient():
+    # socket.timeout is only a TimeoutError alias on Python 3.10+; a raw
+    # read timeout on 3.8/3.9 must still map to a transient provider error.
+    for func in (
+        lambda: http_client.make_request("https://api.example.com/search", {}, {"q": "test"}),
+        lambda: http_client.make_get_request("https://api.example.com/search", {}),
+    ):
+        with mock.patch("http_client.urlopen", side_effect=socket.timeout("timed out")):
+            with pytest.raises(http_client.ProviderRequestError) as exc_info:
+                func()
+        assert exc_info.value.transient is True
+
+
+def test_urlerror_wrapping_socket_timeout_is_transient():
+    # The reason's str() ("_") does not contain "timed out"; classification
+    # must rely on the exception type, not the message text.
+    with mock.patch("http_client.urlopen", side_effect=URLError(socket.timeout("_"))):
+        with pytest.raises(http_client.ProviderRequestError) as exc_info:
+            http_client.make_request("https://api.example.com/search", {}, {"q": "test"})
+    assert exc_info.value.transient is True
+
+
+def test_invalid_json_response_raises_provider_error():
+    with mock.patch("http_client.urlopen", return_value=FakeResponse(b"<html>bad gateway</html>")):
+        with pytest.raises(http_client.ProviderRequestError) as exc_info:
+            http_client.make_get_request("https://api.example.com/search", {})
+    assert exc_info.value.transient is True
+
+
+def test_non_utf8_response_raises_provider_error():
+    with mock.patch("http_client.urlopen", return_value=FakeResponse(b"\xff\xfe\xfa")):
+        with pytest.raises(http_client.ProviderRequestError) as exc_info:
+            http_client.make_get_request("https://api.example.com/search", {})
+    assert exc_info.value.transient is True
+
+
+def test_corrupt_gzip_response_raises_provider_error():
+    response = FakeResponse(b"\x1f\x8bgarbage", {"Content-Encoding": "gzip"})
+    with mock.patch("http_client.urlopen", return_value=response):
+        with pytest.raises(http_client.ProviderRequestError) as exc_info:
+            http_client.make_get_request("https://api.example.com/search", {})
+    assert exc_info.value.transient is True
+
+
+def test_corrupt_deflate_response_raises_provider_error():
+    response = FakeResponse(b"not-deflate", {"Content-Encoding": "deflate"})
+    with mock.patch("http_client.urlopen", return_value=response):
+        with pytest.raises(http_client.ProviderRequestError) as exc_info:
+            http_client.make_get_request("https://api.example.com/search", {})
+    assert exc_info.value.transient is True
+
+
+def test_http_error_with_corrupt_body_still_reports_status():
+    error = _make_http_error(500, {"Content-Encoding": "gzip"}, body=b"\x1f\x8bgarbage")
+    with mock.patch("http_client.urlopen", side_effect=error):
+        with pytest.raises(http_client.ProviderRequestError) as exc_info:
+            http_client.make_request("https://api.example.com/search", {}, {"q": "test"})
+    assert exc_info.value.status_code == 500
+
+
+def test_http_error_with_non_utf8_body_does_not_crash_detail_extraction():
+    error = _make_http_error(500, body=b"\xff\xfe server exploded")
+    with mock.patch("http_client.urlopen", side_effect=error):
+        with pytest.raises(http_client.ProviderRequestError) as exc_info:
+            http_client.make_request("https://api.example.com/search", {}, {"q": "test"})
+    assert exc_info.value.status_code == 500


### PR DESCRIPTION
## Summary

Fixes three related robustness gaps found during a deep repo review, all in the provider error-classification layer:

1. **Read timeouts were unclassified on Python 3.8/3.9.** `socket.timeout` only became an alias of `TimeoutError` in Python 3.10. On 3.8/3.9 (the README-supported floor, tested in CI) a timeout during `response.read()` escaped `except TimeoutError`, was never marked `transient`, and therefore never hit the documented retry path. Now both `http_client.py` and the You.com/SearXNG GET paths catch `(TimeoutError, socket.timeout)`, and `URLError`-wrapped timeouts are detected by type instead of only by the fragile `"timed out" in str(reason)` match.

2. **Response decode failures bypassed error handling entirely.** A corrupted gzip/deflate body, a non-UTF-8 payload, or invalid JSON escaped as raw `EOFError`/`UnicodeDecodeError`/`JSONDecodeError`, skipping the retry logic and sending the provider into cooldown with a cryptic message. These now raise `ProviderRequestError(transient=True)`.

3. **A corrupt HTTP *error* body could mask the real status.** `_extract_http_error_detail` now decodes with `errors="replace"` and falls back to `str(error)`, so a 500 with a garbled body still reports HTTP 500.

Additionally, `config.json` and `.env` files are now read explicitly as UTF-8 — previously a valid UTF-8 config with non-ASCII content was quarantined as "broken" under non-UTF-8 locales (Windows cp1252, `LC_ALL=C`).

## Tests

- 8 new tests covering socket timeouts (POST/GET), `URLError`-wrapped timeouts, invalid JSON, non-UTF-8 bodies, corrupt gzip/deflate, and corrupt error bodies.
- `python -m pytest tests/ -q` → 333 passed
- `ruff check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)