### PR TITLE
feat(bench): persist bench history and show it in the web UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Added
+- Bench history: every `--bench` run now appends a compact record (per-provider score, success rate, median latency, error count, plus the recommended priority) to `bench_history.jsonl` in the cache directory — best-effort, opt out with `--no-history`. Inspect past runs with `python3 search.py --bench-history` (compact table, `--json` for raw records) or via the new read-only bench-history panel in the local web UI, which shows recent runs and per-provider score trends versus the previous run. The UI never starts a bench; benching stays CLI-only because it spends provider quota.
 - Local read-only web UI (`python3 ui.py`): a stdlib-only dashboard on `127.0.0.1` showing the doctor report, provider health/cooldowns, adaptive provider stats, and cache stats, plus an offline Routing v2 explainer (query in → routing class, confidence, signals, and provider scores out — no provider calls, no cost). Every request requires the startup-generated token, the Host header is validated against localhost to block DNS rebinding, and responses never contain key values.
 
 ### 🔧 Improved

--- a/bench.py
+++ b/bench.py
@@ -15,17 +15,21 @@ Two deliberate properties:
   ``record_provider_outcome`` (provider_stats adaptive-routing memory).
 
 The bench never writes configuration. Applying the recommended priority is an
-explicit operator step (``setup.py config set-priority ...``).
+explicit operator step (``setup.py config set-priority ...``). The only state
+a run leaves behind is an optional, best-effort history record in
+``bench_history.jsonl`` (cache directory) so runs can be compared over time.
 """
 
 from __future__ import annotations
 
 import importlib
+import json
 import statistics
 import time
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
+from cache import CACHE_DIR
 from config import (
     _validate_searxng_url,
     keyless_public_allowed,
@@ -84,6 +88,16 @@ QUALITY_WEIGHT_SNIPPET_COVERAGE = 0.5
 MIN_SNIPPET_CHARS = 40
 # Bench output is often pasted into issues; keep captured error strings short.
 ERROR_MESSAGE_MAX_CHARS = 200
+
+# Bench history: one compact JSONL record per completed bench run, so runs can
+# be compared over time (CLI --bench-history, UI bench-history panel). Kept in
+# the cache directory next to the other operational state files.
+BENCH_HISTORY_FILE = CACHE_DIR / "bench_history.jsonl"
+BENCH_HISTORY_SCHEMA_VERSION = 1
+# Default number of most-recent history records surfaced by readers.
+DEFAULT_BENCH_HISTORY_LIMIT = 20
+# Compact history table shows at most this many providers per run.
+BENCH_HISTORY_TOP_PROVIDERS = 3
 
 RECOMMENDATION_CONFIG_KEY = "auto_routing.provider_priority"
 RECOMMENDATION_NOTE = (
@@ -288,6 +302,116 @@ def _build_recommendation(ranked: List[str], current_priority: List[str]) -> Dic
     }
 
 
+def _history_record_from_report(report: Dict[str, Any], now: Optional[float] = None) -> Dict[str, Any]:
+    """Compact per-run history record derived from a full bench report."""
+    providers = []
+    for row in report.get("providers", []):
+        providers.append({
+            "provider": row.get("provider"),
+            "score": row.get("score"),
+            "success_rate": row.get("success_rate"),
+            "median_latency_seconds": row.get("median_latency_seconds"),
+            "error_count": len(row.get("errors") or []),
+        })
+    recommendation = report.get("recommendation") or {}
+    return {
+        "schema_version": BENCH_HISTORY_SCHEMA_VERSION,
+        "timestamp": round(float(now if now is not None else time.time()), 3),
+        "ok": bool(report.get("ok")),
+        "providers": providers,
+        "recommended_priority": list(recommendation.get("provider_priority") or []),
+    }
+
+
+def append_bench_history(report: Dict[str, Any], now: Optional[float] = None) -> bool:
+    """Append one compact history record for a finished bench run.
+
+    Best-effort, mirroring ``provider_stats.record_provider_outcome``: history
+    persistence must never break a bench run, so every error is swallowed.
+    The record is written as a single line via ``open(..., "a")`` (O_APPEND
+    semantics), keeping concurrent appends line-atomic enough for JSONL.
+    """
+    try:
+        line = json.dumps(_history_record_from_report(report, now=now), ensure_ascii=False) + "\n"
+        BENCH_HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        with open(BENCH_HISTORY_FILE, "a", encoding="utf-8") as handle:
+            handle.write(line)
+        return True
+    except Exception:  # noqa: BLE001 - history is best-effort by contract
+        return False
+
+
+def load_bench_history(limit: int = DEFAULT_BENCH_HISTORY_LIMIT) -> List[Dict[str, Any]]:
+    """Return the last ``limit`` bench history records, most recent first.
+
+    Tolerant by design: a missing file yields an empty list and corrupt or
+    non-record lines are skipped, so one torn write never hides the rest of
+    the history.
+    """
+    try:
+        with open(BENCH_HISTORY_FILE, "r", encoding="utf-8") as handle:
+            lines = handle.readlines()
+    except OSError:
+        return []
+    records: List[Dict[str, Any]] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            record = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(record, dict) and isinstance(record.get("providers"), list):
+            records.append(record)
+    if limit is not None and limit > 0:
+        records = records[-int(limit):]
+    records.reverse()
+    return records
+
+
+def _format_relative_time(seconds_ago: float) -> str:
+    """Coarse '5m ago' style rendering for the history table."""
+    seconds = max(0, int(seconds_ago))
+    if seconds < 60:
+        return "{}s ago".format(seconds)
+    if seconds < 3600:
+        return "{}m ago".format(seconds // 60)
+    if seconds < 86400:
+        return "{}h ago".format(seconds // 3600)
+    return "{}d ago".format(seconds // 86400)
+
+
+def format_bench_history_text(records: List[Dict[str, Any]], now: Optional[float] = None) -> str:
+    """Compact human-readable table of past bench runs, newest first."""
+    if not records:
+        return "\n".join([
+            "Web Search Plus Bench History",
+            "No bench runs yet — run: python3 search.py --bench",
+        ])
+    now_ts = float(now if now is not None else time.time())
+    lines = [
+        "Web Search Plus Bench History",
+        "Showing {} run(s), newest first:".format(len(records)),
+        "",
+        "  {:<10} {:<4} {}".format("when", "ok", "top providers (score)"),
+    ]
+    for record in records:
+        top = sorted(
+            record.get("providers") or [],
+            key=lambda row: -(row.get("score") or 0.0),
+        )[:BENCH_HISTORY_TOP_PROVIDERS]
+        top_text = ", ".join(
+            "{} ({:.2f})".format(row.get("provider"), float(row.get("score") or 0.0))
+            for row in top
+        ) or "(no providers)"
+        when = _format_relative_time(now_ts - float(record.get("timestamp") or 0.0))
+        lines.append(
+            "  {:<10} {:<4} {}".format(when, "yes" if record.get("ok") else "no", top_text)
+        )
+    return "\n".join(lines)
+
+
 def run_bench(
     config: Dict[str, Any],
     queries: Optional[List[Dict[str, str]]] = None,
@@ -295,13 +419,16 @@ def run_bench(
     max_results: int = DEFAULT_BENCH_MAX_RESULTS,
     timeout_budget: float = DEFAULT_BENCH_TIMEOUT_BUDGET_SECONDS,
     search_module: Optional[Any] = None,
+    record_history: bool = True,
 ) -> Dict[str, Any]:
     """Bench configured search providers in-process and rank them.
 
     Returns a structured report with per-provider metrics (best score first)
     plus an ``auto_routing.provider_priority`` recommendation. Provider errors
     are captured per query; a failing provider ranks last but never aborts the
-    run. Health cooldowns and adaptive routing stats are untouched.
+    run. Health cooldowns and adaptive routing stats are untouched. Unless
+    ``record_history`` is false, a compact record of the finished run is
+    appended (best-effort) to ``bench_history.jsonl`` in the cache directory.
     """
     search = _resolve_search_module(search_module)
     config = config if isinstance(config, dict) else {}
@@ -336,7 +463,7 @@ def run_bench(
     )
     ranked = [row["provider"] for row in rows]
 
-    return {
+    report = {
         "ok": any(row["success_count"] for row in rows),
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "query_count": len(suite),
@@ -351,6 +478,9 @@ def run_bench(
         "skipped_providers": skipped,
         "recommendation": _build_recommendation(ranked, current_priority),
     }
+    if record_history:
+        append_bench_history(report)
+    return report
 
 
 def format_bench_text(report: Dict[str, Any]) -> str:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -76,6 +76,8 @@ Two guarantees worth knowing:
 
 Note that the bench makes a few real API calls per provider, so it spends a small amount of quota on every configured provider.
 
+Each bench run is also recorded (best-effort — a failed write never breaks the bench) as one compact line in `bench_history.jsonl` inside the cache directory, so you can compare runs over time. Print the recent history with `python3 search.py --bench-history` (relative time plus the top providers by score per run; `--json` for the raw records), or view it as a panel in the local web UI. Pass `--no-history` to a bench run to skip recording it.
+
 ## Provider setup
 
 Keys live in the active Hermes environment file, normally `~/.hermes/.env`. The setup helper preserves existing entries and does not print secret values. See the generated [provider reference](PROVIDERS.md) for every provider's capabilities, env var, auto-routing default, free tier, and signup link.
@@ -355,6 +357,7 @@ The command prints a URL of the form `http://127.0.0.1:8765/?token=...` — open
 
 - Provider table: configured/keyless status, auto-routing participation, active cooldowns, and adaptive stats (success rate, median latency) when fresh samples exist.
 - Routing config summary and cache stats.
+- **Bench history**: the most recent recorded bench runs with per-provider scores, and — once at least two runs exist — a score trend (▲/▼ delta versus the previous run) per provider. The panel only displays recorded history; starting a bench stays a deliberate CLI action (`python3 search.py --bench`) because it spends provider quota.
 - **Routing explainer**: type a query and see the Routing v2 decision — routing class, chosen provider, confidence, matched signals, and the full provider score table. This runs the offline scoring only; it never calls a provider and costs nothing.
 
 Security properties, in plain terms:

--- a/search.py
+++ b/search.py
@@ -612,6 +612,8 @@ def run_provider_bench(config: Dict[str, Any], **kwargs) -> Dict[str, Any]:
 
 
 format_bench_text = _bench.format_bench_text
+load_bench_history = _bench.load_bench_history
+format_bench_history_text = _bench.format_bench_history_text
 
 
 def _format_doctor_text(report: Dict[str, Any]) -> str:
@@ -704,6 +706,16 @@ Full docs: See README.md and SKILL.md
         "--bench",
         action="store_true",
         help="Benchmark configured search providers against a fixed live query suite and recommend an auto_routing.provider_priority (alias for the 'bench' command; spends real provider quota)",
+    )
+    parser.add_argument(
+        "--no-history",
+        action="store_true",
+        help="Do not record this bench run in the local bench history (cache/bench_history.jsonl)",
+    )
+    parser.add_argument(
+        "--bench-history",
+        action="store_true",
+        help="Show recent recorded bench runs (relative time, top providers by score) and exit; no provider calls",
     )
 
     # Common arguments
@@ -1018,8 +1030,19 @@ def main():
             print(_format_doctor_text(report))
         return
 
+    if args.bench_history:
+        records = load_bench_history()
+        if args.json or args.compact:
+            indent = None if args.compact else 2
+            print(json.dumps(records, indent=indent, ensure_ascii=False))
+        else:
+            print(format_bench_history_text(records))
+        return
+
     if args.command == "bench" or args.bench:
-        report = run_provider_bench(config, max_results=args.max_results)
+        report = run_provider_bench(
+            config, max_results=args.max_results, record_history=not args.no_history
+        )
         if args.json or args.compact:
             indent = None if args.compact else 2
             print(json.dumps(report, indent=indent, ensure_ascii=False))

--- a/static/index.html
+++ b/static/index.html
@@ -35,6 +35,8 @@
   button { padding: 7px 16px; border: 1px solid var(--accent); background: var(--accent); color: #fff; border-radius: 6px; font-size: 14px; cursor: pointer; }
   button:hover { filter: brightness(1.08); }
   #route-result { margin-top: 14px; display: none; }
+  .trend-up { color: var(--ok); font-weight: 600; }
+  .trend-down { color: var(--bad); font-weight: 600; }
   #error-banner { display: none; background: #ffebe9; border: 1px solid #ff8182; color: var(--bad); border-radius: 8px; padding: 12px 16px; }
   .grid-2 { display: grid; gap: 20px; grid-template-columns: 1fr 1fr; }
   @media (max-width: 800px) { .grid-2 { grid-template-columns: 1fr; } }
@@ -67,6 +69,17 @@
       </tr></thead>
       <tbody></tbody>
     </table></div>
+  </section>
+
+  <section class="card">
+    <h2>Bench history <span class="muted">(recorded runs — the UI never starts a bench)</span></h2>
+    <div class="table-wrap"><table id="bench-history" style="display: none;">
+      <thead><tr>
+        <th>When</th><th>OK</th><th>Providers (score, trend vs. previous run)</th>
+      </tr></thead>
+      <tbody></tbody>
+    </table></div>
+    <p id="bench-history-empty" class="muted" style="display: none;">No bench runs yet — run <code>python3 search.py --bench</code>.</p>
   </section>
 
   <div class="grid-2">
@@ -196,6 +209,66 @@ function renderRouteResult(decision) {
   }
 }
 
+function formatRelativeTime(timestamp) {
+  const seconds = Math.max(0, Math.floor(Date.now() / 1000 - timestamp));
+  if (seconds < 60) return seconds + "s ago";
+  if (seconds < 3600) return Math.floor(seconds / 60) + "m ago";
+  if (seconds < 86400) return Math.floor(seconds / 3600) + "h ago";
+  return Math.floor(seconds / 86400) + "d ago";
+}
+
+function renderBenchHistory(payload) {
+  const runs = (payload && payload.runs) || [];
+  const table = document.getElementById("bench-history");
+  const empty = document.getElementById("bench-history-empty");
+  const tbody = table.querySelector("tbody");
+  tbody.textContent = "";
+  if (!runs.length) {
+    table.style.display = "none";
+    empty.style.display = "block";
+    return;
+  }
+  empty.style.display = "none";
+  table.style.display = "";
+  // Trend: score delta per provider between the latest and the previous run.
+  const previousScores = {};
+  if (runs.length >= 2) {
+    for (const p of runs[1].providers || []) {
+      if (typeof p.score === "number") previousScores[p.provider] = p.score;
+    }
+  }
+  runs.forEach((run, runIndex) => {
+    const row = document.createElement("tr");
+    row.appendChild(el("td", typeof run.timestamp === "number" ? formatRelativeTime(run.timestamp) : "—", "muted"));
+    const okCell = document.createElement("td");
+    okCell.appendChild(badge(run.ok ? "ok" : "failed", run.ok ? "ok" : "bad"));
+    row.appendChild(okCell);
+
+    const providersCell = document.createElement("td");
+    const providers = (run.providers || [])
+      .slice()
+      .sort((a, b) => (b.score || 0) - (a.score || 0));
+    providers.forEach((p, i) => {
+      if (i > 0) providersCell.appendChild(el("span", ", "));
+      const score = typeof p.score === "number" ? p.score.toFixed(2) : "—";
+      providersCell.appendChild(el("span", p.provider + " " + score));
+      const prev = previousScores[p.provider];
+      if (runIndex === 0 && typeof prev === "number" && typeof p.score === "number") {
+        const delta = p.score - prev;
+        if (Math.abs(delta) >= 0.005) {
+          const arrow = delta > 0 ? "▲" : "▼";
+          const sign = delta > 0 ? "+" : "";
+          providersCell.appendChild(el("span", " " + arrow + sign + delta.toFixed(2),
+                                       delta > 0 ? "trend-up" : "trend-down"));
+        }
+      }
+    });
+    if (!providers.length) providersCell.appendChild(el("span", "—", "muted"));
+    row.appendChild(providersCell);
+    tbody.appendChild(row);
+  });
+}
+
 async function loadOverview() {
   const overview = await api("/api/overview");
   document.getElementById("version").textContent = "v" + overview.version;
@@ -217,6 +290,8 @@ async function loadOverview() {
     ["Size", (cache.total_size_kb || 0) + " KB"],
     ["Directory", cache.cache_dir],
   ]);
+
+  renderBenchHistory(await api("/api/bench-history"));
 }
 
 document.getElementById("route-form").addEventListener("submit", async (event) => {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+import bench
 import provider_stats
 
 
@@ -10,5 +11,8 @@ def _isolate_provider_stats(tmp_path, monkeypatch):
     Search tests record outcomes for mocked providers; without isolation those
     samples would pollute the operator's provider_stats.json and, worse, feed
     back into routing decisions and make routing tests order-dependent.
+    Bench history is isolated for the same reason: bench tests run mocked
+    benches whose records must not land in the operator's real history file.
     """
     monkeypatch.setattr(provider_stats, "PROVIDER_STATS_FILE", tmp_path / "provider_stats.json")
+    monkeypatch.setattr(bench, "BENCH_HISTORY_FILE", tmp_path / "bench_history.jsonl")

--- a/tests/test_bench_history.py
+++ b/tests/test_bench_history.py
@@ -1,0 +1,236 @@
+"""Bench history coverage (persistence, CLI, and web UI panel).
+
+Locks down the bench-history guarantees: every bench run appends one compact
+JSONL record (opt-out via --no-history), history writing is best-effort and
+never breaks a bench, readers skip corrupt lines and honour the limit, and the
+read-only UI serves the records behind the same token auth as every other
+endpoint. All providers are mocked; no network. The conftest autouse fixture
+points bench.BENCH_HISTORY_FILE at a per-test tmp_path.
+"""
+
+from __future__ import annotations
+
+import http.client
+import importlib.util
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+import bench
+import search
+
+from test_bench import _clear_provider_env, _payload, _rich_results
+
+
+def _run_mocked_bench(monkeypatch, **kwargs):
+    _clear_provider_env(monkeypatch)
+    monkeypatch.setenv("YOU_API_KEY", "you-test-key")
+    monkeypatch.setattr(search, "search_you", lambda **kw: _payload("you", _rich_results()))
+    return search.run_provider_bench({"auto_routing": {}}, **kwargs)
+
+
+def _history_lines():
+    return bench.BENCH_HISTORY_FILE.read_text(encoding="utf-8").splitlines()
+
+
+def _record(timestamp, provider="you", score=0.9):
+    return {
+        "schema_version": bench.BENCH_HISTORY_SCHEMA_VERSION,
+        "timestamp": timestamp,
+        "ok": True,
+        "providers": [
+            {
+                "provider": provider,
+                "score": score,
+                "success_rate": 1.0,
+                "median_latency_seconds": 0.2,
+                "error_count": 0,
+            }
+        ],
+        "recommended_priority": [provider],
+    }
+
+
+def _write_history(records):
+    lines = [json.dumps(record) for record in records]
+    bench.BENCH_HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    bench.BENCH_HISTORY_FILE.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ----- persistence -----------------------------------------------------------
+
+
+def test_run_bench_appends_compact_history_record(monkeypatch):
+    report = _run_mocked_bench(monkeypatch)
+
+    lines = _history_lines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["schema_version"] == bench.BENCH_HISTORY_SCHEMA_VERSION
+    assert isinstance(record["timestamp"], float)
+    assert record["ok"] is True
+    assert record["recommended_priority"] == ["you"]
+    (row,) = record["providers"]
+    report_row = report["providers"][0]
+    assert row == {
+        "provider": "you",
+        "score": report_row["score"],
+        "success_rate": 1.0,
+        "median_latency_seconds": report_row["median_latency_seconds"],
+        "error_count": 0,
+    }
+
+
+def test_run_bench_record_history_false_writes_nothing(monkeypatch):
+    _run_mocked_bench(monkeypatch, record_history=False)
+    assert not bench.BENCH_HISTORY_FILE.exists()
+
+
+def test_history_write_failure_never_breaks_the_bench(monkeypatch, tmp_path):
+    # Parent path is a regular file, so mkdir/open must fail inside append.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    monkeypatch.setattr(bench, "BENCH_HISTORY_FILE", blocker / "bench_history.jsonl")
+
+    report = _run_mocked_bench(monkeypatch)
+
+    assert report["ok"] is True
+    assert bench.append_bench_history(report) is False
+
+
+def test_repeated_runs_accumulate_records(monkeypatch):
+    _run_mocked_bench(monkeypatch)
+    _run_mocked_bench(monkeypatch)
+    assert len(_history_lines()) == 2
+
+
+# ----- reading ---------------------------------------------------------------
+
+
+def test_load_bench_history_missing_file_returns_empty_list():
+    assert bench.load_bench_history() == []
+
+
+def test_load_bench_history_skips_corrupt_and_foreign_lines():
+    _write_history([_record(100.0), _record(200.0)])
+    with open(bench.BENCH_HISTORY_FILE, "a", encoding="utf-8") as handle:
+        handle.write("{truncated json\n")
+        handle.write("\n")
+        handle.write('"a bare string, not a record"\n')
+        handle.write('{"providers": "not-a-list"}\n')
+        handle.write(json.dumps(_record(300.0)) + "\n")
+
+    records = bench.load_bench_history()
+
+    assert [record["timestamp"] for record in records] == [300.0, 200.0, 100.0]
+
+
+def test_load_bench_history_returns_last_n_most_recent_first():
+    _write_history([_record(float(idx)) for idx in range(30)])
+
+    records = bench.load_bench_history(limit=5)
+
+    assert [record["timestamp"] for record in records] == [29.0, 28.0, 27.0, 26.0, 25.0]
+    assert len(bench.load_bench_history()) == bench.DEFAULT_BENCH_HISTORY_LIMIT
+
+
+# ----- CLI -------------------------------------------------------------------
+
+
+def _run_cli(monkeypatch, tmp_path, argv):
+    _clear_provider_env(monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"version": 1}))
+    monkeypatch.setenv("WEB_SEARCH_PLUS_CONFIG", str(config_path))
+    monkeypatch.setenv("YOU_API_KEY", "you-test-key")
+    monkeypatch.setattr(search, "search_you", lambda **kw: _payload("you", _rich_results()))
+    monkeypatch.setattr(sys, "argv", ["search.py"] + argv)
+    search.main()
+
+
+def test_cli_bench_records_history_and_no_history_opts_out(monkeypatch, tmp_path, capsys):
+    _run_cli(monkeypatch, tmp_path, ["--bench", "--json"])
+    assert len(_history_lines()) == 1
+
+    _run_cli(monkeypatch, tmp_path, ["--bench", "--no-history", "--json"])
+    assert len(_history_lines()) == 1  # unchanged
+
+
+def test_cli_bench_history_prints_compact_table(monkeypatch, tmp_path, capsys):
+    _run_cli(monkeypatch, tmp_path, ["--bench", "--json"])
+    capsys.readouterr()
+
+    _run_cli(monkeypatch, tmp_path, ["--bench-history"])
+
+    stdout = capsys.readouterr().out
+    assert "Web Search Plus Bench History" in stdout
+    assert "you (" in stdout
+    assert "ago" in stdout
+
+
+def test_cli_bench_history_empty_state_points_at_bench(monkeypatch, tmp_path, capsys):
+    _run_cli(monkeypatch, tmp_path, ["--bench-history"])
+    stdout = capsys.readouterr().out
+    assert "No bench runs yet" in stdout
+    assert "python3 search.py --bench" in stdout
+
+
+# ----- web UI ----------------------------------------------------------------
+
+UI_PATH = Path(__file__).resolve().parents[1] / "ui.py"
+ui_spec = importlib.util.spec_from_file_location("wsp_ui_bench_history_under_test", UI_PATH)
+ui = importlib.util.module_from_spec(ui_spec)
+assert ui_spec.loader is not None
+ui_spec.loader.exec_module(ui)
+
+TOKEN = "test-ui-token"
+
+
+@pytest.fixture()
+def ui_server():
+    server = ui.create_server(port=0, token=TOKEN)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _get(server, path, token=TOKEN):
+    conn = http.client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=10)
+    headers = {"X-WSP-Token": token} if token is not None else {}
+    conn.request("GET", path, headers=headers)
+    response = conn.getresponse()
+    raw = response.read()
+    conn.close()
+    return response, raw
+
+
+def test_ui_bench_history_requires_token(ui_server):
+    response, _ = _get(ui_server, "/api/bench-history", token=None)
+    assert response.status == 401
+    response, _ = _get(ui_server, "/api/bench-history", token="wrong-token")
+    assert response.status == 401
+
+
+def test_ui_bench_history_returns_recorded_runs(ui_server):
+    _write_history([_record(100.0, score=0.8), _record(200.0, score=0.9)])
+
+    response, raw = _get(ui_server, "/api/bench-history")
+
+    assert response.status == 200
+    payload = json.loads(raw)
+    assert [run["timestamp"] for run in payload["runs"]] == [200.0, 100.0]
+    assert payload["runs"][0]["providers"][0]["score"] == 0.9
+
+
+def test_ui_bench_history_empty_state_is_empty_list(ui_server):
+    response, raw = _get(ui_server, "/api/bench-history")
+    assert response.status == 200
+    assert json.loads(raw) == {"runs": []}

--- a/ui.py
+++ b/ui.py
@@ -2,8 +2,8 @@
 """Local read-only web UI for Web Search Plus diagnostics.
 
 Serves a single-page dashboard on 127.0.0.1 with the doctor report, provider
-health/cooldowns, adaptive provider stats, cache stats, and an offline
-Routing v2 explainer.
+health/cooldowns, adaptive provider stats, cache stats, recorded bench-run
+history, and an offline Routing v2 explainer.
 
 Security model (see docs/USER_GUIDE.md, "Local web UI"):
 
@@ -53,7 +53,7 @@ def _assert_no_host_module_collision() -> None:
     ways later. The plugin's __init__ handles that via its module stash; ui
     deliberately does not duplicate that machinery and refuses instead.
     """
-    for name in ("search", "cache", "config", "providers", "routing", "provider_registry", "provider_stats"):
+    for name in ("search", "cache", "config", "providers", "routing", "provider_registry", "provider_stats", "bench"):
         existing = sys.modules.get(name)
         module_file = getattr(existing, "__file__", None) if existing is not None else None
         if module_file and Path(module_file).resolve().parent != _PLUGIN_DIR:
@@ -67,6 +67,7 @@ def _assert_no_host_module_collision() -> None:
 
 _assert_no_host_module_collision()
 
+import bench as _bench  # noqa: E402
 import cache as _cache  # noqa: E402
 import search as _search  # noqa: E402
 from config import load_config  # noqa: E402
@@ -122,6 +123,13 @@ def build_overview() -> Dict[str, Any]:
         "provider_stats": {name: get_provider_performance(name) for name in PROVIDER_SPECS},
         "cache": _cache.cache_stats(),
     }
+
+
+def build_bench_history() -> Dict[str, Any]:
+    """Recent recorded bench runs, most recent first. Read-only: the UI never
+    triggers a bench run itself — benching spends provider quota and stays a
+    deliberate CLI action (``python3 search.py --bench``)."""
+    return {"runs": _bench.load_bench_history()}
 
 
 def explain_route(query: str) -> Dict[str, Any]:
@@ -201,6 +209,8 @@ class _UIRequestHandler(BaseHTTPRequestHandler):
             self._serve_index()
         elif parsed.path == "/api/overview":
             self._send_json(200, build_overview())
+        elif parsed.path == "/api/bench-history":
+            self._send_json(200, build_bench_history())
         else:
             self._deny(404, "Unknown path.")
 


### PR DESCRIPTION
## Summary

**Stacked on #76 (web UI)** — the base branch of this PR is `claude/web-ui`; merge #76 first, then retarget this to `main`.

Bench runs (#72) previously discarded their results. This PR turns the one-shot bakeoff into trend monitoring:

- Each bench run appends a compact JSONL record to `bench_history.jsonl` in the cache dir: per-provider score, success rate, median latency, error count, and the recommended priority. `--no-history` opts out.
- History writes are best-effort (mirroring `record_provider_outcome`) — a failed write can never break a bench run.
- New `python3 search.py --bench-history` prints a compact table of recent runs (relative time, top-3 providers by score), tolerant of corrupt lines; `--json` emits raw records.
- New read-only `GET /api/bench-history` endpoint and a dashboard panel with per-provider score trends (▲/▼ delta vs. the previous run when ≥2 runs exist), plus an empty state pointing to `python3 search.py --bench`.
- The UI security model is unchanged: same token/Host auth, rendering strictly via `textContent`, and the UI still cannot *trigger* a bench — quota-costing runs stay CLI-only.

## Tests

- 12 new tests: persistence after mocked runs, record shape, `--no-history`, write-failure tolerance, corrupt-line skipping, limit, CLI table + empty state, UI auth (200 with token / 401 without). All offline.
- The autouse conftest isolation fixture now also redirects bench history to `tmp_path`, keeping tests out of the operator's real cache dir.
- Rebased onto the updated #76 (v2.8.1 base): `python -m pytest tests/ -q` → 410 passed
- `ruff check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)