### PR TITLE
feat: add Caesar as a web-search provider

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -38,3 +38,6 @@ FIRECRAWL_API_KEY=***
 
 # SearXNG (self-hosted, no API key needed — just set your instance URL)
 # SEARXNG_INSTANCE_URL=https://your-searxng-instance.example.com
+
+# Caesar (agentic web search) — https://app.trycaesar.com — credit-backed
+CAESAR_API_KEY=

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img alt="Hermes Plugin" src="https://img.shields.io/badge/Hermes-plugin-a78bfa.svg">
 </p>
 
-**Web Search Plus is the operator-grade web layer for Hermes: one search tool, one extraction tool, many providers, conservative routing, safe large-page handling, freshness controls, and provider benchmarking without locking you into a single API.** Routing v2 spans 14 search providers and 8 extraction-capable providers; `web_extract_plus(provider="auto")` defaults to Tavily-first extraction for fast, reliable fetches, with Exa, Linkup, Firecrawl, Parallel, You.com, and Serper as fallback paths when available.
+**Web Search Plus is the operator-grade web layer for Hermes: one search tool, one extraction tool, many providers, conservative routing, safe large-page handling, freshness controls, and provider benchmarking without locking you into a single API.** Routing v2 spans 15 search providers and 8 extraction-capable providers; `web_extract_plus(provider="auto")` defaults to Tavily-first extraction for fast, reliable fetches, with Exa, Linkup, Firecrawl, Parallel, You.com, and Serper as fallback paths when available.
 
 `web-search-plus` adds two Hermes tools:
 
@@ -84,7 +84,7 @@ Notes:
 
 | Capability | Unlocks | Configure at least one of |
 |---|---|---|
-| Search | `web_search_plus` | Brave, Serper, Tavily, Exa, Linkup, Firecrawl, Parallel, Perplexity, Kilo Perplexity, You.com, SearXNG, SerpBase, Querit, or Keenable |
+| Search | `web_search_plus` | Brave, Serper, Tavily, Exa, Linkup, Firecrawl, Parallel, Perplexity, Kilo Perplexity, You.com, SearXNG, SerpBase, Querit, Keenable, or Caesar |
 | Extraction | `web_extract_plus` | Linkup, Firecrawl, Tavily, Exa, Parallel, You.com, Serper, or Keenable |
 | Best starter | Search + extraction + reliable fallback | You.com + Serper + Linkup |
 
@@ -146,6 +146,7 @@ Full parameter tables for both tools, freshness/vertical/locale semantics, and c
 | SerpBase | ✅ | — | Cheap Google-like SERP fallback; guarded by default (`auto_allow=false`) |
 | Parallel | ✅ | ✅ | LLM-ready search and fast extract with long source excerpts; guarded by default (`auto_allow=false`) |
 | Querit | ✅ | — | Multilingual and real-time queries; guarded by default (`auto_allow=false`) |
+| Caesar | ✅ | — | Agentic web search with per-result provenance and capture timestamps |
 
 Routing v2 is benchmarked and class-aware: it detects language/script hints and query classes (news, shopping/local, docs/API, GitHub, academic, community, CVE/security, finance, weather, and more — see the [Routing Reference](docs/ROUTING.md)). Guarded providers are available for explicit `provider=` calls once their key is set; opt them into automatic routing with `setup.py config set-auto-allow <provider> on`.
 
@@ -170,12 +171,17 @@ KEENABLE_API_KEY=***      # https://keenable.ai — search + extraction
 SERPBASE_API_KEY=***      # https://www.serpbase.dev — explicit/fallback-only Google-like SERP search
 PARALLEL_API_KEY=***      # https://platform.parallel.ai — explicit/guarded LLM-ready search + extraction
 QUERIT_API_KEY=***        # https://querit.ai — explicit/fallback-only by default
+CAESAR_API_KEY=***        # https://app.trycaesar.com — agentic web search with per-result provenance
 
 # Kilo gateway alternate provider (`provider="kilo-perplexity"`)
 KILOCODE_API_KEY=***
 ```
 
 Keenable also has an opt-in keyless public tier (off by default, per-IP limits, no SLA) — see [User Guide → Provider setup](docs/USER_GUIDE.md#provider-setup).
+
+### Caesar
+
+[Caesar](https://docs.trycaesar.com) needs a `CAESAR_API_KEY`, sent as a `Bearer` token. Keys are issued at [app.trycaesar.com](https://app.trycaesar.com) and usage is credit-backed. Each result carries provenance (a canonical URL and a capture timestamp), which is what the mapper surfaces as the result `date`. Caesar is search-only (no `web_extract_plus` backend).
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -142,6 +142,11 @@ DEFAULT_CONFIG = {
         "fetch_url": "https://api.keenable.ai/v1/fetch",
         "timeout": 30,
         "allow_public": False
+    },
+    "caesar": {
+        "search_url": "https://alpha.api.trycaesar.com/v1/search",
+        "timeout": 30,
+        "allow_public": False
     }
 }
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -23,6 +23,7 @@ catalog; regenerate it with `python scripts/gen_provider_docs.py` after changing
 | You.com | ✅ | ✅ | `YOU_API_KEY` | — | yes (priority 1) | Limited/API key required | https://api.you.com |
 | SearXNG | ✅ | — | `SEARXNG_INSTANCE_URL` | — | yes (priority 13) | Free if self-hosted | https://docs.searxng.org/admin/installation.html |
 | Keenable | ✅ | ✅ | `KEENABLE_API_KEY` | yes (`KEENABLE_ALLOW_PUBLIC` opt-in) | yes (priority 14) | Keyless public tier; optional key for higher limits | https://keenable.ai |
+| Caesar | ✅ | — | `CAESAR_API_KEY` | — | yes (priority 15) | Credit-backed; new accounts start with a credit grant | https://app.trycaesar.com |
 
 `priority N` is the provider's position in the default routing priority list.
 Providers marked explicit-only stay out of `provider="auto"` routing and fallback
@@ -91,3 +92,7 @@ Self-hosted/privacy-preserving metasearch instance URL.
 ### Keenable
 
 Independent web index for search and extraction; works keyless, optional key raises rate limits.
+
+### Caesar
+
+Agentic web search with per-result provenance and capture timestamps.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -18,6 +18,7 @@ optional_env:
   - PARALLEL_API_KEY
   - SEARXNG_INSTANCE_URL
   - KEENABLE_API_KEY
+  - CAESAR_API_KEY
 provides_tools:
   - web_search_plus
   - web_extract_plus

--- a/provider_dispatch.py
+++ b/provider_dispatch.py
@@ -267,6 +267,17 @@ def _call_keenable_search(search_module, prov, args, key, config, routing_info):
     )
 
 
+def _call_caesar_search(search_module, prov, args, key, config, routing_info):
+    caesar_config = config.get("caesar", {})
+    return _resolve(search_module, "search_caesar")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        api_url=caesar_config.get("api_url", "https://alpha.api.trycaesar.com/v1/search"),
+        timeout=int(caesar_config.get("timeout", 30)),
+    )
+
+
 # Adapter signature: (search_module, provider, args, key, config, routing_info) -> result dict.
 SEARCH_DISPATCH: Dict[str, Callable[..., Dict[str, Any]]] = {
     "serper": _call_serper_search,
@@ -283,6 +294,7 @@ SEARCH_DISPATCH: Dict[str, Callable[..., Dict[str, Any]]] = {
     "you": _call_you_search,
     "searxng": _call_searxng_search,
     "keenable": _call_keenable_search,
+    "caesar": _call_caesar_search,
 }
 
 

--- a/provider_registry.py
+++ b/provider_registry.py
@@ -209,6 +209,18 @@ _PROVIDER_SPECS = (
         signup_url="https://keenable.ai",
         keyless=True,
     ),
+    ProviderSpec(
+        provider="caesar",
+        env_var="CAESAR_API_KEY",
+        display_name="Caesar",
+        description="Agentic web search with per-result provenance and capture timestamps.",
+        config_section="caesar",
+        supports_search=True,
+        supports_extract=False,
+        capability_labels=("search",),
+        free_tier="Credit-backed; new accounts start with a credit grant",
+        signup_url="https://app.trycaesar.com",
+    ),
 )
 
 PROVIDER_SPECS: Dict[str, ProviderSpec] = {spec.provider: spec for spec in _PROVIDER_SPECS}
@@ -231,6 +243,7 @@ DEFAULT_PROVIDER_PRIORITY = (
     "perplexity",
     "searxng",
     "keenable",
+    "caesar",
 )
 DEFAULT_AUTO_ALLOW = {
     spec.provider: False

--- a/providers.py
+++ b/providers.py
@@ -1846,3 +1846,99 @@ def extract_serper(
         except Exception as e:
             results.append(_normalize_extract_result("serper", url, error=str(e)))
     return {"provider": "serper", "results": results}
+
+
+def _caesar_score(raw: Any) -> Optional[float]:
+    """Normalize a Caesar relevance score.
+
+    Caesar returns a scalar at default verbosity and a ``{"value": 0.87}`` object
+    at higher verbosity. Tolerate both (and a null score from gibberish queries)
+    so a numeric score never crashes the mapping.
+    """
+    if isinstance(raw, dict):
+        raw = raw.get("value")
+    if raw is None:
+        return None
+    try:
+        return round(float(raw), 3)
+    except (TypeError, ValueError):
+        return None
+
+
+def _caesar_snippet(item: Dict[str, Any]) -> str:
+    """Prefer the passages Caesar selected for this query.
+
+    ``snippet`` is the page's meta description, the same for every query that
+    surfaces the document. ``passages`` are the spans Caesar picked for *this*
+    query, so they carry the text that actually answers it. Joining them mirrors
+    how ``search_parallel`` joins its ``excerpts``. Fall back to the flat fields
+    when a result has no passages.
+    """
+    parts = []
+    for passage in item.get("passages") or []:
+        if isinstance(passage, dict):
+            text = passage.get("text") or ""
+        elif isinstance(passage, str):
+            text = passage
+        else:
+            text = ""
+        if text.strip():
+            parts.append(text.strip())
+    if parts:
+        return "\n\n".join(parts)
+    return item.get("snippet") or item.get("content") or item.get("passage") or ""
+
+
+def search_caesar(
+    query: str,
+    api_key: str,
+    max_results: int = 5,
+    api_url: str = "https://alpha.api.trycaesar.com/v1/search",
+    timeout: int = 30,
+) -> dict:
+    """Search using Caesar's agentic web-search API.
+
+    Requires ``CAESAR_API_KEY``, sent as a Bearer token. Caesar is credit-backed;
+    keys are issued at https://app.trycaesar.com.
+    """
+    body: Dict[str, Any] = {"query": query, "max_results": max_results}
+
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+
+    data = make_request(api_url, headers, body, timeout=timeout)
+
+    raw_results = data.get("results") or []
+    results = []
+    for i, item in enumerate(raw_results[:max_results]):
+        url = item.get("url") or item.get("canonical_url") or item.get("source_url") or ""
+        score = _caesar_score(item.get("score"))
+        result = {
+            "title": item.get("title") or _title_from_url(url),
+            "url": url,
+            "snippet": _caesar_snippet(item),
+            # Caesar omits a score for gibberish queries; fall back to a
+            # rank-derived score so ordering survives mapping (mirrors siblings).
+            "score": score if score is not None else round(1.0 - i * 0.05, 3),
+        }
+        metadata = item.get("metadata") or {}
+        published_at = metadata.get("published_at") if isinstance(metadata, dict) else None
+        if published_at:
+            result["date"] = published_at
+        results.append(result)
+
+    answer = results[0]["snippet"] if results else ""
+    access = data.get("access") or {}
+    return {
+        "provider": "caesar",
+        "query": query,
+        "results": results,
+        "images": [],
+        "answer": answer,
+        "metadata": {
+            "tier": access.get("tier") if isinstance(access, dict) else None,
+            "search_id": data.get("search_id"),
+        },
+    }

--- a/search.py
+++ b/search.py
@@ -450,6 +450,11 @@ def extract_serper(*args, **kwargs):
     return _providers.extract_serper(*args, **kwargs)
 
 
+def search_caesar(*args, **kwargs):
+    _sync_provider_dependencies()
+    return _providers.search_caesar(*args, **kwargs)
+
+
 
 # =============================================================================
 # Exa (Neural/Semantic/Deep Search)

--- a/tests/test_caesar_provider.py
+++ b/tests/test_caesar_provider.py
@@ -1,0 +1,143 @@
+import os
+import unittest
+from unittest import mock
+
+import search
+from config import (
+    ProviderConfigError,
+    get_api_key,
+    provider_configured,
+    validate_api_key,
+)
+
+
+class CaesarKeyResolutionTests(unittest.TestCase):
+    def test_get_api_key_returns_none_when_no_key(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(get_api_key("caesar", {}))
+
+    def test_get_api_key_reads_env(self):
+        with mock.patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_secret"}, clear=True):
+            self.assertEqual(get_api_key("caesar", {}), "sk_live_secret")
+
+    def test_provider_configured_requires_a_key(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(provider_configured("caesar", {}))
+        with mock.patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_secret"}, clear=True):
+            self.assertTrue(provider_configured("caesar", {}))
+
+    def test_validate_api_key_raises_without_a_key(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ProviderConfigError):
+                validate_api_key("caesar", {})
+
+    def test_validate_api_key_returns_the_key(self):
+        with mock.patch.dict(os.environ, {"CAESAR_API_KEY": "sk_live_secret_value"}, clear=True):
+            self.assertEqual(validate_api_key("caesar", {}), "sk_live_secret_value")
+
+
+class CaesarSearchTests(unittest.TestCase):
+    def test_sends_bearer_header_and_maps_results(self):
+        fake_response = {
+            "results": [{
+                "title": "Caesar Result",
+                "url": "https://example.com/caesar",
+                "snippet": "Snippet text",
+                "score": 0.91,
+                "metadata": {"published_at": "2026-06-01T00:00:00Z"},
+            }],
+            "access": {"tier": "standard"},
+        }
+        with mock.patch("search.make_request", return_value=fake_response) as mock_request:
+            result = search.search_caesar(
+                query="rust async patterns", api_key="sk_live_secret", max_results=3
+            )
+
+        self.assertEqual(result["provider"], "caesar")
+        self.assertEqual(result["results"][0]["snippet"], "Snippet text")
+        self.assertEqual(result["results"][0]["url"], "https://example.com/caesar")
+        self.assertEqual(result["results"][0]["score"], 0.91)
+        self.assertEqual(result["results"][0]["date"], "2026-06-01T00:00:00Z")
+        self.assertEqual(result["metadata"]["tier"], "standard")
+
+        url, headers, body = mock_request.call_args.args[:3]
+        self.assertEqual(url, "https://alpha.api.trycaesar.com/v1/search")
+        self.assertEqual(headers["Authorization"], "Bearer sk_live_secret")
+        self.assertEqual(body, {"query": "rust async patterns", "max_results": 3})
+
+    def test_prefers_query_selected_passages_over_meta_description(self):
+        fake_response = {
+            "results": [{
+                "title": "Tokio scheduler",
+                "canonical_url": "https://tokio.rs/blog/2019-10-scheduler",
+                # Caesar's `snippet` is the page's meta description, identical for
+                # every query that surfaces this document.
+                "snippet": "A blog about the Tokio runtime.",
+                "passages": [
+                    {"text": "Work stealing balances load across worker threads."},
+                    {"text": "The new scheduler avoids the atomic increment in wake_by_ref."},
+                ],
+                "metadata": {"published_at": "2019-10-13T00:00:00Z"},
+            }]
+        }
+        with mock.patch("search.make_request", return_value=fake_response):
+            result = search.search_caesar(query="work stealing", api_key="sk_live_secret")
+
+        first = result["results"][0]
+        self.assertEqual(
+            first["snippet"],
+            "Work stealing balances load across worker threads.\n\n"
+            "The new scheduler avoids the atomic increment in wake_by_ref.",
+        )
+        self.assertEqual(first["date"], "2019-10-13T00:00:00Z")
+        # The synthesized answer draws on the passages, not the meta description.
+        self.assertIn("Work stealing", result["answer"])
+
+    def test_falls_back_to_snippet_when_no_passages(self):
+        fake_response = {"results": [{"title": "A", "url": "https://a.test", "snippet": "only a snippet"}]}
+        with mock.patch("search.make_request", return_value=fake_response):
+            result = search.search_caesar(query="q", api_key="sk_live_secret")
+
+        self.assertEqual(result["results"][0]["snippet"], "only a snippet")
+        self.assertNotIn("date", result["results"][0])
+
+    def test_ignores_blank_passages_and_tolerates_string_passages(self):
+        fake_response = {
+            "results": [
+                {"url": "https://a.test", "snippet": "fallback", "passages": [{"text": "   "}]},
+                {"url": "https://b.test", "passages": ["a plain string passage"]},
+            ]
+        }
+        with mock.patch("search.make_request", return_value=fake_response):
+            result = search.search_caesar(query="q", api_key="sk_live_secret")
+
+        self.assertEqual(result["results"][0]["snippet"], "fallback")
+        self.assertEqual(result["results"][1]["snippet"], "a plain string passage")
+
+    def test_tolerates_object_and_null_scores(self):
+        fake_response = {
+            "results": [
+                {"url": "https://a.example", "snippet": "a", "score": {"value": 0.8}},
+                {"url": "https://b.example", "snippet": "b", "score": None},
+            ]
+        }
+        with mock.patch("search.make_request", return_value=fake_response):
+            result = search.search_caesar(query="q", api_key="sk_live_secret")
+
+        # Object-form score is unwrapped; a null score falls back to a rank-derived value.
+        self.assertEqual(result["results"][0]["score"], 0.8)
+        self.assertIsInstance(result["results"][1]["score"], float)
+
+    def test_url_and_snippet_field_fallbacks(self):
+        fake_response = {
+            "results": [{"canonical_url": "https://c.example", "content": "body text"}]
+        }
+        with mock.patch("search.make_request", return_value=fake_response):
+            result = search.search_caesar(query="q", api_key="sk_live_secret")
+
+        self.assertEqual(result["results"][0]["url"], "https://c.example")
+        self.assertEqual(result["results"][0]["snippet"], "body text")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -263,7 +263,7 @@ def test_setup_dry_run_uses_target_env_path_for_dashboard(tmp_path, monkeypatch,
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "Providers: 1/14 configured" in out
+    assert "Providers: 1/15 configured" in out
     assert "Active: You.com" in out
     assert "Brave Search" not in out.split("Setup plan:", 1)[0]
 
@@ -279,7 +279,7 @@ def test_status_uses_target_env_path_for_dashboard(tmp_path, monkeypatch, capsys
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "Providers: 1/14 configured" in out
+    assert "Providers: 1/15 configured" in out
     assert "Active: Linkup" in out
     assert "Brave Search" not in out
 

--- a/tests/test_provider_dispatch.py
+++ b/tests/test_provider_dispatch.py
@@ -72,6 +72,7 @@ EXPECTED_SEARCH_KWARGS = {
     "you": {"query", "api_key", "max_results", "country", "language", "freshness", "safesearch", "include_news", "livecrawl"},
     "searxng": {"query", "instance_url", "max_results", "categories", "engines", "language", "time_range", "safesearch"},
     "keenable": {"query", "api_key", "max_results", "time_range", "include_domains", "public", "api_url", "timeout"},
+    "caesar": {"query", "api_key", "max_results", "api_url", "timeout"},
 }
 
 # The provider function each search adapter must resolve (late) from the

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -21,12 +21,16 @@ def test_provider_registry_is_the_complete_capability_source():
         "you",
         "searxng",
         "keenable",
+        "caesar",
     )
     assert registry.EXTRACT_PROVIDER_IDS == ("tavily", "exa", "linkup", "parallel", "firecrawl", "you", "keenable", "serper")
     assert registry.PROVIDER_SPECS["serper"].supports_extract is True
     assert registry.PROVIDER_SPECS["keenable"].supports_extract is True
     assert registry.PROVIDER_SPECS["keenable"].supports_search is True
     assert registry.PROVIDER_SPECS["keenable"].keyless is True
+    assert registry.PROVIDER_SPECS["caesar"].supports_extract is False
+    assert registry.PROVIDER_SPECS["caesar"].supports_search is True
+    assert registry.PROVIDER_SPECS["caesar"].keyless is False
     assert registry.KEYLESS_EXTRACT_PROVIDER_IDS == ("keenable",)
     assert registry.KEYLESS_PROVIDER_IDS == ("keenable",)
     assert registry.PROVIDER_SPECS["serper"].env_var == "SERPER_API_KEY"


### PR DESCRIPTION
Adds [Caesar](https://docs.trycaesar.com) as a search provider next to the existing pool (Serper, Brave, Tavily, Exa, Linkup, Firecrawl, Parallel, Perplexity, You.com, SearXNG, SerpBase, Querit, Keenable).

What earns it a slot: **Caesar returns the passages it selected for your query inline with the search result**, so for most queries there is no follow-up fetch to get the text that answers the question. The closest thing already in the pool is Parallel, which returns `excerpts`; Caesar is in that family rather than the title-plus-snippet family.

**This PR previously described Caesar as keyless. That is no longer true, and the branch has been rewritten.** Details in the comment below.

### Passages, and why the mapping prefers them

Caesar's `snippet` field is the page's meta description, so it is the same text for every query that surfaces the document. Its `passages` are query-conditioned. Same document, two different queries, zero overlap in the passages returned:

```
query: "work stealing balancing load across worker threads"
  -> "That notified processor will steal half the tasks in the batch, and in turn notify another..."

query: "atomic reference counting overhead in the old scheduler"
  -> "There are many outstanding references to the task structure: the scheduler and each waker..."
```

Both from `tokio.rs/blog/2019-10-scheduler`. So `search_caesar` joins the passages into `snippet` exactly the way `search_parallel` joins its `excerpts`, and falls back to the flat `snippet`/`content`/`passage` fields when a result has none. On `why did tokio avoid the atomic increment in wake_by_ref` across 5 results, that is 1,148 characters of meta description versus 4,690 characters of query-relevant text.

### How it fits

The keyed shape follows Exa, the content mapping follows Parallel:

- **Keyed, like Exa and Brave.** `CAESAR_API_KEY` is required and sent as `Authorization: Bearer <key>`. Caesar registers with no `keyless` flag, so it picks up the standard `validate_api_key` path, and a missing key produces the usual `ProviderConfigError` with the signup URL pulled from the registry spec.
- `search_caesar` uses the shared `make_request` helper like the other raw-HTTP providers, so there is **no new dependency**.
- Result mapping is defensive, matching how the sibling providers normalize: `url` falls back across `url`/`canonical_url`/`source_url`, and the relevance score tolerates both Caesar's scalar form and its `{value: ...}` object form. Caesar omits a score on gibberish queries, so a null score falls back to a rank-derived value (mirroring how Linkup/Firecrawl/Parallel derive descending scores) rather than dropping the result.
- The result `date` comes from `metadata.published_at`, which is the document's publication date rather than the time Caesar last crawled it. Roughly 3 in 5 results carry one.
- Caesar is **search-only** (it has no extract endpoint in the public spec), so `web_extract_plus` and the extract priority lists are deliberately untouched.

One honest tradeoff: preferring passages makes a Caesar response roughly 4x larger than a snippet-only mapping, so it costs more context tokens. I think that is the right trade because the alternative is a second request plus the whole page, and it is the same trade Parallel already makes. If you would rather keep responses small, the preference is one function (`_caesar_snippet`).

### Additive scope

Only registration touches existing code: the registry entry, `DEFAULT_PROVIDER_PRIORITY`, the config default section, the `--provider`/tool enum, `.env.template`, the README provider tables, and `plugin.yaml` `optional_env`. The setup wizard, doctor diagnostics, and bench command all derive from the registry, so they pick Caesar up with no extra wiring. Caesar has no native recency filter, so the unified freshness parameter correctly reports as not applied, same as Tavily and Exa.

Two follow-on edits from the same registration, called out so they are not a surprise in the diff: `docs/PROVIDERS.md` is regenerated via `python scripts/gen_provider_docs.py` (its drift-check test requires it), and the README intro's provider count moves from 14 to 15 search providers. The v2.6.1 hero image still shows 14; I left the asset alone since that is yours to regenerate.

One existing assertion is bumped (not a behavior change), flagged explicitly since it touches an existing test:

- `test_onboarding.py`: the hardcoded `Providers: 1/14 configured` dashboard count becomes `1/15`.

`test_provider_registry.py` gains assertions for the new spec, and its frozen `KEYLESS_PROVIDER_IDS` snapshot is left exactly as it is on `main`, since Caesar is not keyless.

### Tested

`tests/test_caesar_provider.py` mirrors the keyed-provider tests: key resolution, `validate_api_key` raising when the key is absent, the Bearer header, passage preference over the meta description, the fallback when a result has no passages, blank and string-form passages, and the score/url field tolerances.

Full suite green and lint clean:

```
$ python -m pytest tests/ -q
479 passed
$ ruff check .
All checks passed!
```

I also fired a real query through the built provider to confirm end-to-end mapping, not just mocked units:

```
$ python -c "import search; from config import validate_api_key; \
key = validate_api_key('caesar', {}); \
r = search.search_caesar(query='why did tokio avoid the atomic increment in wake_by_ref', api_key=key, max_results=3); \
[print(f\"score={x['score']} date={x.get('date','-')[:10]:<11} chars={len(x['snippet']):<5} {x['title'][:44]}\") for x in r['results']]"

score=0.933 date=2019-10-13  chars=1208  Making the Tokio scheduler 10x faster | Toki
score=0.914 date=-           chars=1022  tokio-1.52.x-comment/docs/deep-end-to-end-tr
score=0.819 date=-           chars=965   waker.rs.html -- source
```

The 1,208 characters on the top result are the passages that answer the question, and the date is the post's real publication date.

And the unconfigured path fails the way the other keyed providers do:

```
$ python -c "from config import validate_api_key; validate_api_key('caesar', {})"
ProviderConfigError: Missing API key for caesar
  how_to_fix: 1. Get your API key from https://app.trycaesar.com
```

---

Disclosure up front: I work on GTM for Caesar. I tried to make this read like the rest of the provider pool rather than a vendor drop-in, and I am happy to adjust naming or the default-priority placement to fit your conventions.
