### PR TITLE
feat: unified freshness parameter for web_search_plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Parameters:
 | `depth` | string | `"normal"` | Exa only: `normal`, `deep`, `deep-reasoning` |
 | `count` | integer | `5` | Results, 1–20 |
 | `time_range` | string | — | `day`, `week`, `month`, `year` |
+| `freshness` | string | — | Unified recency filter: `day`, `week`, `month`, `year` (case-insensitive). Applied natively by Serper, Brave, Querit, Firecrawl, Keenable, You.com, Perplexity/Kilo Perplexity, and SearXNG; other providers still search and report `freshness.applied=false` in result metadata |
 | `include_domains` | string[] | — | Restrict search to domains |
 | `exclude_domains` | string[] | — | Exclude domains |
 | `quality_report` | boolean | `false` | Include routing diagnostics, provider scores, result counts, authority signals, and extraction recommendation |

--- a/__init__.py
+++ b/__init__.py
@@ -1154,6 +1154,7 @@ def _run_search(
     count: int = 5,
     exa_depth: str = "normal",
     time_range: Optional[str] = None,
+    freshness: Optional[str] = None,
     include_domains: Optional[List[str]] = None,
     exclude_domains: Optional[List[str]] = None,
     mode: str = "normal",
@@ -1174,7 +1175,7 @@ def _run_search(
     if search is None:
         return _run_search_subprocess(
             query=query, provider=provider, count=count, exa_depth=exa_depth,
-            time_range=time_range, include_domains=include_domains,
+            time_range=time_range, freshness=freshness, include_domains=include_domains,
             exclude_domains=exclude_domains, mode=mode, quality_report=quality_report,
             research_time_budget=research_time_budget, language=language, country=country,
             subprocess_timeout=timeout,
@@ -1183,7 +1184,7 @@ def _run_search(
     def call() -> dict:
         return search.run_search_request(
             query=query, provider=provider, count=count, exa_depth=exa_depth,
-            time_range=time_range, include_domains=include_domains,
+            time_range=time_range, freshness=freshness, include_domains=include_domains,
             exclude_domains=exclude_domains, mode=mode, quality_report=quality_report,
             research_time_budget=research_time_budget, language=language, country=country,
         )
@@ -1202,6 +1203,7 @@ def _run_search_subprocess(
     count: int = 5,
     exa_depth: str = "normal",
     time_range: Optional[str] = None,
+    freshness: Optional[str] = None,
     include_domains: Optional[List[str]] = None,
     exclude_domains: Optional[List[str]] = None,
     mode: str = "normal",
@@ -1224,6 +1226,8 @@ def _run_search_subprocess(
         cmd += ["--exa-depth", exa_depth]
     if time_range and time_range != "none":
         cmd += ["--time-range", time_range]
+    if freshness:
+        cmd += ["--freshness", str(freshness)]
     if include_domains:
         cmd += ["--include-domains"] + include_domains
     if exclude_domains:
@@ -1361,6 +1365,21 @@ def _format_results(data: dict) -> str:
     else:
         lines.append(f"[Provider: {provider}{' | cached' if cached else ''}]")
 
+    freshness_meta = (data.get("metadata") or {}).get("freshness")
+    if isinstance(freshness_meta, dict) and freshness_meta.get("requested"):
+        per_provider = freshness_meta.get("providers")
+        if isinstance(per_provider, list):
+            applied = [m.get("provider") for m in per_provider if m.get("applied")]
+            skipped = [m.get("provider") for m in per_provider if not m.get("applied")]
+            detail = "applied by: " + (", ".join(str(p) for p in applied) or "none")
+            if skipped:
+                detail += " | not supported: " + ", ".join(str(p) for p in skipped)
+        elif freshness_meta.get("applied"):
+            detail = "applied"
+        else:
+            detail = f"not applied — {freshness_meta.get('reason', 'unsupported provider')}"
+        lines.append(f"[Freshness: {freshness_meta['requested']} | {detail}]")
+
     if answer:
         lines.append(f"\nAnswer: {answer}\n")
 
@@ -1471,6 +1490,16 @@ def register(ctx: Any) -> None:
                     "enum": ["day", "week", "month", "year"],
                     "description": "Filter results by recency. Optional.",
                 },
+                "freshness": {
+                    "type": "string",
+                    "enum": ["day", "week", "month", "year"],
+                    "description": (
+                        "Unified recency filter (case-insensitive). Applied natively by serper, brave, "
+                        "querit, firecrawl, keenable, you, perplexity, kilo-perplexity, and searxng; "
+                        "providers without recency support (tavily, exa, linkup, parallel, serpbase) still "
+                        "run the search and report freshness.applied=false in result metadata. Optional."
+                    ),
+                },
                 "include_domains": {
                     "type": "array",
                     "items": {"type": "string"},
@@ -1505,7 +1534,8 @@ def register(ctx: Any) -> None:
     }
 
     def handler(args_or_query, provider: str = "auto", count: int = 5, depth: str = "normal",
-                time_range: Optional[str] = None, include_domains: Optional[List[str]] = None,
+                time_range: Optional[str] = None, freshness: Optional[str] = None,
+                include_domains: Optional[List[str]] = None,
                 exclude_domains: Optional[List[str]] = None, mode: str = "normal",
                 quality_report: bool = False, research_time_budget: float = 55.0, **kwargs) -> str:
         # Hermes registry passes the entire input dict as first positional arg
@@ -1515,6 +1545,7 @@ def register(ctx: Any) -> None:
             count = args_or_query.get("count", count)
             depth = args_or_query.get("depth", depth)
             time_range = args_or_query.get("time_range", time_range)
+            freshness = args_or_query.get("freshness", freshness)
             include_domains = args_or_query.get("include_domains", include_domains)
             exclude_domains = args_or_query.get("exclude_domains", exclude_domains)
             mode = args_or_query.get("mode", mode)
@@ -1528,6 +1559,7 @@ def register(ctx: Any) -> None:
             count=count,
             exa_depth=depth,
             time_range=time_range,
+            freshness=freshness,
             include_domains=include_domains,
             exclude_domains=exclude_domains,
             mode=mode,

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -244,6 +244,7 @@ Important parameters:
 - `provider`: `auto`, or a concrete provider such as `you`, `serper`, `exa`, `firecrawl`, `tavily`, `linkup`, `brave`, `perplexity`, `kilo-perplexity`, `searxng`, `serpbase`, or `querit`. Brave, Parallel, Perplexity/Kilo Perplexity, SerpBase, and Querit are available for explicit calls but default to `auto_allow=false`.
 - `count`: result count, from 1 to 20.
 - `time_range`: `day`, `week`, `month`, or `year` where supported.
+- `freshness`: unified recency filter with the values `day`, `week`, `month`, or `year` (case-insensitive; invalid values return a clear error). It is applied natively by Serper, Brave, Querit, Firecrawl, Keenable, You.com, Perplexity/Kilo Perplexity, and SearXNG, each translated into that provider's own format (for example Brave `pw` or Serper `tbs=qdr:w` for `week`). Providers without recency support (Tavily, Exa, Linkup, Parallel, SerpBase) still run the search normally; the result metadata then reports `"freshness": {"requested": "week", "applied": false, "reason": "provider tavily does not support freshness"}` instead of silently dropping the filter. In `mode="research"` the filter is passed to every participating provider and the applied status is reported per provider.
 - `include_domains` / `exclude_domains`: provider-dependent domain filters.
 - `quality_report`: include routing diagnostics, skipped providers, result quality hints, and extraction recommendation.
 - `mode="research"`: query multiple providers and optionally extract selected URLs within a best-effort wall-clock budget.

--- a/providers.py
+++ b/providers.py
@@ -29,6 +29,80 @@ from quality import _title_from_url
 _BATCH_TIMEOUT_GRACE_SECONDS = 5
 
 
+# =============================================================================
+# Unified freshness filter
+# =============================================================================
+
+FRESHNESS_VALUES = ("day", "week", "month", "year")
+
+# Native recency formats per provider, derived from the request bodies the
+# provider functions in this module already send. Providers absent from this
+# table (tavily, exa, linkup, parallel, serpbase) have no relative-recency
+# parameter in their current API calls, so no native value is invented for them.
+PROVIDER_FRESHNESS_FORMATS: Dict[str, Dict[str, str]] = {
+    # search_serper: body["tbs"]
+    "serper": {"day": "qdr:d", "week": "qdr:w", "month": "qdr:m", "year": "qdr:y"},
+    # search_brave: params["freshness"]
+    "brave": {"day": "pd", "week": "pw", "month": "pm", "year": "py"},
+    # search_querit: filters["timeRange"]["date"]
+    "querit": {"day": "d1", "week": "w1", "month": "m1", "year": "y1"},
+    # search_firecrawl: body["tbs"]
+    "firecrawl": {"day": "qdr:d", "week": "qdr:w", "month": "qdr:m", "year": "qdr:y"},
+    # search_keenable: body["published_after"]
+    "keenable": {"day": "1d", "week": "7d", "month": "1mo", "year": "1y"},
+    # search_you: params["freshness"] (native values match the unified ones)
+    "you": {"day": "day", "week": "week", "month": "month", "year": "year"},
+    # search_perplexity: body["search_recency_filter"]
+    "perplexity": {"day": "day", "week": "week", "month": "month", "year": "year"},
+    "kilo-perplexity": {"day": "day", "week": "week", "month": "month", "year": "year"},
+    # search_searxng: params["time_range"]
+    "searxng": {"day": "day", "week": "week", "month": "month", "year": "year"},
+}
+
+
+def normalize_freshness(value: Optional[str]) -> Optional[str]:
+    """Return the canonical lowercase freshness value, or None when unset.
+
+    Raises ValueError for values outside day|week|month|year so callers can
+    surface the standard error dict instead of silently dropping the filter.
+    """
+    if value is None:
+        return None
+    normalized = str(value).strip().lower()
+    if not normalized:
+        return None
+    if normalized not in FRESHNESS_VALUES:
+        raise ValueError(
+            "Invalid freshness value: {!r}. Valid values: {}".format(value, ", ".join(FRESHNESS_VALUES))
+        )
+    return normalized
+
+
+def provider_supports_freshness(provider: str) -> bool:
+    """Return whether a provider's current API call can apply a freshness filter."""
+    return provider in PROVIDER_FRESHNESS_FORMATS
+
+
+def map_freshness_for_provider(provider: str, freshness: Optional[str]) -> Optional[str]:
+    """Translate the unified freshness value into the provider's native format."""
+    if not freshness:
+        return None
+    return PROVIDER_FRESHNESS_FORMATS.get(provider, {}).get(freshness)
+
+
+def freshness_metadata(provider: str, requested: str) -> Dict[str, Any]:
+    """Describe whether a provider applied the requested freshness filter."""
+    native = map_freshness_for_provider(provider, requested)
+    if native is not None:
+        return {"requested": requested, "applied": True, "provider": provider, "native_value": native}
+    return {
+        "requested": requested,
+        "applied": False,
+        "provider": provider,
+        "reason": "provider {} does not support freshness".format(provider),
+    }
+
+
 def search_serper(
     query: str,
     api_key: str,

--- a/search.py
+++ b/search.py
@@ -284,6 +284,27 @@ def _sync_provider_dependencies() -> None:
     _providers.execute_provider_with_retry = execute_provider_with_retry
 
 
+# Unified freshness helpers (re-exported for tests and callers).
+FRESHNESS_VALUES = _providers.FRESHNESS_VALUES
+PROVIDER_FRESHNESS_FORMATS = _providers.PROVIDER_FRESHNESS_FORMATS
+
+
+def normalize_freshness(*args, **kwargs):
+    return _providers.normalize_freshness(*args, **kwargs)
+
+
+def provider_supports_freshness(*args, **kwargs):
+    return _providers.provider_supports_freshness(*args, **kwargs)
+
+
+def map_freshness_for_provider(*args, **kwargs):
+    return _providers.map_freshness_for_provider(*args, **kwargs)
+
+
+def freshness_metadata(*args, **kwargs):
+    return _providers.freshness_metadata(*args, **kwargs)
+
+
 def search_serper(*args, **kwargs):
     _sync_provider_dependencies()
     return _providers.search_serper(*args, **kwargs)
@@ -706,8 +727,19 @@ Full docs: See README.md and SKILL.md
         choices=["search", "news", "images", "videos", "places", "shopping"]
     )
     parser.add_argument(
-        "--time-range", 
+        "--time-range",
         choices=["hour", "day", "week", "month", "year"]
+    )
+    parser.add_argument(
+        "--freshness",
+        type=str.lower,
+        choices=list(_providers.FRESHNESS_VALUES),
+        help=(
+            "Unified recency filter (day, week, month, year; case-insensitive). "
+            "Applied natively where the provider supports it (serper, brave, querit, firecrawl, "
+            "keenable, you, perplexity, kilo-perplexity, searxng); otherwise the search runs "
+            "unfiltered and result metadata reports freshness.applied=false"
+        )
     )
     
     # Tavily-specific
@@ -805,11 +837,6 @@ Full docs: See README.md and SKILL.md
         default=you_config.get("safesearch", "moderate"),
         choices=["off", "moderate", "strict"],
         help="You.com SafeSearch filter"
-    )
-    parser.add_argument(
-        "--freshness",
-        choices=["day", "week", "month", "year"],
-        help="Filter results by recency (You.com/Serper)"
     )
     parser.add_argument(
         "--livecrawl",
@@ -1107,7 +1134,7 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
                 country=args.country,
                 language=args.language,
                 search_type=args.search_type,
-                time_range=args.time_range,
+                time_range=args.time_range or args.freshness,
                 include_images=args.images,
             )
         elif prov == "serpbase":
@@ -1256,7 +1283,7 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
                 categories=args.categories,
                 engines=args.engines,
                 language=args.language,
-                time_range=args.time_range,
+                time_range=args.time_range or args.freshness,
                 safesearch=args.searxng_safesearch,
             )
         elif prov == "keenable":
@@ -1359,6 +1386,13 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
         routing_info["mode"] = "research"
         routing_info["provider"] = "research"
         result["routing"].update(routing_info)
+        if args.freshness:
+            result.setdefault("metadata", {})["freshness"] = {
+                "requested": args.freshness,
+                "providers": [
+                    _providers.freshness_metadata(p, args.freshness) for p in research_providers
+                ],
+            }
         _apply_result_quality_pipeline(result, config, query=args.query or "", include_domains=args.include_domains)
         result["quality_report"] = build_quality_report(
             query=args.query,
@@ -1471,6 +1505,11 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
 
         result["routing"] = routing_info
 
+        if args.freshness:
+            result.setdefault("metadata", {})["freshness"] = _providers.freshness_metadata(
+                successful_provider or provider, args.freshness
+            )
+
         if not cache_hit and not args.no_cache and args.query:
             cache_put(
                 query=args.query,
@@ -1517,6 +1556,7 @@ def run_search_request(
     count: int = 5,
     exa_depth: str = "normal",
     time_range: Optional[str] = None,
+    freshness: Optional[str] = None,
     include_domains: Optional[List[str]] = None,
     exclude_domains: Optional[List[str]] = None,
     mode: str = "normal",
@@ -1534,6 +1574,10 @@ def run_search_request(
     """
     if not query and not (include_domains or exclude_domains):
         return {"error": "query is required", "provider": provider, "query": query, "results": []}
+    try:
+        freshness = _providers.normalize_freshness(freshness)
+    except ValueError as exc:
+        return {"error": str(exc), "provider": provider, "query": query, "results": []}
     config = config or load_config()
     argv: List[str] = [
         "--query", query or "",
@@ -1544,6 +1588,8 @@ def run_search_request(
         argv += ["--exa-depth", exa_depth]
     if time_range and time_range != "none":
         argv += ["--time-range", time_range]
+    if freshness:
+        argv += ["--freshness", freshness]
     if include_domains:
         argv += ["--include-domains", *include_domains]
     if exclude_domains:

--- a/tests/test_freshness.py
+++ b/tests/test_freshness.py
@@ -1,0 +1,259 @@
+"""Unified freshness parameter coverage.
+
+Locks down the day|week|month|year freshness contract: the central mapping
+table matches what each provider function actually sends, invalid values fail
+with the standard error dict, the value is passed down into provider requests,
+and unsupported providers still run while reporting applied=false in metadata.
+"""
+
+import contextlib
+import unittest
+from unittest import mock
+
+import providers
+import search
+
+
+def _canned(provider):
+    return {
+        "provider": provider,
+        "query": "q",
+        "results": [{"url": "https://example.test/a", "title": "A", "snippet": "s"}],
+        "images": [],
+        "answer": "",
+        "metadata": {},
+    }
+
+
+class FreshnessMappingTests(unittest.TestCase):
+    def test_mapping_table_per_provider(self):
+        expected = {
+            "serper": {"day": "qdr:d", "week": "qdr:w", "month": "qdr:m", "year": "qdr:y"},
+            "brave": {"day": "pd", "week": "pw", "month": "pm", "year": "py"},
+            "querit": {"day": "d1", "week": "w1", "month": "m1", "year": "y1"},
+            "firecrawl": {"day": "qdr:d", "week": "qdr:w", "month": "qdr:m", "year": "qdr:y"},
+            "keenable": {"day": "1d", "week": "7d", "month": "1mo", "year": "1y"},
+            "you": {"day": "day", "week": "week", "month": "month", "year": "year"},
+            "perplexity": {"day": "day", "week": "week", "month": "month", "year": "year"},
+            "kilo-perplexity": {"day": "day", "week": "week", "month": "month", "year": "year"},
+            "searxng": {"day": "day", "week": "week", "month": "month", "year": "year"},
+        }
+        self.assertEqual(providers.PROVIDER_FRESHNESS_FORMATS, expected)
+
+    def test_map_freshness_for_provider(self):
+        self.assertEqual(providers.map_freshness_for_provider("brave", "week"), "pw")
+        self.assertEqual(providers.map_freshness_for_provider("serper", "day"), "qdr:d")
+        self.assertIsNone(providers.map_freshness_for_provider("tavily", "week"))
+        self.assertIsNone(providers.map_freshness_for_provider("brave", None))
+
+    def test_unsupported_providers_are_not_in_table(self):
+        for provider in ("tavily", "exa", "linkup", "parallel", "serpbase"):
+            self.assertFalse(providers.provider_supports_freshness(provider), provider)
+
+    def test_table_matches_existing_provider_mappers(self):
+        # The central table must never drift from the maps the provider
+        # functions actually use when building requests.
+        for generic, native in providers.PROVIDER_FRESHNESS_FORMATS["keenable"].items():
+            self.assertEqual(providers._KEENABLE_TIME_RANGE[generic], native)
+        for generic, native in providers.PROVIDER_FRESHNESS_FORMATS["firecrawl"].items():
+            self.assertEqual(providers._map_firecrawl_time_range(generic), native)
+        for generic, native in providers.PROVIDER_FRESHNESS_FORMATS["querit"].items():
+            self.assertEqual(providers._map_querit_time_range(generic), native)
+
+    def test_freshness_metadata_shapes(self):
+        applied = providers.freshness_metadata("brave", "week")
+        self.assertEqual(applied, {
+            "requested": "week",
+            "applied": True,
+            "provider": "brave",
+            "native_value": "pw",
+        })
+        skipped = providers.freshness_metadata("tavily", "week")
+        self.assertEqual(skipped, {
+            "requested": "week",
+            "applied": False,
+            "provider": "tavily",
+            "reason": "provider tavily does not support freshness",
+        })
+
+
+class NormalizeFreshnessTests(unittest.TestCase):
+    def test_valid_values_pass_through(self):
+        for value in providers.FRESHNESS_VALUES:
+            self.assertEqual(providers.normalize_freshness(value), value)
+
+    def test_case_insensitive_and_trimmed(self):
+        self.assertEqual(providers.normalize_freshness("WEEK"), "week")
+        self.assertEqual(providers.normalize_freshness(" Day "), "day")
+
+    def test_unset_values_return_none(self):
+        self.assertIsNone(providers.normalize_freshness(None))
+        self.assertIsNone(providers.normalize_freshness(""))
+        self.assertIsNone(providers.normalize_freshness("   "))
+
+    def test_invalid_value_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            providers.normalize_freshness("fortnight")
+        message = str(ctx.exception)
+        self.assertIn("fortnight", message)
+        self.assertIn("day, week, month, year", message)
+
+
+class FreshnessRequestTests(unittest.TestCase):
+    def test_brave_request_includes_native_freshness(self):
+        captured = {}
+
+        def fake_get(url, headers, timeout=30):
+            captured["url"] = url
+            return {"web": {"results": []}}
+
+        with mock.patch("search.make_get_request", side_effect=fake_get):
+            search.search_brave(query="q", api_key="brave-key", time_range="week")
+
+        self.assertIn("freshness=pw", captured["url"])
+
+    def test_serper_request_includes_tbs(self):
+        captured = {}
+
+        def fake_post(url, headers, body, timeout=30):
+            captured["body"] = body
+            return {"organic": []}
+
+        with mock.patch("search.make_request", side_effect=fake_post):
+            search.search_serper(query="q", api_key="serper-key", time_range="month")
+
+        self.assertEqual(captured["body"]["tbs"], "qdr:m")
+
+    def test_you_request_includes_freshness_param(self):
+        captured = {}
+
+        def fake_urlopen(req, timeout=30):
+            captured["url"] = req.full_url
+
+            class _Resp:
+                def __enter__(self):
+                    return self
+
+                def __exit__(self, *exc):
+                    return False
+
+            return _Resp()
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock.patch("urllib.request.urlopen", side_effect=fake_urlopen))
+            stack.enter_context(mock.patch.object(
+                providers, "_read_json_response",
+                return_value={"results": {"web": [], "news": []}, "metadata": {}},
+            ))
+            search.search_you(query="q", api_key="you-key", freshness="day")
+
+        self.assertIn("freshness=day", captured["url"])
+
+    def test_perplexity_request_includes_recency_filter(self):
+        captured = {}
+
+        def fake_post(url, headers, body, timeout=30):
+            captured["body"] = body
+            return {"choices": [{"message": {"content": "answer"}}], "citations": []}
+
+        with mock.patch("search.make_request", side_effect=fake_post):
+            search.search_perplexity(query="q", api_key="pplx-key", freshness="year")
+
+        self.assertEqual(captured["body"]["search_recency_filter"], "year")
+
+
+class FreshnessPipelineTests(unittest.TestCase):
+    def _isolate(self, stack):
+        # Keep the pipeline off the real cache/cooldown/health files.
+        stack.enter_context(mock.patch.object(search, "provider_in_cooldown", lambda p: (False, 0)))
+        stack.enter_context(mock.patch.object(search, "cache_get", lambda **kw: None))
+        stack.enter_context(mock.patch.object(search, "cache_put", lambda **kw: None))
+        stack.enter_context(mock.patch.object(search, "reset_provider_health", lambda p: None))
+
+    def test_invalid_freshness_returns_error_dict(self):
+        result = search.run_search_request(query="q", provider="serper", freshness="fortnight")
+        self.assertIn("Invalid freshness value", result["error"])
+        self.assertEqual(result["provider"], "serper")
+        self.assertEqual(result["results"], [])
+
+    def test_freshness_reaches_provider_and_metadata_reports_applied(self):
+        with contextlib.ExitStack() as stack:
+            self._isolate(stack)
+            stack.enter_context(mock.patch.dict("os.environ", {"SERPER_API_KEY": "serper-test-key"}))
+            seen = {}
+
+            def fake_serper(**kwargs):
+                seen.update(kwargs)
+                return _canned("serper")
+
+            stack.enter_context(mock.patch.object(search, "search_serper", fake_serper))
+            result = search.run_search_request(query="latest news", provider="serper", freshness="WEEK")
+
+        self.assertEqual(seen["time_range"], "week")
+        self.assertEqual(result["metadata"]["freshness"], {
+            "requested": "week",
+            "applied": True,
+            "provider": "serper",
+            "native_value": "qdr:w",
+        })
+
+    def test_unsupported_provider_still_searches_and_reports_not_applied(self):
+        with contextlib.ExitStack() as stack:
+            self._isolate(stack)
+            stack.enter_context(mock.patch.dict("os.environ", {"TAVILY_API_KEY": "tavily-test-key"}))
+            stack.enter_context(mock.patch.object(search, "search_tavily", lambda **kw: _canned("tavily")))
+            result = search.run_search_request(query="how does https work", provider="tavily", freshness="week")
+
+        self.assertEqual(result["results"][0]["url"], "https://example.test/a")
+        self.assertEqual(result["metadata"]["freshness"], {
+            "requested": "week",
+            "applied": False,
+            "provider": "tavily",
+            "reason": "provider tavily does not support freshness",
+        })
+
+    def test_research_mode_reports_freshness_per_provider(self):
+        with contextlib.ExitStack() as stack:
+            self._isolate(stack)
+            stack.enter_context(mock.patch.dict("os.environ", {
+                "SERPER_API_KEY": "serper-test-key",
+                "TAVILY_API_KEY": "tavily-test-key",
+            }))
+            seen = {}
+
+            def fake_serper(**kwargs):
+                seen.update(kwargs)
+                return _canned("serper")
+
+            stack.enter_context(mock.patch.object(search, "search_serper", fake_serper))
+            stack.enter_context(mock.patch.object(search, "search_tavily", lambda **kw: _canned("tavily")))
+            stack.enter_context(mock.patch.object(
+                search, "extract_plus", lambda **kw: {"provider": None, "results": []},
+            ))
+
+            parser = search.build_parser({})
+            args = parser.parse_args([
+                "--query", "compare turntables",
+                "--provider", "serper",
+                "--mode", "research",
+                "--research-providers", "serper", "tavily",
+                "--freshness", "week",
+            ])
+            payload, exit_code = search.execute_search_request(args, {})
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(seen["time_range"], "week")
+        by_provider = {m["provider"]: m for m in payload["metadata"]["freshness"]["providers"]}
+        self.assertEqual(payload["metadata"]["freshness"]["requested"], "week")
+        self.assertTrue(by_provider["serper"]["applied"])
+        self.assertFalse(by_provider["tavily"]["applied"])
+        self.assertIn("does not support freshness", by_provider["tavily"]["reason"])
+
+    def test_cli_parser_lowercases_freshness(self):
+        parser = search.build_parser({})
+        args = parser.parse_args(["--query", "q", "--freshness", "WEEK"])
+        self.assertEqual(args.freshness, "week")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Freshness/date filtering existed only as scattered provider-specific options. This PR adds one unified, validated `freshness` parameter (`day|week|month|year`, case-insensitive) across the tool schema, CLI, and in-process search path — mapped per provider to its native format.

- New `freshness` property in the `web_search_plus` tool schema, a `--freshness` CLI flag, and `run_search_request(freshness=...)`; invalid values return the standard error dict.
- Central per-provider mapping table in `providers.py` (`PROVIDER_FRESHNESS_FORMATS`, `map_freshness_for_provider()`), derived strictly from existing request code — no guessed API parameters.
- **Nine providers apply it natively:** serper (`tbs=qdr:*`), brave (`freshness=pd/pw/pm/py`), querit (`timeRange`), firecrawl (`tbs=qdr:*`), keenable (`published_after`), you, perplexity + kilo-perplexity (`search_recency_filter`), searxng (`time_range`).
- **Unsupported providers** (tavily, exa, linkup, parallel, serpbase) still run the search and report `freshness: {requested, applied: false, reason}` in result metadata. Exa was deliberately left out — its API only takes absolute start/end dates, no relative recency filter.
- Research mode forwards freshness to all participating providers and records applied status per provider. Routing logic is intentionally untouched.
- Docs updated in `docs/USER_GUIDE.md` and the README tool-parameter table.

## Tests

- 15 new tests: mapping-table drift guards, validation, mocked request pass-through per provider, metadata for unsupported providers, research-mode forwarding.
- `python -m pytest tests/ -q` → 343 passed
- `ruff check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)