### PR TITLE
docs: add generated provider reference with drift check

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Restart Hermes, or run `/reset` in an existing session, so the updated plugin co
 ## Documentation
 
 - [User Guide](docs/USER_GUIDE.md) — detailed setup, provider tuning, routing, extraction, reliability, and cost controls.
+- [Provider Reference](docs/PROVIDERS.md) — generated per-provider matrix: capabilities, env vars, auto-routing defaults, free tiers, and signup links.
 - [FAQ](docs/FAQ.md) — common setup, SerpBase auto-allow, provider selection, cache, quota, and troubleshooting questions.
 - [Architecture](docs/ARCHITECTURE.md) — plugin boundary, routing engine, auto-allow gate, cache/cooldown state, data flow, and provider-extension notes.
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -1,0 +1,93 @@
+# Provider reference
+
+<!-- Generated file. Do not edit by hand. -->
+
+This reference is generated from `provider_registry.py` and the plugin provider
+catalog; regenerate it with `python scripts/gen_provider_docs.py` after changing provider metadata.
+
+## Provider matrix
+
+| Provider | Search | Extract | Env var | Keyless | Auto routing | Free tier | Signup |
+|---|---:|---:|---|---|---|---|---|
+| Serper | ✅ | — | `SERPER_API_KEY` | — | yes (priority 2) | 2,500 one-time credits | https://serper.dev/api-key |
+| SerpBase | ✅ | — | `SERPBASE_API_KEY` | — | explicit-only (`auto_allow=false`) | 100 free searches, paid packs available | https://www.serpbase.dev |
+| Brave Search | ✅ | — | `BRAVE_API_KEY` | — | explicit-only (`auto_allow=false`) | $5 free monthly credits | https://api.search.brave.com/app/keys |
+| Tavily | ✅ | ✅ | `TAVILY_API_KEY` | — | yes (priority 5) | 1,000 free searches/month | https://tavily.com |
+| Querit | ✅ | — | `QUERIT_API_KEY` | — | explicit-only (`auto_allow=false`) | 1,000 free searches/month | https://www.querit.ai |
+| Linkup | ✅ | ✅ | `LINKUP_API_KEY` | — | yes (priority 6) | €5 free monthly credits (~5,000 standard extracts) | https://www.linkup.so |
+| Exa | ✅ | ✅ | `EXA_API_KEY` | — | yes (priority 3) | 1,000 free searches/month | https://dashboard.exa.ai/api-keys |
+| Firecrawl | ✅ | ✅ | `FIRECRAWL_API_KEY` | — | yes (priority 4) | 500 one-time credits | https://www.firecrawl.dev/app/api-keys |
+| Parallel | ✅ | ✅ | `PARALLEL_API_KEY` | — | explicit-only (`auto_allow=false`) | API key required | https://platform.parallel.ai |
+| Perplexity | ✅ | — | `PERPLEXITY_API_KEY` | — | explicit-only (`auto_allow=false`) | API key required | https://www.perplexity.ai/settings/api |
+| Kilo Code Perplexity bridge | ✅ | — | `KILOCODE_API_KEY` | — | explicit-only (`auto_allow=false`) | Depends on Kilo account | https://kilo.ai |
+| You.com | ✅ | ✅ | `YOU_API_KEY` | — | yes (priority 1) | Limited/API key required | https://api.you.com |
+| SearXNG | ✅ | — | `SEARXNG_INSTANCE_URL` | — | yes (priority 13) | Free if self-hosted | https://docs.searxng.org/admin/installation.html |
+| Keenable | ✅ | ✅ | `KEENABLE_API_KEY` | yes (`KEENABLE_ALLOW_PUBLIC` opt-in) | yes (priority 14) | Keyless public tier; optional key for higher limits | https://keenable.ai |
+
+`priority N` is the provider's position in the default routing priority list.
+Providers marked explicit-only stay out of `provider="auto"` routing and fallback
+until opted in with `setup.py config set-auto-allow <provider> on`.
+
+## Provider notes
+
+### Serper
+
+Google-like SERP results for facts, shopping, local and news queries.
+
+### SerpBase
+
+Cheap Google-like SERP fallback; WSP exposes search only, explicit/fallback-only by default.
+
+### Brave Search
+
+Independent general web index; explicit/guarded by default after Routing v2 reliability testing.
+
+### Tavily
+
+*Recommended starter provider.*
+
+Research/tutorial provider in the Routing v2 default pool.
+
+### Querit
+
+Multilingual and real-time search candidate.
+
+### Linkup
+
+*Recommended starter provider.*
+
+Best starter for cheap clean extraction and citation-grounded retrieval.
+
+### Exa
+
+Semantic discovery, alternatives, docs, academic and long-form discovery.
+
+### Firecrawl
+
+Robust scraping/extraction fallback, especially for JS-heavy pages.
+
+### Parallel
+
+LLM-ready web search and fast URL extraction with long source excerpts.
+
+### Perplexity
+
+Direct answer-style search when configured directly.
+
+### Kilo Code Perplexity bridge
+
+Perplexity-compatible access through Kilo Code when configured.
+
+### You.com
+
+*Recommended starter provider.*
+
+Fast Routing v2 core provider for current, multilingual, and LLM-ready search.
+
+### SearXNG
+
+Self-hosted/privacy-preserving metasearch instance URL.
+
+### Keenable
+
+Independent web index for search and extraction; works keyless, optional key raises rate limits.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -58,7 +58,7 @@ Use this when Web Search Plus should be the preferred web layer. Without it, Web
 
 ## Provider setup
 
-Keys live in the active Hermes environment file, normally `~/.hermes/.env`. The setup helper preserves existing entries and does not print secret values.
+Keys live in the active Hermes environment file, normally `~/.hermes/.env`. The setup helper preserves existing entries and does not print secret values. See the generated [provider reference](PROVIDERS.md) for every provider's capabilities, env var, auto-routing default, free tier, and signup link.
 
 Useful commands:
 

--- a/scripts/gen_provider_docs.py
+++ b/scripts/gen_provider_docs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Generate docs/PROVIDERS.md from the provider registry.
+
+Every provider fact in the output comes from provider_registry.py and the
+plugin onboarding catalog in __init__.py, so the reference cannot drift from
+the single source of truth by hand-editing. Run without arguments to rewrite
+the file; run with --check (used by tests/CI) to exit non-zero on drift.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC_PATH = ROOT / "docs" / "PROVIDERS.md"
+REGENERATE_COMMAND = "python scripts/gen_provider_docs.py"
+
+
+def _load_module(name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load module {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module  # Needed so dataclass annotation lookups resolve.
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_registry_and_catalog() -> Tuple[Any, List[Dict[str, Any]]]:
+    """Load provider_registry.py and the plugin catalog from __init__.py.
+
+    __init__.py is a Hermes plugin, so it is loaded via spec_from_file_location
+    (like tests/test_onboarding.py) instead of a package import. Its fallback
+    `from provider_registry import ...` path needs the plugin root on sys.path.
+    """
+    registry = _load_module("wsp_provider_registry_docgen", ROOT / "provider_registry.py")
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    plugin = _load_module("wsp_plugin_docgen", ROOT / "__init__.py")
+    return registry, plugin._get_provider_catalog()
+
+
+def _capability_mark(supported: bool) -> str:
+    return "✅" if supported else "—"
+
+
+def _keyless_cell(registry: Any, provider: str) -> str:
+    if provider not in registry.KEYLESS_PROVIDER_IDS:
+        return "—"
+    return f"yes (`{registry.keyless_public_env_var(provider)}` opt-in)"
+
+
+def _auto_routing_cell(registry: Any, provider: str, supports_search: bool) -> str:
+    if not supports_search:
+        return "—"
+    if registry.DEFAULT_AUTO_ALLOW.get(provider) is False:
+        return "explicit-only (`auto_allow=false`)"
+    priority = list(registry.DEFAULT_PROVIDER_PRIORITY)
+    if provider in priority:
+        return f"yes (priority {priority.index(provider) + 1})"
+    return "yes"
+
+
+def render_provider_docs() -> str:
+    registry, catalog = _load_registry_and_catalog()
+
+    lines: List[str] = [
+        "# Provider reference",
+        "",
+        "<!-- Generated file. Do not edit by hand. -->",
+        "",
+        "This reference is generated from `provider_registry.py` and the plugin provider",
+        f"catalog; regenerate it with `{REGENERATE_COMMAND}` after changing provider metadata.",
+        "",
+        "## Provider matrix",
+        "",
+        "| Provider | Search | Extract | Env var | Keyless | Auto routing | Free tier | Signup |",
+        "|---|---:|---:|---|---|---|---|---|",
+    ]
+
+    for item in catalog:
+        spec = registry.PROVIDER_SPECS[item["provider"]]
+        lines.append(
+            "| {name} | {search} | {extract} | `{env}` | {keyless} | {auto} | {free_tier} | {signup} |".format(
+                name=item["display_name"],
+                search=_capability_mark(spec.supports_search),
+                extract=_capability_mark(spec.supports_extract),
+                env=item["env"],
+                keyless=_keyless_cell(registry, spec.provider),
+                auto=_auto_routing_cell(registry, spec.provider, spec.supports_search),
+                free_tier=item["free_tier"],
+                signup=item["signup_url"] or "—",
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "`priority N` is the provider's position in the default routing priority list.",
+            "Providers marked explicit-only stay out of `provider=\"auto\"` routing and fallback",
+            "until opted in with `setup.py config set-auto-allow <provider> on`.",
+            "",
+            "## Provider notes",
+        ]
+    )
+
+    for item in catalog:
+        lines.extend(["", f"### {item['display_name']}", ""])
+        if item["recommended"]:
+            lines.extend(["*Recommended starter provider.*", ""])
+        lines.append(item["description"])
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Any = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="gen_provider_docs.py",
+        description="Generate docs/PROVIDERS.md from the provider registry.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 if docs/PROVIDERS.md drifted from the registry instead of rewriting it.",
+    )
+    args = parser.parse_args(argv)
+
+    content = render_provider_docs()
+    relative_doc = DOC_PATH.relative_to(ROOT)
+
+    if args.check:
+        existing = DOC_PATH.read_text(encoding="utf-8") if DOC_PATH.exists() else None
+        if existing != content:
+            print(f"{relative_doc} is out of date with the provider registry.", file=sys.stderr)
+            print(f"Regenerate it with: {REGENERATE_COMMAND}", file=sys.stderr)
+            return 1
+        print(f"{relative_doc} is up to date.")
+        return 0
+
+    DOC_PATH.parent.mkdir(parents=True, exist_ok=True)
+    DOC_PATH.write_text(content, encoding="utf-8")
+    print(f"Wrote {relative_doc}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_provider_docs.py
+++ b/tests/test_provider_docs.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import provider_registry as registry
+
+
+GENERATOR_PATH = Path(__file__).resolve().parents[1] / "scripts" / "gen_provider_docs.py"
+spec = importlib.util.spec_from_file_location("wsp_gen_provider_docs_under_test", GENERATOR_PATH)
+gen = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = gen
+spec.loader.exec_module(gen)
+
+
+def test_provider_docs_have_no_drift_from_registry():
+    assert gen.DOC_PATH.exists(), (
+        f"docs/PROVIDERS.md is missing; generate it with `{gen.REGENERATE_COMMAND}`."
+    )
+    assert gen.DOC_PATH.read_text(encoding="utf-8") == gen.render_provider_docs(), (
+        "docs/PROVIDERS.md drifted from the provider registry; regenerate it with "
+        f"`{gen.REGENERATE_COMMAND}` and commit the result."
+    )
+
+
+def test_provider_docs_cover_every_registered_provider():
+    content = gen.DOC_PATH.read_text(encoding="utf-8")
+
+    assert registry.PROVIDER_SPECS, "provider registry unexpectedly empty"
+    for provider_spec in registry.PROVIDER_SPECS.values():
+        assert provider_spec.display_name in content, provider_spec.provider
+        assert provider_spec.env_var in content, provider_spec.provider
+        assert f"### {provider_spec.display_name}" in content, provider_spec.provider
+        assert provider_spec.description in content, provider_spec.provider


### PR DESCRIPTION
## Summary

Adds an auto-generated provider reference so provider documentation can never drift from the code again (the kind of drift that already exists elsewhere: `ARCHITECTURE.md` lists 13 providers while the registry has 14).

- New `scripts/gen_provider_docs.py` generates `docs/PROVIDERS.md` entirely from `provider_registry.py` and the plugin onboarding catalog — no hand-maintained provider facts in the script or the doc.
- The generated reference contains a 14-provider comparison matrix (search/extract capabilities, env vars, keyless opt-in incl. `KEENABLE_ALLOW_PUBLIC`, default auto-routing participation and priority position, free tiers, signup links) plus per-provider description sections.
- `--check` mode exits 1 on drift with a clear regenerate command; the new `tests/test_provider_docs.py` runs that check in CI without any workflow changes.
- The test also asserts every provider in `PROVIDER_SPECS` appears in the doc, so a newly registered provider cannot be silently missing from the docs.
- Minimal links added in `README.md` (Documentation section) and `docs/USER_GUIDE.md` (Provider setup).

## Tests

- `python -m pytest tests/ -q` → 327 passed
- `ruff check .` → clean
- `python scripts/gen_provider_docs.py --check` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)