### PR TITLE
fix: make plugin imports cwd-independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [v2.8.1] — 2026-07-02
+
+### Credits
+- #75 by @robbyczgw-cla — cwd-independent plugin import fix for Hermes standalone discovery.
+
+### 🐛 Fixed
+- Web Search Plus plugin discovery no longer depends on the current working directory when Hermes loads the flat plugin from outside the plugin directory. The plugin root is added as a fallback import path so sibling modules such as `provider_registry` resolve under Hermes Agent v0.18 standalone discovery without shadowing host modules.
+
 ## [v2.8.0] — 2026-07-02
 
 ### Credits

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v2.8.0
+web-search-plus — Hermes Plugin v2.8.1
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "2.8.0"
+__version__ = "2.8.1"
 
 import argparse
 import getpass
@@ -24,6 +24,13 @@ import webbrowser
 from concurrent.futures import TimeoutError as FuturesTimeout
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional
+
+# Hermes standalone plugin discovery can execute this flat plugin from outside
+# the plugin directory. Keep sibling-module fallback imports cwd-independent
+# without shadowing host/other-plugin modules ahead of normal sys.path entries.
+_PLUGIN_DIR = Path(__file__).resolve().parent
+if str(_PLUGIN_DIR) not in sys.path:
+    sys.path.append(str(_PLUGIN_DIR))
 
 try:  # Package load path used by Hermes plugin discovery.
     from .provider_registry import (

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.8.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.8.1"
 
 
 class ProviderRequestError(Exception):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "2.8.0"
+version: "2.8.1"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 2.8.0
+Version: 2.8.1
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable.

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -53,7 +53,7 @@ def test_http_client_provider_request_error_exports_retry_metadata():
 
 
 def test_default_user_agent_uses_release_version():
-    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.8.0"
+    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.8.1"
 
 
 def _make_http_error(code: int, headers=None, body: bytes = b"{}") -> HTTPError:

--- a/tests/test_plugin_package_import.py
+++ b/tests/test_plugin_package_import.py
@@ -35,9 +35,28 @@ def test_plugin_loads_with_hermes_package_style_import():
 
         spec.loader.exec_module(module)
 
-        assert module.__version__ == "2.8.0"
+        assert module.__version__ == "2.8.1"
         assert module._get_provider_catalog()
     finally:
         sys.modules.pop(module_name, None)
         if previous_parent is None:
             sys.modules.pop(parent_name, None)
+
+def test_plugin_loads_from_foreign_cwd_without_package_context(tmp_path, monkeypatch):
+    """Hermes standalone discovery can exec __init__.py outside plugin cwd."""
+    module_name = "wsp_standalone_import_test"
+    monkeypatch.chdir(tmp_path)
+    sys.modules.pop(module_name, None)
+
+    try:
+        spec = importlib.util.spec_from_file_location(module_name, ROOT / "__init__.py")
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+
+        spec.loader.exec_module(module)
+
+        assert module.__version__ == "2.8.1"
+        assert module._get_provider_catalog()
+    finally:
+        sys.modules.pop(module_name, None)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "2.8.0"
+EXPECTED_VERSION = "2.8.1"
 
 
 def _load_plugin_module():


### PR DESCRIPTION
## Summary
- makes Web Search Plus plugin imports independent of the current working directory during standalone Hermes plugin discovery
- adds the plugin directory as a fallback `sys.path` entry with `append`, avoiding host/other-plugin module shadowing from `insert(0)`
- adds a regression test that imports `__init__.py` from a foreign cwd with no package context
- prepares the v2.8.1 patch release metadata/changelog

## Why
Hermes Agent v0.18 can execute standalone plugins from outside the plugin directory. Web Search Plus v2.8.0 supported both package-style imports and flat sibling imports, but the flat fallback still required the plugin root to already be on `sys.path`. That made discovery cwd-sensitive and could fail with `ModuleNotFoundError: provider_registry`.

## Test Plan
- `python3 -m compileall -q .`
- `python3 -m pytest tests/ -q` → 384 passed
- `ruff check .`
- `git diff --check`
