### PR TITLE
feat(eval): golden snapshot recorder and expanded snapshot suite

### DIFF
--- a/scripts/golden_eval.py
+++ b/scripts/golden_eval.py
@@ -3,6 +3,28 @@
 
 Runs a fixed set of representative queries against normal search and optional
 research mode, then writes machine-readable JSONL plus a compact markdown report.
+
+Offline snapshot fixtures (``--snapshot-fixtures``) replay pinned provider
+payloads deterministically; CI exercises them via tests/test_golden_eval.py.
+Every fixture payload must satisfy ``SNAPSHOT_PAYLOAD_CONTRACT`` so fixtures
+cannot drift away from the envelope search.py actually emits.
+
+Recording workflow for refreshing snapshot fixtures (requires configured
+provider API keys, like the live eval):
+
+1. Record: ``python scripts/golden_eval.py --record --record-output
+   tests/fixtures/golden_snapshots.recorded.json`` runs the live golden
+   queries (normal mode, one snapshot per category) and writes sanitized
+   payloads: snippets/content truncated to stable lengths, volatile fields
+   (cache metadata, routing, latency, timestamps) stripped, keys sorted
+   deterministically.
+2. Review: manually inspect the ``.recorded.json`` file and tighten the
+   auto-generated ``expect`` blocks (top_domain_any_of, must_include_domains,
+   blocked_domains, required_terms, min_content_chars) so they encode real
+   source-quality expectations rather than just what happened to come back.
+3. Promote: copy the reviewed snapshots into
+   ``tests/fixtures/golden_snapshots.json``. The recorder deliberately
+   refuses to write the canonical fixture file directly.
 """
 from __future__ import annotations
 
@@ -14,7 +36,7 @@ import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Tuple
 from urllib.parse import urlparse
 
 
@@ -68,6 +90,49 @@ DEFAULT_GOLDEN_QUERIES: List[Dict[str, Any]] = [
         "notes": "Extraction-sensitive / JS-ish query.",
     },
 ]
+
+
+CANONICAL_SNAPSHOT_FIXTURE = Path("tests") / "fixtures" / "golden_snapshots.json"
+
+# Contract between snapshot fixtures and the real search.py output envelope.
+# The recorder sanitizes live payloads down to exactly these fields and the
+# schema test in tests/test_golden_eval.py validates every fixture against it,
+# so schema drift between fixtures and real output fails immediately.
+SNAPSHOT_PAYLOAD_CONTRACT: Dict[str, Any] = {
+    "required_payload_fields": {"results": list},
+    "optional_payload_fields": {
+        "provider": str,
+        "query": str,
+        "answer": str,
+        "source_summaries": list,
+        "quality_report": dict,
+        "metadata": dict,
+    },
+    "required_result_fields": {"title": str, "url": str},
+    "optional_result_fields": {
+        "snippet": str,
+        "content": str,
+        "raw_content": str,
+        "score": (int, float),
+        "published_date": str,
+        "type": str,
+    },
+    "required_source_summary_fields": {"url": str},
+    "optional_source_summary_fields": {
+        "title": str,
+        "snippet": str,
+        "content": str,
+        "raw_content": str,
+    },
+}
+
+# Sanitization limits applied by the recorder so fixtures stay reviewable.
+SNAPSHOT_TEXT_LIMITS: Dict[str, int] = {
+    "snippet": 300,
+    "content": 1200,
+    "raw_content": 1200,
+    "answer": 600,
+}
 
 
 def load_golden_queries(path: Path | None = None) -> List[Dict[str, Any]]:
@@ -124,6 +189,204 @@ def _result_text(item: Dict[str, Any]) -> str:
     return " ".join(
         str(item.get(key) or "")
         for key in ("title", "snippet", "description", "content", "raw_content", "summary")
+    )
+
+
+def _matches_type(value: Any, expected: Any) -> bool:
+    if isinstance(value, bool) and expected is not bool:
+        return False
+    return isinstance(value, expected)
+
+
+def _validate_fields(
+    item: Any,
+    required: Dict[str, Any],
+    optional: Dict[str, Any],
+    label: str,
+) -> List[str]:
+    if not isinstance(item, dict):
+        return [f"{label} must be a JSON object"]
+    issues: List[str] = []
+    for field, expected in required.items():
+        if field not in item:
+            issues.append(f"{label} is missing required field '{field}'")
+        elif not _matches_type(item[field], expected):
+            issues.append(f"{label} field '{field}' must be {getattr(expected, '__name__', expected)}")
+    for field, value in item.items():
+        if field in required:
+            continue
+        if field not in optional:
+            issues.append(f"{label} has unknown field '{field}'")
+        elif value is not None and not _matches_type(value, optional[field]):
+            issues.append(f"{label} optional field '{field}' has wrong type")
+    return issues
+
+
+def validate_snapshot_payload(payload: Any) -> List[str]:
+    """Validate a snapshot payload against SNAPSHOT_PAYLOAD_CONTRACT.
+
+    Returns a list of human-readable contract violations; empty means the
+    payload matches the envelope search.py produces (required results list,
+    typed result fields, no unknown top-level fields).
+    """
+    contract = SNAPSHOT_PAYLOAD_CONTRACT
+    issues = _validate_fields(
+        payload,
+        contract["required_payload_fields"],
+        contract["optional_payload_fields"],
+        "payload",
+    )
+    if not isinstance(payload, dict):
+        return issues
+    for index, item in enumerate(payload.get("results") or []):
+        issues.extend(_validate_fields(
+            item,
+            contract["required_result_fields"],
+            contract["optional_result_fields"],
+            f"results[{index}]",
+        ))
+    for index, item in enumerate(payload.get("source_summaries") or []):
+        issues.extend(_validate_fields(
+            item,
+            contract["required_source_summary_fields"],
+            contract["optional_source_summary_fields"],
+            f"source_summaries[{index}]",
+        ))
+    return issues
+
+
+def _truncate_text(value: Any, limit: int) -> str:
+    text = str(value)
+    return text if len(text) <= limit else text[:limit].rstrip()
+
+
+def _sanitize_item(item: Dict[str, Any], required: Dict[str, Any], optional: Dict[str, Any]) -> Dict[str, Any]:
+    sanitized: Dict[str, Any] = {}
+    for field in required:
+        sanitized[field] = str(item.get(field) or "")
+    for field, expected in optional.items():
+        value = item.get(field)
+        if value is None:
+            continue
+        if field in SNAPSHOT_TEXT_LIMITS:
+            value = _truncate_text(value, SNAPSHOT_TEXT_LIMITS[field])
+            if not value:
+                continue
+        if _matches_type(value, expected):
+            sanitized[field] = value
+    return sanitized
+
+
+def sanitize_payload_for_snapshot(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Reduce a live search payload to the deterministic snapshot contract.
+
+    Drops volatile fields (cache metadata, routing, latency, freshness
+    timestamps), truncates long text to SNAPSHOT_TEXT_LIMITS, and keeps only
+    fields declared in SNAPSHOT_PAYLOAD_CONTRACT so recorded fixtures replay
+    identically on every run.
+    """
+    contract = SNAPSHOT_PAYLOAD_CONTRACT
+    sanitized: Dict[str, Any] = {
+        "provider": str(payload.get("provider") or "replay"),
+        "results": [
+            _sanitize_item(item, contract["required_result_fields"], contract["optional_result_fields"])
+            for item in (payload.get("results") or [])
+            if isinstance(item, dict)
+        ],
+    }
+    answer = payload.get("answer")
+    if isinstance(answer, str) and answer.strip():
+        sanitized["answer"] = _truncate_text(answer, SNAPSHOT_TEXT_LIMITS["answer"])
+    source_summaries = [
+        _sanitize_item(item, contract["required_source_summary_fields"], contract["optional_source_summary_fields"])
+        for item in (payload.get("source_summaries") or [])
+        if isinstance(item, dict)
+    ]
+    if source_summaries:
+        sanitized["source_summaries"] = source_summaries
+    reported_duplicates = (payload.get("quality_report") or {}).get(
+        "duplicate_count", (payload.get("metadata") or {}).get("dedup_count", 0)
+    )
+    sanitized["quality_report"] = {"duplicate_count": int(reported_duplicates or 0)}
+    return sanitized
+
+
+def default_snapshot_expectations(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Derive conservative starter expectations from a sanitized payload.
+
+    These are a floor, not a review: promote a recorded snapshot only after
+    manually tightening the expect block (see module docstring workflow).
+    """
+    results = payload.get("results") or []
+    domains = {_safe_domain(item.get("url", "")) for item in results if item.get("url")}
+    domains.discard("")
+    return {
+        "min_results": max(1, min(len(results), 3)),
+        "min_domain_count": max(1, min(len(domains), 3)),
+        "max_duplicate_count": _duplicate_url_count(results),
+    }
+
+
+def record_snapshots(
+    cases: List[Dict[str, Any]],
+    script_path: Path,
+    max_results: int,
+    timeout_seconds: int,
+    env: Dict[str, str],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Run live golden queries and build sanitized snapshot fixtures.
+
+    Returns (snapshots, errors); cases that error, time out, or violate the
+    payload contract are reported in errors instead of being recorded.
+    """
+    snapshots: List[Dict[str, Any]] = []
+    errors: List[Dict[str, Any]] = []
+    for case in cases:
+        cmd = [
+            sys.executable,
+            str(script_path),
+            "--query",
+            case["query"],
+            "--provider",
+            case.get("provider", "auto"),
+            "--max-results",
+            str(max_results),
+            "--quality-report",
+            "--no-cache",
+            "--compact",
+        ]
+        try:
+            proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_seconds, env=env)
+        except subprocess.TimeoutExpired:
+            errors.append({"id": case["id"], "error": f"timeout after {timeout_seconds}s"})
+            continue
+        payload = _json_from_stdout(proc.stdout if proc.returncode == 0 else (proc.stdout or proc.stderr))
+        if proc.returncode != 0 or payload.get("error") or not payload.get("results"):
+            errors.append({
+                "id": case["id"],
+                "error": str(payload.get("error") or f"exit code {proc.returncode} with no results"),
+            })
+            continue
+        sanitized = sanitize_payload_for_snapshot(payload)
+        contract_issues = validate_snapshot_payload(sanitized)
+        if contract_issues:
+            errors.append({"id": case["id"], "error": "; ".join(contract_issues)})
+            continue
+        snapshots.append({
+            "id": case["id"],
+            "category": case.get("category"),
+            "query": case["query"],
+            "payload": sanitized,
+            "expect": default_snapshot_expectations(sanitized),
+        })
+    return snapshots, errors
+
+
+def write_snapshot_fixture(snapshots: List[Dict[str, Any]], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(snapshots, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
     )
 
 
@@ -370,11 +633,56 @@ def main() -> int:
     parser.add_argument(
         "--snapshot-fixtures",
         type=Path,
-        help="Validate offline replay fixtures instead of making live provider calls",
+        nargs="?",
+        const=CANONICAL_SNAPSHOT_FIXTURE,
+        help="Validate offline replay fixtures instead of making live provider calls "
+             "(defaults to tests/fixtures/golden_snapshots.json when no path is given)",
+    )
+    parser.add_argument(
+        "--record",
+        action="store_true",
+        help="Run the live golden queries and record sanitized snapshot fixtures "
+             "(requires configured provider keys; see module docstring workflow)",
+    )
+    parser.add_argument(
+        "--record-output",
+        type=Path,
+        help="Destination for recorded snapshots (default: tests/fixtures/golden_snapshots.recorded.json); "
+             "the canonical fixture file is never written directly",
     )
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parents[1]
+    if args.record:
+        canonical = (repo_root / CANONICAL_SNAPSHOT_FIXTURE).resolve()
+        output = args.record_output or CANONICAL_SNAPSHOT_FIXTURE.with_suffix(".recorded.json")
+        if not output.is_absolute():
+            output = repo_root / output
+        if output.resolve() == canonical:
+            print(json.dumps({
+                "error": "refusing to overwrite the canonical fixture; record to a "
+                         ".recorded.json path, review manually, then promote",
+                "canonical": str(canonical),
+            }, indent=2, sort_keys=True))
+            return 2
+        cases = load_golden_queries(args.queries)
+        if args.limit:
+            cases = cases[: args.limit]
+        snapshots, errors = record_snapshots(
+            cases=cases,
+            script_path=repo_root / "search.py",
+            max_results=args.max_results,
+            timeout_seconds=args.timeout,
+            env=os.environ.copy(),
+        )
+        write_snapshot_fixture(snapshots, output)
+        print(json.dumps({
+            "recorded": len(snapshots),
+            "errors": errors,
+            "output": str(output),
+        }, indent=2, sort_keys=True))
+        return 1 if errors else 0
+
     if args.snapshot_fixtures:
         fixture_path = args.snapshot_fixtures if args.snapshot_fixtures.is_absolute() else repo_root / args.snapshot_fixtures
         rows = run_snapshot_quality(load_snapshot_fixtures(fixture_path))

--- a/tests/fixtures/golden_snapshots.json
+++ b/tests/fixtures/golden_snapshots.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "github-primary-source",
-    "category": "software_canonical",
+    "category": "tech_release",
     "query": "Hermes Web Search Plus GitHub",
     "payload": {
       "provider": "replay",
@@ -35,7 +35,7 @@
   },
   {
     "id": "policy-primary-source",
-    "category": "policy_canonical",
+    "category": "research_policy",
     "query": "EU AI Act official obligations",
     "payload": {
       "provider": "replay",
@@ -69,7 +69,7 @@
   },
   {
     "id": "extract-content-quality",
-    "category": "extract_replay",
+    "category": "js_extraction",
     "query": "extract homepage docs",
     "payload": {
       "provider": "replay",
@@ -88,6 +88,198 @@
       "min_content_chars": 120,
       "must_include_domains": ["websearchplus.xyz"],
       "required_terms": ["Hermes Agent", "providers", "quality reports"],
+      "max_duplicate_count": 0
+    }
+  },
+  {
+    "id": "hifi-turntables-under-1000",
+    "category": "hifi_product",
+    "query": "best turntables under 1000 euro 2026",
+    "payload": {
+      "provider": "replay",
+      "results": [
+        {
+          "title": "Best turntables 2026: top record players for every budget",
+          "url": "https://www.whathifi.com/best-buys/best-turntables",
+          "snippet": "Our expert pick of the best turntables under 1000 euro, tested by the What Hi-Fi? review team.",
+          "score": 0.95
+        },
+        {
+          "title": "Rega Planar 3 turntable review",
+          "url": "https://www.stereophile.com/content/rega-planar-3-turntable",
+          "snippet": "In-depth review and measurements of the Rega Planar 3 turntable with RB330 tonearm.",
+          "score": 0.9
+        },
+        {
+          "title": "Turntable recommendations under 1000 euro?",
+          "url": "https://www.audiosciencereview.com/forum/index.php?threads/turntable-recommendations-under-1000.54321/",
+          "snippet": "Measurement-focused community discussion of turntable performance in the sub-1000 euro bracket.",
+          "score": 0.85
+        }
+      ],
+      "quality_report": {"duplicate_count": 0}
+    },
+    "expect": {
+      "min_results": 3,
+      "min_domain_count": 3,
+      "top_domain_any_of": ["whathifi.com", "stereophile.com"],
+      "must_include_domains": ["whathifi.com"],
+      "blocked_domains": ["seo-listicle-farm.invalid"],
+      "required_terms": ["turntable"],
+      "max_duplicate_count": 0
+    }
+  },
+  {
+    "id": "graz-weather-today",
+    "category": "local_realtime",
+    "query": "Graz weather today",
+    "payload": {
+      "provider": "replay",
+      "results": [
+        {
+          "title": "Wetter Graz - aktuelle Wettervorhersage von ORF",
+          "url": "https://wetter.orf.at/steiermark/graz",
+          "snippet": "Aktuelles Wetter und Prognose für Graz und die Steiermark vom ORF.",
+          "score": 0.95
+        },
+        {
+          "title": "Aktuelle Messwerte Graz Universität - GeoSphere Austria",
+          "url": "https://www.geosphere.at/de/services/wetter/graz",
+          "snippet": "Current observations and forecast for Graz from Austria's national weather service.",
+          "score": 0.9
+        },
+        {
+          "title": "Weather for Graz, Styria, Austria",
+          "url": "https://www.timeanddate.com/weather/austria/graz",
+          "snippet": "Current conditions, hourly forecast and 14 day outlook for Graz, Austria.",
+          "score": 0.85
+        }
+      ],
+      "quality_report": {"duplicate_count": 0}
+    },
+    "expect": {
+      "min_results": 3,
+      "min_domain_count": 3,
+      "top_domain_any_of": ["wetter.orf.at", "geosphere.at"],
+      "must_include_domains": ["wetter.orf.at"],
+      "blocked_domains": ["weather-aggregator.invalid"],
+      "required_terms": ["Graz"],
+      "max_duplicate_count": 0
+    }
+  },
+  {
+    "id": "deutsche-ki-news",
+    "category": "german_realtime",
+    "query": "aktuelle KI Regulierung Österreich Unternehmen 2026",
+    "payload": {
+      "provider": "replay",
+      "results": [
+        {
+          "title": "KI-Verordnung: Was Unternehmen jetzt beachten müssen - WKO",
+          "url": "https://www.wko.at/digitalisierung/ki-verordnung-unternehmen",
+          "snippet": "Die Wirtschaftskammer Österreich erklärt die Pflichten der KI-Verordnung für Unternehmen ab 2026.",
+          "score": 0.95
+        },
+        {
+          "title": "Künstliche Intelligenz - Regulierung in Österreich",
+          "url": "https://www.oesterreich.gv.at/themen/digitales/kuenstliche-intelligenz.html",
+          "snippet": "Offizielle Informationen zur KI-Regulierung und KI-Servicestelle für Unternehmen in Österreich.",
+          "score": 0.9
+        },
+        {
+          "title": "KI-Regeln: Was auf heimische Unternehmen zukommt",
+          "url": "https://www.derstandard.at/story/ki-regulierung-oesterreich-unternehmen-2026",
+          "snippet": "Überblick über die aktuellen KI-Regeln und Übergangsfristen für Unternehmen in Österreich.",
+          "score": 0.85
+        }
+      ],
+      "quality_report": {"duplicate_count": 0}
+    },
+    "expect": {
+      "min_results": 3,
+      "min_domain_count": 3,
+      "top_domain_any_of": ["wko.at", "oesterreich.gv.at"],
+      "must_include_domains": ["wko.at", "oesterreich.gv.at"],
+      "blocked_domains": ["ki-consulting-spam.invalid"],
+      "required_terms": ["KI", "Unternehmen"],
+      "max_duplicate_count": 0
+    }
+  },
+  {
+    "id": "reddit-local-llama",
+    "category": "reddit_community",
+    "query": "site:reddit.com/r/LocalLLaMA best local LLM inference server 2026",
+    "payload": {
+      "provider": "replay",
+      "results": [
+        {
+          "title": "Best local LLM inference server in 2026? : r/LocalLLaMA",
+          "url": "https://www.reddit.com/r/LocalLLaMA/comments/1abc123/best_local_llm_inference_server_in_2026/",
+          "snippet": "Community thread comparing vLLM, llama.cpp server and TGI for local inference workloads.",
+          "score": 0.95
+        },
+        {
+          "title": "vLLM vs llama.cpp server benchmarks : r/LocalLLaMA",
+          "url": "https://www.reddit.com/r/LocalLLaMA/comments/1def456/vllm_vs_llamacpp_server_benchmarks/",
+          "snippet": "Throughput and latency benchmarks for popular local inference servers on consumer GPUs.",
+          "score": 0.9
+        },
+        {
+          "title": "My 2026 local inference stack : r/LocalLLaMA",
+          "url": "https://www.reddit.com/r/LocalLLaMA/comments/1ghi789/my_2026_local_inference_stack/",
+          "snippet": "Setup writeup: quantized models, an inference server and an OpenAI-compatible gateway.",
+          "score": 0.85
+        }
+      ],
+      "quality_report": {"duplicate_count": 0}
+    },
+    "expect": {
+      "min_results": 3,
+      "min_domain_count": 1,
+      "top_domain_any_of": ["reddit.com"],
+      "must_include_domains": ["reddit.com"],
+      "blocked_domains": ["reddit-mirror.invalid"],
+      "required_terms": ["LocalLLaMA", "inference"],
+      "max_duplicate_count": 0
+    }
+  },
+  {
+    "id": "academic-rag-eval",
+    "category": "academic",
+    "query": "recent papers retrieval augmented generation evaluation benchmark 2026",
+    "payload": {
+      "provider": "replay",
+      "results": [
+        {
+          "title": "A Survey of Retrieval-Augmented Generation Evaluation",
+          "url": "https://arxiv.org/abs/2601.01234",
+          "snippet": "We survey evaluation methodology for retrieval-augmented generation systems and propose a unified benchmark taxonomy.",
+          "score": 0.95,
+          "published_date": "2026-01-15"
+        },
+        {
+          "title": "RAGBench: A Reproducible Benchmark for Retrieval-Augmented Generation",
+          "url": "https://aclanthology.org/2026.acl-long.123/",
+          "snippet": "Benchmark suite measuring faithfulness, answer relevance and retrieval quality for RAG pipelines.",
+          "score": 0.9,
+          "published_date": "2026-03-02"
+        },
+        {
+          "title": "Evaluating Retrieval Quality in RAG Systems",
+          "url": "https://openreview.net/forum?id=rag-eval-2026",
+          "snippet": "Peer-reviewed study on retrieval evaluation metrics and their correlation with end-task benchmark scores.",
+          "score": 0.85
+        }
+      ],
+      "quality_report": {"duplicate_count": 0}
+    },
+    "expect": {
+      "min_results": 3,
+      "min_domain_count": 3,
+      "top_domain_any_of": ["arxiv.org"],
+      "must_include_domains": ["arxiv.org", "aclanthology.org"],
+      "blocked_domains": ["paper-mill.invalid"],
+      "required_terms": ["retrieval", "benchmark"],
       "max_duplicate_count": 0
     }
   }

--- a/tests/test_golden_eval.py
+++ b/tests/test_golden_eval.py
@@ -97,9 +97,13 @@ class GoldenEvalTests(unittest.TestCase):
         snapshots = golden_eval.load_snapshot_fixtures(fixture_path)
         rows = golden_eval.run_snapshot_quality(snapshots)
 
-        self.assertEqual(len(rows), 3)
+        self.assertEqual(len(rows), 8)
         self.assertTrue(all(row["status"] == "ok" for row in rows))
         self.assertEqual(rows[0]["top_domain"], "github.com")
+
+        live_categories = {case["category"] for case in golden_eval.load_golden_queries()}
+        snapshot_categories = {snapshot["category"] for snapshot in snapshots}
+        self.assertEqual(snapshot_categories, live_categories)
 
         broken = snapshots[0].copy()
         broken["payload"] = {"results": [{"url": "https://example-mirror.invalid/only"}]}
@@ -176,6 +180,173 @@ class GoldenEvalTests(unittest.TestCase):
         self.assertNotIn("--mode", calls[0])
         self.assertIn("--mode", calls[1])
         self.assertIn("research", calls[1])
+
+
+class SnapshotContractTests(unittest.TestCase):
+    def test_all_fixture_payloads_match_output_contract(self):
+        fixture_path = Path(__file__).parent / "fixtures" / "golden_snapshots.json"
+        snapshots = golden_eval.load_snapshot_fixtures(fixture_path)
+
+        self.assertEqual(len(snapshots), 8)
+        for snapshot in snapshots:
+            issues = golden_eval.validate_snapshot_payload(snapshot["payload"])
+            self.assertEqual(issues, [], f"{snapshot['id']}: {issues}")
+
+    def test_contract_rejects_unknown_top_level_field(self):
+        payload = {
+            "results": [{"title": "t", "url": "https://example.com"}],
+            "latency_ms": 1234,
+        }
+
+        issues = golden_eval.validate_snapshot_payload(payload)
+
+        self.assertTrue(any("unknown field 'latency_ms'" in issue for issue in issues))
+
+    def test_contract_rejects_bad_result_shapes(self):
+        payload = {
+            "results": [
+                {"title": "missing url"},
+                {"title": 42, "url": "https://example.com"},
+                {"title": "t", "url": "https://example.com", "score": "high"},
+                {"title": "t", "url": "https://example.com", "tracking_id": "abc"},
+            ],
+        }
+
+        issues = "\n".join(golden_eval.validate_snapshot_payload(payload))
+
+        self.assertIn("results[0] is missing required field 'url'", issues)
+        self.assertIn("results[1] field 'title' must be str", issues)
+        self.assertIn("results[2] optional field 'score' has wrong type", issues)
+        self.assertIn("results[3] has unknown field 'tracking_id'", issues)
+
+    def test_contract_requires_results_list(self):
+        issues = golden_eval.validate_snapshot_payload({"provider": "replay"})
+
+        self.assertTrue(any("missing required field 'results'" in issue for issue in issues))
+
+
+class SnapshotRecorderTests(unittest.TestCase):
+    def test_sanitize_payload_strips_volatile_fields_and_truncates(self):
+        payload = {
+            "provider": "linkup",
+            "results": [
+                {
+                    "title": "Long result",
+                    "url": "https://example.com/a",
+                    "snippet": "x" * 900,
+                    "score": 0.91,
+                    "favicon": "https://example.com/favicon.ico",
+                }
+            ],
+            "source_summaries": [{"url": "https://example.com/a", "content": "y" * 5000}],
+            "answer": "z" * 2000,
+            "cached": True,
+            "cache_age_seconds": 42,
+            "deduplicated": False,
+            "routing": {"provider": "linkup", "auto_routed": True},
+            "metadata": {"dedup_count": 1, "freshness": {"requested": "week"}},
+            "quality_report": {"duplicate_count": 1, "domains": ["example.com"]},
+        }
+
+        sanitized = golden_eval.sanitize_payload_for_snapshot(payload)
+
+        self.assertEqual(golden_eval.validate_snapshot_payload(sanitized), [])
+        for volatile in ("cached", "cache_age_seconds", "deduplicated", "routing", "metadata"):
+            self.assertNotIn(volatile, sanitized)
+        self.assertNotIn("favicon", sanitized["results"][0])
+        self.assertLessEqual(len(sanitized["results"][0]["snippet"]), 300)
+        self.assertLessEqual(len(sanitized["source_summaries"][0]["content"]), 1200)
+        self.assertLessEqual(len(sanitized["answer"]), 600)
+        self.assertEqual(sanitized["quality_report"], {"duplicate_count": 1})
+
+    def test_default_snapshot_expectations_are_derived_from_payload(self):
+        expect = golden_eval.default_snapshot_expectations({
+            "results": [
+                {"title": "a", "url": "https://example.com/a"},
+                {"title": "b", "url": "https://example.org/b"},
+            ],
+        })
+
+        self.assertEqual(expect["min_results"], 2)
+        self.assertEqual(expect["min_domain_count"], 2)
+        self.assertEqual(expect["max_duplicate_count"], 0)
+
+    def test_record_snapshots_builds_contract_clean_snapshots(self):
+        def fake_run(cmd, capture_output, text, timeout, env):
+            class Result:
+                returncode = 0
+                stdout = json.dumps({
+                    "provider": "linkup",
+                    "results": [{"title": "T", "url": "https://example.com", "snippet": "s", "score": 0.9}],
+                    "cached": False,
+                    "routing": {"provider": "linkup"},
+                    "quality_report": {"duplicate_count": 0},
+                })
+                stderr = ""
+            return Result()
+
+        with mock.patch("scripts.golden_eval.subprocess.run", side_effect=fake_run):
+            snapshots, errors = golden_eval.record_snapshots(
+                cases=[{"id": "q1", "category": "hifi_product", "query": "turntables"}],
+                script_path=Path("search.py"),
+                max_results=4,
+                timeout_seconds=10,
+                env={},
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(snapshots), 1)
+        snapshot = snapshots[0]
+        self.assertEqual(snapshot["id"], "q1")
+        self.assertEqual(snapshot["category"], "hifi_product")
+        self.assertEqual(golden_eval.validate_snapshot_payload(snapshot["payload"]), [])
+        self.assertNotIn("routing", snapshot["payload"])
+        self.assertIn("expect", snapshot)
+
+    def test_record_snapshots_reports_failed_cases(self):
+        def fake_run(cmd, capture_output, text, timeout, env):
+            class Result:
+                returncode = 1
+                stdout = json.dumps({"error": "All providers failed", "results": []})
+                stderr = "boom"
+            return Result()
+
+        with mock.patch("scripts.golden_eval.subprocess.run", side_effect=fake_run):
+            snapshots, errors = golden_eval.record_snapshots(
+                cases=[{"id": "q1", "category": "academic", "query": "papers"}],
+                script_path=Path("search.py"),
+                max_results=4,
+                timeout_seconds=10,
+                env={},
+            )
+
+        self.assertEqual(snapshots, [])
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["id"], "q1")
+        self.assertIn("All providers failed", errors[0]["error"])
+
+    def test_record_mode_refuses_canonical_fixture_and_writes_elsewhere(self):
+        with mock.patch("sys.argv", [
+            "golden_eval.py", "--record", "--record-output", "tests/fixtures/golden_snapshots.json",
+        ]):
+            self.assertEqual(golden_eval.main(), 2)
+
+        snapshot = {
+            "id": "q1",
+            "category": "hifi_product",
+            "query": "turntables",
+            "payload": {"provider": "replay", "results": [{"title": "T", "url": "https://example.com"}]},
+            "expect": {"min_results": 1},
+        }
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "golden_snapshots.recorded.json"
+            with mock.patch("scripts.golden_eval.record_snapshots", return_value=([snapshot], [])):
+                with mock.patch("sys.argv", ["golden_eval.py", "--record", "--record-output", str(out)]):
+                    self.assertEqual(golden_eval.main(), 0)
+
+            data = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(len(data), 1)
+            self.assertEqual(data[0]["id"], "q1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Strengthens the golden-eval infrastructure so the offline snapshot suite can't drift from the real output schema, and so new snapshots can be recorded from real provider runs instead of being hand-written.

- **New `--record` mode** in `scripts/golden_eval.py`: runs the live golden queries and writes sanitized, deterministic snapshot fixtures (snippets/content/answer truncated, volatile cache/routing/timestamp fields stripped, sorted keys). The documented workflow is record → manual review → promote; the recorder refuses to overwrite the canonical fixture file (exit 2) and defaults to `tests/fixtures/golden_snapshots.recorded.json`.
- **Named `SNAPSHOT_PAYLOAD_CONTRACT`** shared by the recorder and a new schema test — any drift between fixture payloads and the real `search.py` output envelope (required `results` list, typed title/url/snippet/score fields, no unknown top-level fields) now fails CI immediately.
- **Snapshot suite expanded 3 → 8** — one per live eval category (tech release, research/policy, JS extraction, hifi product, local realtime, German realtime, Reddit community, academic), payloads schema-derived from the existing provider-test fakes, each with source-quality assertions (canonical top domain, required/blocked domains, required terms, duplicate caps).
- `--snapshot-fixtures` now defaults to the canonical fixture path when invoked without an argument.

## Tests

- New contract tests (every fixture validates; unknown/mistyped fields rejected) and recorder tests (sanitization, happy/error paths, canonical-fixture refusal). The deterministic negative-path test for broken snapshots is unchanged and green.
- `python -m pytest tests/ -q` → 393 passed
- `ruff check .` → clean
- `python scripts/golden_eval.py --snapshot-fixtures` → exit 0 (8 snapshots, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)