### PR TITLE
fix: restrict .env/cache permissions and harden CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,17 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/__init__.py
+++ b/__init__.py
@@ -93,7 +93,7 @@ def _read_env_file(path: Path) -> Dict[str, str]:
     values: Dict[str, str] = {}
     if not path.exists():
         return values
-    for line in path.read_text().splitlines():
+    for line in path.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
         if not stripped or stripped.startswith("#") or "=" not in stripped:
             continue
@@ -684,7 +684,7 @@ def _providers_for_preset(preset: str) -> List[Dict[str, Any]]:
 def _upsert_env_values(env_path: Path, values: Mapping[str, str]) -> Dict[str, List[str]]:
     """Insert/update env values in a .env file. Caller owns secret prompting."""
     env_path.parent.mkdir(parents=True, exist_ok=True)
-    existing_lines = env_path.read_text().splitlines() if env_path.exists() else []
+    existing_lines = env_path.read_text(encoding="utf-8").splitlines() if env_path.exists() else []
     keys = set(values)
     seen = set()
     added: List[str] = []
@@ -709,7 +709,14 @@ def _upsert_env_values(env_path: Path, values: Mapping[str, str]) -> Dict[str, L
             output.append(f"{key}={value}")
             added.append(key)
 
-    env_path.write_text("\n".join(output).rstrip() + "\n")
+    # The .env holds plaintext API keys: create it 0600 and re-tighten an
+    # existing file before writing so other local users cannot read secrets.
+    env_path.touch(mode=0o600, exist_ok=True)
+    try:
+        os.chmod(env_path, 0o600)
+    except OSError:
+        pass
+    env_path.write_text("\n".join(output).rstrip() + "\n", encoding="utf-8")
     return {"updated": updated, "added": added}
 
 

--- a/cache.py
+++ b/cache.py
@@ -41,7 +41,9 @@ def _get_cache_path(cache_key: str) -> Path:
 
 def _ensure_cache_dir() -> None:
     """Create cache directory if it doesn't exist."""
-    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    # 0700: cached files carry search queries/results that other local users
+    # have no business listing or reading.
+    CACHE_DIR.mkdir(parents=True, exist_ok=True, mode=0o700)
 
 
 def _atomic_write_json(path: Path, data: Dict[str, Any]) -> None:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 
 PLUGIN_PATH = Path(__file__).resolve().parents[1] / "__init__.py"
@@ -141,6 +144,19 @@ def test_env_upsert_writes_selected_provider_keys_without_leaking_values(tmp_pat
     assert "LINKUP_API_KEY=lk-secret" in written
     assert "EXISTING=1" in written
     assert result == {"updated": ["TAVILY_API_KEY"], "added": ["LINKUP_API_KEY"]}
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions")
+def test_env_upsert_restricts_env_file_permissions(tmp_path):
+    new_env = tmp_path / "new" / ".env"
+    wsp._upsert_env_values(new_env, {"TAVILY_API_KEY": "secret"})
+    assert (new_env.stat().st_mode & 0o777) == 0o600
+
+    existing = tmp_path / ".env"
+    existing.write_text("EXISTING=1\n")
+    existing.chmod(0o644)
+    wsp._upsert_env_values(existing, {"TAVILY_API_KEY": "secret"})
+    assert (existing.stat().st_mode & 0o777) == 0o600
 
 
 def test_on_session_start_hint_is_one_shot_when_unconfigured(tmp_path):


### PR DESCRIPTION
## Summary

Security-hardening follow-ups from a deep repo review:

- **`.env` was written world-readable.** The setup wizard's `_upsert_env_values` used `Path.write_text` with the default umask (typically 0644) for the one file that holds plaintext API keys — everything else sensitive already goes through 0600 `mkstemp`. The `.env` is now created at 0600 and an existing file is re-tightened before new content is written. Reads/writes are also explicitly UTF-8.
- **Cache directory is now created 0700** — cached files carry search queries and results other local users shouldn't be able to list or read (the files themselves were already 0600 via `mkstemp`).
- **CI workflow hardening:** least-privilege `permissions: contents: read` (previously inherited default repo permissions), `timeout-minutes: 10`, and a `concurrency` group with cancel-in-progress.

## Tests

- New test asserting 0600 on both freshly created and pre-existing `.env` files (POSIX-only, skipped elsewhere).
- `python -m pytest tests/ -q` → 326 passed
- `ruff check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)