### PR TITLE
chore: prepare Web Search Plus v2.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v2.8.0] — 2026-07-02
+
 ### Credits
 - #65 by @robbyczgw-cla — truncate-and-store handling for large `web_extract_plus` pages.
 - #66 by @robbyczgw-cla — provider/decode/read-timeout error classification.

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v2.5.0
+web-search-plus — Hermes Plugin v2.8.0
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "2.7.0"
+__version__ = "2.8.0"
 
 import argparse
 import getpass

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.7.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.8.0"
 
 
 class ProviderRequestError(Exception):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "2.7.0"
+version: "2.8.0"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 2.7.0
+Version: 2.8.0
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable.

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -53,7 +53,7 @@ def test_http_client_provider_request_error_exports_retry_metadata():
 
 
 def test_default_user_agent_uses_release_version():
-    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.7.0"
+    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.8.0"
 
 
 def _make_http_error(code: int, headers=None, body: bytes = b"{}") -> HTTPError:

--- a/tests/test_plugin_package_import.py
+++ b/tests/test_plugin_package_import.py
@@ -35,7 +35,7 @@ def test_plugin_loads_with_hermes_package_style_import():
 
         spec.loader.exec_module(module)
 
-        assert module.__version__ == "2.7.0"
+        assert module.__version__ == "2.8.0"
         assert module._get_provider_catalog()
     finally:
         sys.modules.pop(module_name, None)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "2.7.0"
+EXPECTED_VERSION = "2.8.0"
 
 
 def _load_plugin_module():


### PR DESCRIPTION
## Summary
- Prepare Web Search Plus v2.8.0 release metadata across plugin/version surfaces.
- Move the completed #65–#72 changelog entries from Unreleased into `v2.8.0` with credits.
- Keep this release framed as an operator-quality release: safe large extracts, explicit freshness, provider benchmarking, hardened routing/docs/security.

## Release inventory since v2.7.0
- #65 by @robbyczgw-cla — truncate-and-store handling for large `web_extract_plus` pages.
- #66 by @robbyczgw-cla — provider/decode/read-timeout error classification.
- #67 by @robbyczgw-cla — `.env` and cache permission hardening plus tighter CI workflow defaults.
- #68 by @robbyczgw-cla — look-alike domain boost hardening.
- #69 by @robbyczgw-cla — generated provider reference and drift check.
- #70 by @robbyczgw-cla — generated Routing v2 reference and drift check.
- #71 by @robbyczgw-cla — unified `freshness` parameter for `web_search_plus`.
- #72 by @robbyczgw-cla — provider bench and `provider_priority` recommendation command.

## Local verification
- `python3 scripts/gen_provider_docs.py`
- `python3 scripts/gen_routing_docs.py`
- docs drift check clean for `docs/PROVIDERS.md` and `docs/ROUTING.md`
- `python3 -m compileall -q .`
- `python3 -m pytest tests/ -q` → 383 passed
- `ruff check .`
- `git diff --check`
- public-copy privacy scan clean

## Not included
- No tag created.
- No GitHub Release published.
- No homepage deploy.
