### PR TITLE
fix: stop look-alike domains from inheriting authority boosts

### DIFF
--- a/quality.py
+++ b/quality.py
@@ -110,7 +110,14 @@ CANONICAL_DOMAIN_RULES: Dict[str, Dict[str, List[str]]] = {
 
 
 def _domain_matches_rule(domain: str, rule: str) -> bool:
-    return domain == rule or domain.endswith(f".{rule}") or domain.startswith(rule)
+    if rule.endswith("."):
+        # Label-prefix rules such as "docs." / "investor." / "ir." match a
+        # leading host label (docs.python.org), never a bare domain (notdocs.com).
+        return domain.startswith(rule)
+    # Exact domain or true subdomain only. A bare startswith would let
+    # look-alike registrations such as openai.com.evil.example inherit
+    # authority boosts (same reasoning as _blocked_domain_matches below).
+    return domain == rule or domain.endswith(f".{rule}")
 
 
 # Known content mirrors and SEO scraper sites that republish Stack Overflow,

--- a/tests/test_routing_v2.py
+++ b/tests/test_routing_v2.py
@@ -191,6 +191,14 @@ def test_domain_rule_does_not_substring_match_middle_of_domain():
     assert search._domain_matches_rule("mirror.com", "ir.") is False
 
 
+def test_domain_rule_rejects_lookalike_registrations():
+    # A look-alike domain must not inherit the boost of the real one.
+    assert search._domain_matches_rule("openai.com.evil.example", "openai.com") is False
+    assert search._domain_matches_rule("github.community-fake.xyz", "github.com") is False
+    assert search._domain_matches_rule("openai.com", "openai.com") is True
+    assert search._domain_matches_rule("platform.openai.com", "openai.com") is True
+
+
 def test_reddit_company_finance_query_is_not_community_query():
     routing = _route("Reddit IPO earnings revenue investor relations")
 


### PR DESCRIPTION
## Summary

`_domain_matches_rule` in `quality.py` matched `domain.startswith(rule)`, so a look-alike registration such as `openai.com.evil.example` or `github.community-fake.xyz` inherited the +10.0 intent-reranker authority boost of the real domain and could outrank the legitimate source. `_blocked_domain_matches` a few lines below already documents and avoids exactly this trap — but only for block/allow lists, not for boosts.

The fix keeps both intended behaviors:

- Rules ending in a dot (`docs.`, `investor.`, `ir.`, `security.`) keep prefix semantics and match a leading host label (`docs.python.org`), never a bare domain (`notdocs.com`).
- All other rules now match only the exact domain or true subdomains, same semantics as `_blocked_domain_matches`.

## Tests

- New test asserting look-alike registrations no longer match while exact domains and true subdomains still do; the existing prefix-rule test (`docs.`, `ir.`) continues to pass unchanged.
- `python -m pytest tests/ -q` → 326 passed
- `ruff check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)