### PR TITLE
refactor: registry-driven provider dispatch

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -37,10 +37,12 @@ try:  # Package load path used by Hermes plugin discovery.
         DEFAULT_AUTO_ALLOW,
         DEFAULT_PROVIDER_PRIORITY,
         EXTRACT_PROVIDER_ENV_KEYS,
+        EXTRACT_PROVIDER_IDS,
         KEYLESS_EXTRACT_PROVIDER_IDS,
         KEYLESS_PROVIDER_IDS,
         PROVIDER_ENV_KEYS,
         PROVIDER_SPECS,
+        SEARCH_PROVIDER_IDS,
         keyless_public_env_var,
         plugin_catalog,
     )
@@ -52,10 +54,12 @@ except ImportError:  # Direct script/test imports from the plugin directory.
         DEFAULT_AUTO_ALLOW,
         DEFAULT_PROVIDER_PRIORITY,
         EXTRACT_PROVIDER_ENV_KEYS,
+        EXTRACT_PROVIDER_IDS,
         KEYLESS_EXTRACT_PROVIDER_IDS,
         KEYLESS_PROVIDER_IDS,
         PROVIDER_ENV_KEYS,
         PROVIDER_SPECS,
+        SEARCH_PROVIDER_IDS,
         keyless_public_env_var,
         plugin_catalog,
     )
@@ -1129,6 +1133,7 @@ def _load_search_module() -> Any:
             "http_client",
             "env_loader",
             "provider_health",
+            "provider_dispatch",
             "provider_registry",
         )
         stashed: dict[str, Any] = {}
@@ -1584,7 +1589,7 @@ def register(ctx: Any) -> None:
                 },
                 "provider": {
                     "type": "string",
-                    "enum": ["auto", "serper", "serpbase", "brave", "tavily", "exa", "querit", "linkup", "firecrawl", "parallel", "perplexity", "kilo-perplexity", "you", "searxng", "keenable"],
+                    "enum": ["auto", *SEARCH_PROVIDER_IDS],
                     "description": "Search provider. Use 'auto' for intelligent routing (default). Brave and Serper share generic web-search intents and ties are distributed deterministically per query.",
                     "default": "auto",
                 },
@@ -1714,7 +1719,7 @@ def register(ctx: Any) -> None:
             "type": "object",
             "properties": {
                 "urls": {"type": "array", "items": {"type": "string"}, "description": "URLs to extract"},
-                "provider": {"type": "string", "enum": ["auto", "firecrawl", "linkup", "parallel", "tavily", "exa", "you", "keenable"], "default": "auto"},
+                "provider": {"type": "string", "enum": ["auto", *EXTRACT_PROVIDER_IDS], "default": "auto"},
                 "format": {"type": "string", "enum": ["markdown", "html"], "default": "markdown"},
                 "include_images": {"type": "boolean", "default": False},
                 "include_raw_html": {"type": "boolean", "default": False},

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,8 @@ The plugin does not run a separate hosted backend. It does not add an analytics 
 - `plugin.yaml`: plugin manifest, optional environment variables, onboarding commands, and tool declarations.
 - `__init__.py`: Hermes plugin entrypoint, tool schemas, setup/onboarding helpers, and wrapper functions exposed to Hermes.
 - `search.py`: provider adapters, routing, caching, cooldowns, extraction, and CLI.
+- `provider_registry.py`: data-only provider metadata registry (single source of truth).
+- `provider_dispatch.py`: registry-driven `SEARCH_DISPATCH`/`EXTRACT_DISPATCH` adapter tables used by `search.py` and `extract.py`.
 - `setup.py`: thin standalone CLI entrypoint that loads setup helpers from `__init__.py`.
 - `tests/`: unit and regression coverage for providers, onboarding, routing, extraction, and docs-sensitive configuration.
 
@@ -215,15 +217,24 @@ The plugin does not promise “no data leaves your machine.” A more accurate s
 
 ## Extending with a new provider
 
+Provider wiring is registry-driven. `provider_registry.py` is the data-only
+single source of truth (id, env var, capabilities, onboarding metadata,
+`auto_allow` default), and `provider_dispatch.py` maps each provider id to a
+search/extract adapter in `SEARCH_DISPATCH` / `EXTRACT_DISPATCH`. CLI choices,
+tool-schema enums, doctor output, onboarding, and extraction priority all
+derive from the registry, and completeness tests
+(`tests/test_provider_dispatch.py`) fail if a registry entry has no dispatch
+adapter or vice versa — a new provider can no longer be silently forgotten on
+one surface.
+
 A provider addition should include:
 
-- provider adapter function in `search.py`
-- API key mapping in runtime and onboarding code
-- provider metadata in setup/list/status output
-- routing score/match behavior if it participates in auto-routing
-- explicit default `auto_allow` decision
-- docs in README, User Guide, FAQ, and Architecture when behavior is user-visible
-- tests for response normalization, missing-key behavior, routing eligibility, onboarding metadata, and CLI/provider choices
+- a `ProviderSpec` entry in `provider_registry.py` (id, env var, capabilities, `auto_allow` default)
+- provider function(s) in `providers.py` (`search_<provider>`, optionally `extract_<provider>`) plus the `search.py` seam wrapper
+- a dispatch adapter per capability in `provider_dispatch.py`, registered in `SEARCH_DISPATCH`/`EXTRACT_DISPATCH`
+- routing score/match behavior in `routing.py` if it participates in auto-routing
+- docs in README, User Guide, FAQ, and Architecture when behavior is user-visible (`docs/PROVIDERS.md` regenerates from the registry)
+- tests for response normalization and missing-key behavior (dispatch/enum/onboarding completeness is enforced by existing registry-driven tests)
 
 Default stance: new or surprising providers should start explicit-only until their cost and quality characteristics are boring enough for automatic fallback.
 

--- a/extract.py
+++ b/extract.py
@@ -12,7 +12,10 @@ from provider_health import (
     provider_in_cooldown,
     reset_provider_health,
 )
-from providers import (
+# These imports stay module-level attributes on purpose: search.py's
+# _sync_extract_dependencies() overwrites them for monkeypatch compatibility,
+# and provider_dispatch adapters resolve them late through this module.
+from providers import (  # noqa: F401 - resolved late via EXTRACT_DISPATCH/monkeypatch seams
     extract_exa,
     extract_firecrawl,
     extract_keenable,
@@ -21,6 +24,7 @@ from providers import (
     extract_tavily,
     extract_you,
 )
+from provider_dispatch import EXTRACT_DISPATCH
 from provider_registry import EXTRACT_PROVIDER_IDS
 
 
@@ -138,33 +142,14 @@ def extract_plus(
             continue
         try:
             def execute_extract() -> Dict[str, Any]:
-                if prov == "firecrawl":
-                    fc = config.get("firecrawl", {})
-                    return extract_firecrawl(urls, key, output_format, include_images, include_raw_html, render_js, api_url=fc.get("scrape_url", "https://api.firecrawl.dev/v2/scrape"), timeout=int(fc.get("extract_timeout", 60)))
-                if prov == "linkup":
-                    lu = config.get("linkup", {})
-                    return extract_linkup(urls, key, output_format, include_images, include_raw_html, render_js, api_url=lu.get("fetch_url", "https://api.linkup.so/v1/fetch"), timeout=int(lu.get("timeout", 30)))
-                if prov == "tavily":
-                    tv = config.get("tavily", {})
-                    return extract_tavily(urls, key, output_format, include_images, include_raw_html, render_js, api_url=tv.get("extract_url", "https://api.tavily.com/extract"), timeout=int(tv.get("timeout", 30)))
-                if prov == "exa":
-                    exa = config.get("exa", {})
-                    return extract_exa(urls, key, output_format, include_images, include_raw_html, render_js, api_url=exa.get("contents_url", "https://api.exa.ai/contents"), timeout=int(exa.get("timeout", 30)))
-                if prov == "parallel":
-                    parallel = config.get("parallel", {})
-                    return extract_parallel(
-                        urls, key, output_format, include_images, include_raw_html, render_js,
-                        api_url=parallel.get("extract_url", "https://api.parallel.ai/v1/extract"),
-                        timeout=int(parallel.get("extract_timeout", parallel.get("timeout", 60))),
-                        client_model=parallel.get("client_model"),
-                        max_chars_total=int(parallel.get("max_chars_total", 12000)),
-                        max_chars_per_result=int(parallel.get("max_chars_per_result", 6000)),
-                    )
-                if prov == "keenable":
-                    kn = config.get("keenable", {})
-                    return extract_keenable(urls, key, output_format, include_images, include_raw_html, render_js, public=keyless_allowed, api_url=kn.get("fetch_url", "https://api.keenable.ai/v1/fetch"), timeout=int(kn.get("timeout", 30)))
-                you = config.get("you", {})
-                return extract_you(urls, key, output_format, include_images, include_raw_html, render_js, api_url=you.get("contents_url", "https://ydc-index.io/v1/contents"), timeout=int(you.get("timeout", 30)))
+                # Provider-specific kwargs-building lives in
+                # provider_dispatch.EXTRACT_DISPATCH; the caller namespace
+                # (globals()) is passed so adapters resolve extract_<provider>
+                # late and honour monkeypatches synced onto this module.
+                adapter = EXTRACT_DISPATCH.get(prov)
+                if adapter is None:
+                    raise ValueError(f"Unknown extract provider: {prov}")
+                return adapter(globals(), prov, urls, key, output_format, include_images, include_raw_html, render_js, config, keyless_allowed)
 
             result = execute_provider_with_retry(prov, execute_extract)
             res_list = result.get("results") or []

--- a/provider_dispatch.py
+++ b/provider_dispatch.py
@@ -1,0 +1,321 @@
+"""Registry-driven provider dispatch tables for Web Search Plus.
+
+This module replaces the historical if/elif provider chains in ``search.py``
+(``execute_search``) and ``extract.py`` (``execute_extract``) with explicit
+per-provider adapters registered in ``SEARCH_DISPATCH`` / ``EXTRACT_DISPATCH``.
+Each adapter encapsulates exactly the provider-specific kwargs-building the
+old chain branch did, so behaviour is unchanged.
+
+Monkeypatch seam contract (do not early-bind provider functions here):
+tests patch provider functions on the *calling module* (for example
+``mock.patch.object(search, "search_you", ...)`` or
+``mock.patch("search.extract_firecrawl", ...)``). Adapters therefore receive
+the caller's namespace (a module object or its ``globals()`` dict) and resolve
+``search_<provider>`` / ``extract_<provider>`` late on every call — the same
+late-resolution pattern ``bench.py`` uses via its ``search_module`` seam.
+
+``provider_registry.py`` stays data-only by design; the callable wiring lives
+here. tests/test_provider_dispatch.py enforces that these tables and the
+registry capability flags can never drift apart.
+"""
+
+from typing import Any, Callable, Dict
+
+from config import DEFAULT_CONFIG, _validate_searxng_url, keyless_public_allowed
+
+
+def _resolve(namespace: Any, name: str) -> Callable[..., Dict[str, Any]]:
+    """Late-resolve a provider function from the caller's namespace.
+
+    Accepts either a module object (``getattr`` lookup, like bench.py's
+    ``search_module`` seam) or a ``globals()`` dict, so callers loaded under
+    non-standard module names (spec_from_file_location in tests) work too.
+    """
+    if isinstance(namespace, dict):
+        return namespace[name]
+    return getattr(namespace, name)
+
+
+# =============================================================================
+# Search adapters — one per provider, kwargs identical to the old
+# search.py execute_search() if/elif branches.
+# =============================================================================
+
+
+def _call_serper_search(search_module, prov, args, key, config, routing_info):
+    return _resolve(search_module, "search_serper")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        country=args.country,
+        language=args.language,
+        search_type=args.search_type,
+        time_range=args.time_range or args.freshness,
+        include_images=args.images,
+    )
+
+
+def _call_serpbase_search(search_module, prov, args, key, config, routing_info):
+    serpbase_config = config.get("serpbase", {})
+    return _resolve(search_module, "search_serpbase")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        country=serpbase_config.get("country", args.country),
+        language=serpbase_config.get("language", args.language),
+        page=int(serpbase_config.get("page", 1)),
+        api_url=serpbase_config.get("api_url", "https://api.serpbase.dev/google/search"),
+        timeout=int(serpbase_config.get("timeout", 30)),
+    )
+
+
+def _call_brave_search(search_module, prov, args, key, config, routing_info):
+    brave_config = config.get("brave", {})
+    return _resolve(search_module, "search_brave")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        country=brave_config.get("country", args.country),
+        language=brave_config.get("search_lang", args.language),
+        time_range=args.time_range or args.freshness,
+        safesearch=brave_config.get("safesearch", "moderate"),
+    )
+
+
+def _call_tavily_search(search_module, prov, args, key, config, routing_info):
+    return _resolve(search_module, "search_tavily")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        depth=args.depth,
+        topic=args.topic,
+        include_domains=args.include_domains,
+        exclude_domains=args.exclude_domains,
+        include_images=args.images,
+        include_raw_content=args.raw_content,
+    )
+
+
+def _call_linkup_search(search_module, prov, args, key, config, routing_info):
+    linkup_config = config.get("linkup", {})
+    return _resolve(search_module, "search_linkup")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        depth=args.linkup_depth,
+        output_type=args.linkup_output_type,
+        include_domains=args.include_domains,
+        exclude_domains=args.exclude_domains,
+        api_url=linkup_config.get("api_url", "https://api.linkup.so/v1/search"),
+        timeout=int(linkup_config.get("timeout", 30)),
+    )
+
+
+def _call_querit_search(search_module, prov, args, key, config, routing_info):
+    querit_config = config.get("querit", {})
+    return _resolve(search_module, "search_querit")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        language=args.language,
+        country=args.country,
+        time_range=args.time_range or args.freshness,
+        include_domains=args.include_domains,
+        exclude_domains=args.exclude_domains,
+        base_url=args.querit_base_url,
+        base_path=args.querit_base_path,
+        timeout=int(querit_config.get("timeout", 30)),
+    )
+
+
+def _call_exa_search(search_module, prov, args, key, config, routing_info):
+    # CLI --exa-depth overrides; fallback to auto-routing suggestion
+    exa_depth = args.exa_depth
+    if exa_depth == "normal" and routing_info.get("exa_depth") in ("deep", "deep-reasoning"):
+        exa_depth = routing_info["exa_depth"]
+    return _resolve(search_module, "search_exa")(
+        query=args.query or "",
+        api_key=key,
+        max_results=args.max_results,
+        search_type=args.exa_type,
+        exa_depth=exa_depth,
+        category=args.category,
+        start_date=args.start_date,
+        end_date=args.end_date,
+        similar_url=args.similar_url,
+        include_domains=args.include_domains,
+        exclude_domains=args.exclude_domains,
+        text_verbosity=args.exa_verbosity,
+    )
+
+
+def _call_firecrawl_search(search_module, prov, args, key, config, routing_info):
+    firecrawl_config = config.get("firecrawl", {})
+    return _resolve(search_module, "search_firecrawl")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        country=firecrawl_config.get("country", args.country),
+        time_range=args.time_range or args.freshness,
+        sources=args.firecrawl_sources,
+        include_domains=args.include_domains,
+        exclude_domains=args.exclude_domains,
+        scrape_markdown=args.firecrawl_scrape or args.raw_content,
+        ignore_invalid_urls=firecrawl_config.get("ignore_invalid_urls", False),
+        api_url=firecrawl_config.get("api_url", "https://api.firecrawl.dev/v2/search"),
+        timeout_ms=int(firecrawl_config.get("timeout", 30000)),
+    )
+
+
+def _call_parallel_search(search_module, prov, args, key, config, routing_info):
+    parallel_config = config.get("parallel", {})
+    return _resolve(search_module, "search_parallel")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        include_domains=args.include_domains,
+        exclude_domains=args.exclude_domains,
+        api_url=parallel_config.get("api_url", "https://api.parallel.ai/v1/search"),
+        timeout=int(parallel_config.get("timeout", 45)),
+        client_model=parallel_config.get("client_model"),
+    )
+
+
+def _call_perplexity_search(search_module, prov, args, key, config, routing_info):
+    """Shared adapter for both ``perplexity`` and ``kilo-perplexity``."""
+    perplexity_config = config.get(prov, {})
+    defaults = DEFAULT_CONFIG.get(prov, {})
+    return _resolve(search_module, "search_perplexity")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        model=perplexity_config.get("model", defaults.get("model", "sonar-pro")),
+        api_url=perplexity_config.get("api_url", defaults.get("api_url", "https://api.perplexity.ai/chat/completions")),
+        freshness=getattr(args, "freshness", None),
+        provider_name=prov,
+    )
+
+
+def _call_you_search(search_module, prov, args, key, config, routing_info):
+    return _resolve(search_module, "search_you")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        country=args.country,
+        language=args.language,
+        freshness=args.freshness,
+        safesearch=args.you_safesearch,
+        include_news=not args.no_news,
+        livecrawl=args.livecrawl,
+    )
+
+
+def _call_searxng_search(search_module, prov, args, key, config, routing_info):
+    # For SearXNG, 'key' is actually the instance URL
+    instance_url = args.searxng_url or key
+    if instance_url:
+        instance_url = _validate_searxng_url(instance_url)
+    return _resolve(search_module, "search_searxng")(
+        query=args.query,
+        instance_url=instance_url,
+        max_results=args.max_results,
+        categories=args.categories,
+        engines=args.engines,
+        language=args.language,
+        time_range=args.time_range or args.freshness,
+        safesearch=args.searxng_safesearch,
+    )
+
+
+def _call_keenable_search(search_module, prov, args, key, config, routing_info):
+    keenable_config = config.get("keenable", {})
+    return _resolve(search_module, "search_keenable")(
+        query=args.query,
+        api_key=key,
+        max_results=args.max_results,
+        time_range=args.time_range or args.freshness,
+        include_domains=args.include_domains,
+        public=keyless_public_allowed(prov, config),
+        api_url=keenable_config.get("search_url", "https://api.keenable.ai/v1/search"),
+        timeout=int(keenable_config.get("timeout", 30)),
+    )
+
+
+# Adapter signature: (search_module, provider, args, key, config, routing_info) -> result dict.
+SEARCH_DISPATCH: Dict[str, Callable[..., Dict[str, Any]]] = {
+    "serper": _call_serper_search,
+    "serpbase": _call_serpbase_search,
+    "brave": _call_brave_search,
+    "tavily": _call_tavily_search,
+    "querit": _call_querit_search,
+    "linkup": _call_linkup_search,
+    "exa": _call_exa_search,
+    "firecrawl": _call_firecrawl_search,
+    "parallel": _call_parallel_search,
+    "perplexity": _call_perplexity_search,
+    "kilo-perplexity": _call_perplexity_search,
+    "you": _call_you_search,
+    "searxng": _call_searxng_search,
+    "keenable": _call_keenable_search,
+}
+
+
+# =============================================================================
+# Extract adapters — one per provider, kwargs identical to the old
+# extract.py execute_extract() if-chain branches.
+# =============================================================================
+
+
+def _call_firecrawl_extract(extract_module, prov, urls, key, output_format, include_images, include_raw_html, render_js, config, keyless_allowed):
+    fc = config.get("firecrawl", {})
+    return _resolve(extract_module, "extract_firecrawl")(urls, key, output_format, include_images, include_raw_html, render_js, api_url=fc.get("scrape_url", "https://api.firecrawl.dev/v2/scrape"), timeout=int(fc.get("extract_timeout", 60)))
+
+
+def _call_linkup_extract(extract_module, prov, urls, key, output_format, include_images, include_raw_html, render_js, config, keyless_allowed):
+    lu = config.get("linkup", {})
+    return _resolve(extract_module, "extract_linkup")(urls, key, output_format, include_images, include_raw_html, render_js, api_url=lu.get("fetch_url", "https://api.linkup.so/v1/fetch"), timeout=int(lu.get("timeout", 30)))
+
+
+def _call_tavily_extract(extract_module, prov, urls, key, output_format, include_images, include_raw_html, render_js, config, keyless_allowed):
+    tv = config.get("tavily", {})
+    return _resolve(extract_module, "extract_tavily")(urls, key, output_format, include_images, include_raw_html, render_js, api_url=tv.get("extract_url", "https://api.tavily.com/extract"), timeout=int(tv.get("timeout", 30)))
+
+
+def _call_exa_extract(extract_module, prov, urls, key, output_format, include_images, include_raw_html, render_js, config, keyless_allowed):
+    exa = config.get("exa", {})
+    return _resolve(extract_module, "extract_exa")(urls, key, output_format, include_images, include_raw_html, render_js, api_url=exa.get("contents_url", "https://api.exa.ai/contents"), timeout=int(exa.get("timeout", 30)))
+
+
+def _call_parallel_extract(extract_module, prov, urls, key, output_format, include_images, include_raw_html, render_js, config, keyless_allowed):
+    parallel = config.get("parallel", {})
+    return _resolve(extract_module, "extract_parallel")(
+        urls, key, output_format, include_images, include_raw_html, render_js,
+        api_url=parallel.get("extract_url", "https://api.parallel.ai/v1/extract"),
+        timeout=int(parallel.get("extract_timeout", parallel.get("timeout", 60))),
+        client_model=parallel.get("client_model"),
+        max_chars_total=int(parallel.get("max_chars_total", 12000)),
+        max_chars_per_result=int(parallel.get("max_chars_per_result", 6000)),
+    )
+
+
+def _call_keenable_extract(extract_module, prov, urls, key, output_format, include_images, include_raw_html, render_js, config, keyless_allowed):
+    kn = config.get("keenable", {})
+    return _resolve(extract_module, "extract_keenable")(urls, key, output_format, include_images, include_raw_html, render_js, public=keyless_allowed, api_url=kn.get("fetch_url", "https://api.keenable.ai/v1/fetch"), timeout=int(kn.get("timeout", 30)))
+
+
+def _call_you_extract(extract_module, prov, urls, key, output_format, include_images, include_raw_html, render_js, config, keyless_allowed):
+    you = config.get("you", {})
+    return _resolve(extract_module, "extract_you")(urls, key, output_format, include_images, include_raw_html, render_js, api_url=you.get("contents_url", "https://ydc-index.io/v1/contents"), timeout=int(you.get("timeout", 30)))
+
+
+# Adapter signature: (extract_module, provider, urls, key, output_format,
+# include_images, include_raw_html, render_js, config, keyless_allowed) -> result dict.
+EXTRACT_DISPATCH: Dict[str, Callable[..., Dict[str, Any]]] = {
+    "firecrawl": _call_firecrawl_extract,
+    "linkup": _call_linkup_extract,
+    "tavily": _call_tavily_extract,
+    "exa": _call_exa_extract,
+    "parallel": _call_parallel_extract,
+    "keenable": _call_keenable_extract,
+    "you": _call_you_extract,
+}

--- a/search.py
+++ b/search.py
@@ -81,6 +81,7 @@ from quality import (  # noqa: F401 - re-exported for backward-compatible tests/
     rerank_results_for_intent,
     select_research_providers,
 )
+from provider_dispatch import SEARCH_DISPATCH
 from provider_registry import PROVIDER_SPECS, SEARCH_PROVIDER_IDS, doctor_catalog
 from env_loader import load_env_files
 from research import run_research_mode
@@ -1151,183 +1152,16 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
     if not eligible_providers:
         eligible_providers = providers_to_try[:1]
 
-    # Helper function to execute search for a provider
+    # Helper function to execute search for a provider. Provider-specific
+    # kwargs-building lives in provider_dispatch.SEARCH_DISPATCH; the caller
+    # namespace (globals()) is passed so adapters resolve search_<provider>
+    # late and honour monkeypatches on this module (search.search_you etc.).
     def execute_search(prov: str) -> Dict[str, Any]:
         key = validate_api_key(prov, config)
-        if prov == "serper":
-            return search_serper(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                country=args.country,
-                language=args.language,
-                search_type=args.search_type,
-                time_range=args.time_range or args.freshness,
-                include_images=args.images,
-            )
-        elif prov == "serpbase":
-            serpbase_config = config.get("serpbase", {})
-            return search_serpbase(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                country=serpbase_config.get("country", args.country),
-                language=serpbase_config.get("language", args.language),
-                page=int(serpbase_config.get("page", 1)),
-                api_url=serpbase_config.get("api_url", "https://api.serpbase.dev/google/search"),
-                timeout=int(serpbase_config.get("timeout", 30)),
-            )
-        elif prov == "brave":
-            brave_config = config.get("brave", {})
-            return search_brave(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                country=brave_config.get("country", args.country),
-                language=brave_config.get("search_lang", args.language),
-                time_range=args.time_range or args.freshness,
-                safesearch=brave_config.get("safesearch", "moderate"),
-            )
-        elif prov == "tavily":
-            return search_tavily(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                depth=args.depth,
-                topic=args.topic,
-                include_domains=args.include_domains,
-                exclude_domains=args.exclude_domains,
-                include_images=args.images,
-                include_raw_content=args.raw_content,
-            )
-        elif prov == "linkup":
-            linkup_config = config.get("linkup", {})
-            return search_linkup(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                depth=args.linkup_depth,
-                output_type=args.linkup_output_type,
-                include_domains=args.include_domains,
-                exclude_domains=args.exclude_domains,
-                api_url=linkup_config.get("api_url", "https://api.linkup.so/v1/search"),
-                timeout=int(linkup_config.get("timeout", 30)),
-            )
-        elif prov == "querit":
-            querit_config = config.get("querit", {})
-            return search_querit(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                language=args.language,
-                country=args.country,
-                time_range=args.time_range or args.freshness,
-                include_domains=args.include_domains,
-                exclude_domains=args.exclude_domains,
-                base_url=args.querit_base_url,
-                base_path=args.querit_base_path,
-                timeout=int(querit_config.get("timeout", 30)),
-            )
-        elif prov == "exa":
-            # CLI --exa-depth overrides; fallback to auto-routing suggestion
-            exa_depth = args.exa_depth
-            if exa_depth == "normal" and routing_info.get("exa_depth") in ("deep", "deep-reasoning"):
-                exa_depth = routing_info["exa_depth"]
-            return search_exa(
-                query=args.query or "",
-                api_key=key,
-                max_results=args.max_results,
-                search_type=args.exa_type,
-                exa_depth=exa_depth,
-                category=args.category,
-                start_date=args.start_date,
-                end_date=args.end_date,
-                similar_url=args.similar_url,
-                include_domains=args.include_domains,
-                exclude_domains=args.exclude_domains,
-                text_verbosity=args.exa_verbosity,
-            )
-        elif prov == "firecrawl":
-            firecrawl_config = config.get("firecrawl", {})
-            return search_firecrawl(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                country=firecrawl_config.get("country", args.country),
-                time_range=args.time_range or args.freshness,
-                sources=args.firecrawl_sources,
-                include_domains=args.include_domains,
-                exclude_domains=args.exclude_domains,
-                scrape_markdown=args.firecrawl_scrape or args.raw_content,
-                ignore_invalid_urls=firecrawl_config.get("ignore_invalid_urls", False),
-                api_url=firecrawl_config.get("api_url", "https://api.firecrawl.dev/v2/search"),
-                timeout_ms=int(firecrawl_config.get("timeout", 30000)),
-            )
-        elif prov == "parallel":
-            parallel_config = config.get("parallel", {})
-            return search_parallel(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                include_domains=args.include_domains,
-                exclude_domains=args.exclude_domains,
-                api_url=parallel_config.get("api_url", "https://api.parallel.ai/v1/search"),
-                timeout=int(parallel_config.get("timeout", 45)),
-                client_model=parallel_config.get("client_model"),
-            )
-        elif prov in {"perplexity", "kilo-perplexity"}:
-            perplexity_config = config.get(prov, {})
-            defaults = DEFAULT_CONFIG.get(prov, {})
-            return search_perplexity(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                model=perplexity_config.get("model", defaults.get("model", "sonar-pro")),
-                api_url=perplexity_config.get("api_url", defaults.get("api_url", "https://api.perplexity.ai/chat/completions")),
-                freshness=getattr(args, "freshness", None),
-                provider_name=prov,
-            )
-        elif prov == "you":
-            return search_you(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                country=args.country,
-                language=args.language,
-                freshness=args.freshness,
-                safesearch=args.you_safesearch,
-                include_news=not args.no_news,
-                livecrawl=args.livecrawl,
-            )
-        elif prov == "searxng":
-            # For SearXNG, 'key' is actually the instance URL
-            instance_url = args.searxng_url or key
-            if instance_url:
-                instance_url = _validate_searxng_url(instance_url)
-            return search_searxng(
-                query=args.query,
-                instance_url=instance_url,
-                max_results=args.max_results,
-                categories=args.categories,
-                engines=args.engines,
-                language=args.language,
-                time_range=args.time_range or args.freshness,
-                safesearch=args.searxng_safesearch,
-            )
-        elif prov == "keenable":
-            keenable_config = config.get("keenable", {})
-            return search_keenable(
-                query=args.query,
-                api_key=key,
-                max_results=args.max_results,
-                time_range=args.time_range or args.freshness,
-                include_domains=args.include_domains,
-                public=keyless_public_allowed(prov, config),
-                api_url=keenable_config.get("search_url", "https://api.keenable.ai/v1/search"),
-                timeout=int(keenable_config.get("timeout", 30)),
-            )
-        else:
+        adapter = SEARCH_DISPATCH.get(prov)
+        if adapter is None:
             raise ValueError(f"Unknown provider: {prov}")
+        return adapter(globals(), prov, args, key, config, routing_info)
 
     def execute_with_retry(prov: str) -> Dict[str, Any]:
         started = time.monotonic()

--- a/tests/test_provider_dispatch.py
+++ b/tests/test_provider_dispatch.py
@@ -1,0 +1,202 @@
+"""Registry/dispatch completeness and seam coverage for provider_dispatch.py.
+
+These tests make a forgotten touchpoint structurally impossible: every
+search/extract-capable provider in provider_registry.PROVIDER_SPECS must have
+a dispatch adapter, no adapter may exist without a registry spec, the plugin
+tool-schema enums must be derived from the registry, and adapters must keep
+resolving provider functions late so module-level monkeypatches
+(mock.patch.object(search, "search_you", ...)) keep working.
+"""
+
+import contextlib
+import unittest
+from unittest import mock
+
+import __init__ as plugin
+import provider_dispatch
+import provider_registry
+import search
+
+
+class SearchDispatchCompletenessTests(unittest.TestCase):
+    def test_every_search_capable_spec_has_a_search_dispatch_entry(self):
+        search_capable = {
+            spec.provider for spec in provider_registry.PROVIDER_SPECS.values() if spec.supports_search
+        }
+        missing = search_capable - set(provider_dispatch.SEARCH_DISPATCH)
+        self.assertEqual(missing, set(), f"providers without SEARCH_DISPATCH adapter: {sorted(missing)}")
+
+    def test_no_search_dispatch_entry_without_search_capable_spec(self):
+        for provider in provider_dispatch.SEARCH_DISPATCH:
+            spec = provider_registry.PROVIDER_SPECS.get(provider)
+            self.assertIsNotNone(spec, f"SEARCH_DISPATCH entry {provider!r} has no registry spec")
+            self.assertTrue(spec.supports_search, f"SEARCH_DISPATCH entry {provider!r} is not search-capable")
+
+    def test_search_dispatch_matches_registry_search_provider_ids(self):
+        self.assertEqual(set(provider_dispatch.SEARCH_DISPATCH), set(provider_registry.SEARCH_PROVIDER_IDS))
+
+
+class ExtractDispatchCompletenessTests(unittest.TestCase):
+    def test_every_extract_capable_spec_has_an_extract_dispatch_entry(self):
+        extract_capable = {
+            spec.provider for spec in provider_registry.PROVIDER_SPECS.values() if spec.supports_extract
+        }
+        missing = extract_capable - set(provider_dispatch.EXTRACT_DISPATCH)
+        self.assertEqual(missing, set(), f"providers without EXTRACT_DISPATCH adapter: {sorted(missing)}")
+
+    def test_no_extract_dispatch_entry_without_extract_capable_spec(self):
+        for provider in provider_dispatch.EXTRACT_DISPATCH:
+            spec = provider_registry.PROVIDER_SPECS.get(provider)
+            self.assertIsNotNone(spec, f"EXTRACT_DISPATCH entry {provider!r} has no registry spec")
+            self.assertTrue(spec.supports_extract, f"EXTRACT_DISPATCH entry {provider!r} is not extract-capable")
+
+    def test_extract_dispatch_matches_registry_extract_provider_ids(self):
+        self.assertEqual(set(provider_dispatch.EXTRACT_DISPATCH), set(provider_registry.EXTRACT_PROVIDER_IDS))
+
+
+# Golden kwarg surface per provider, copied 1:1 from the pre-refactor if/elif
+# chain in search.py execute_search(). Changing an adapter's kwargs is a
+# behavior change and must show up here.
+EXPECTED_SEARCH_KWARGS = {
+    "serper": {"query", "api_key", "max_results", "country", "language", "search_type", "time_range", "include_images"},
+    "serpbase": {"query", "api_key", "max_results", "country", "language", "page", "api_url", "timeout"},
+    "brave": {"query", "api_key", "max_results", "country", "language", "time_range", "safesearch"},
+    "tavily": {"query", "api_key", "max_results", "depth", "topic", "include_domains", "exclude_domains", "include_images", "include_raw_content"},
+    "querit": {"query", "api_key", "max_results", "language", "country", "time_range", "include_domains", "exclude_domains", "base_url", "base_path", "timeout"},
+    "linkup": {"query", "api_key", "max_results", "depth", "output_type", "include_domains", "exclude_domains", "api_url", "timeout"},
+    "exa": {"query", "api_key", "max_results", "search_type", "exa_depth", "category", "start_date", "end_date", "similar_url", "include_domains", "exclude_domains", "text_verbosity"},
+    "firecrawl": {"query", "api_key", "max_results", "country", "time_range", "sources", "include_domains", "exclude_domains", "scrape_markdown", "ignore_invalid_urls", "api_url", "timeout_ms"},
+    "parallel": {"query", "api_key", "max_results", "include_domains", "exclude_domains", "api_url", "timeout", "client_model"},
+    "perplexity": {"query", "api_key", "max_results", "model", "api_url", "freshness", "provider_name"},
+    "kilo-perplexity": {"query", "api_key", "max_results", "model", "api_url", "freshness", "provider_name"},
+    "you": {"query", "api_key", "max_results", "country", "language", "freshness", "safesearch", "include_news", "livecrawl"},
+    "searxng": {"query", "instance_url", "max_results", "categories", "engines", "language", "time_range", "safesearch"},
+    "keenable": {"query", "api_key", "max_results", "time_range", "include_domains", "public", "api_url", "timeout"},
+}
+
+# The provider function each search adapter must resolve (late) from the
+# calling module's namespace.
+EXPECTED_SEARCH_FUNCTION = {
+    provider: "search_perplexity" if provider in ("perplexity", "kilo-perplexity") else "search_" + provider
+    for provider in EXPECTED_SEARCH_KWARGS
+}
+
+EXPECTED_EXTRACT_KWARGS = {
+    "firecrawl": {"api_url", "timeout"},
+    "linkup": {"api_url", "timeout"},
+    "tavily": {"api_url", "timeout"},
+    "exa": {"api_url", "timeout"},
+    "parallel": {"api_url", "timeout", "client_model", "max_chars_total", "max_chars_per_result"},
+    "keenable": {"public", "api_url", "timeout"},
+    "you": {"api_url", "timeout"},
+}
+
+
+class _Recorder:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return {"provider": "recorded", "query": "q", "results": [], "answer": "", "images": [], "metadata": {}}
+
+
+class SearchAdapterKwargParityTests(unittest.TestCase):
+    def test_adapters_build_the_same_kwargs_as_the_old_chain(self):
+        config = search._deepcopy_default_config()
+        parser = search.build_parser(config)
+        args = parser.parse_args(["--query", "q"])
+        for provider, adapter in sorted(provider_dispatch.SEARCH_DISPATCH.items()):
+            recorder = _Recorder()
+            namespace = {EXPECTED_SEARCH_FUNCTION[provider]: recorder}
+            adapter(namespace, provider, args, "test-key" if provider != "searxng" else None, config, {})
+            self.assertEqual(len(recorder.calls), 1, provider)
+            call_args, call_kwargs = recorder.calls[0]
+            self.assertEqual(call_args, (), provider)
+            self.assertEqual(set(call_kwargs), EXPECTED_SEARCH_KWARGS[provider], provider)
+
+    def test_exa_adapter_honours_routing_exa_depth_suggestion(self):
+        config = search._deepcopy_default_config()
+        args = search.build_parser(config).parse_args(["--query", "q"])
+        recorder = _Recorder()
+        provider_dispatch.SEARCH_DISPATCH["exa"]({"search_exa": recorder}, "exa", args, "k", config, {"exa_depth": "deep"})
+        self.assertEqual(recorder.calls[0][1]["exa_depth"], "deep")
+
+
+class ExtractAdapterKwargParityTests(unittest.TestCase):
+    def test_adapters_build_the_same_kwargs_as_the_old_chain(self):
+        config = search._deepcopy_default_config()
+        for provider, adapter in sorted(provider_dispatch.EXTRACT_DISPATCH.items()):
+            recorder = _Recorder()
+            namespace = {"extract_" + provider: recorder}
+            adapter(namespace, provider, ["https://example.com"], "test-key", "markdown", False, False, False, config, False)
+            self.assertEqual(len(recorder.calls), 1, provider)
+            call_args, call_kwargs = recorder.calls[0]
+            self.assertEqual(call_args, (["https://example.com"], "test-key", "markdown", False, False, False), provider)
+            self.assertEqual(set(call_kwargs), EXPECTED_EXTRACT_KWARGS[provider], provider)
+
+
+class DispatchMonkeypatchSeamTests(unittest.TestCase):
+    """Dispatch must resolve provider functions late through search.py."""
+
+    def _isolate(self, stack):
+        stack.enter_context(mock.patch.object(search, "provider_in_cooldown", lambda p: (False, 0)))
+        stack.enter_context(mock.patch.object(search, "cache_get", lambda **kw: None))
+        stack.enter_context(mock.patch.object(search, "cache_put", lambda **kw: None))
+        stack.enter_context(mock.patch.object(search, "reset_provider_health", lambda p: None))
+
+    def test_search_dispatch_uses_module_level_monkeypatch(self):
+        with contextlib.ExitStack() as stack:
+            self._isolate(stack)
+            stack.enter_context(mock.patch.dict("os.environ", {"KEENABLE_API_KEY": "keen-test-key"}))
+            seen = {}
+
+            def fake_keenable(**kwargs):
+                seen.update(kwargs)
+                return {"provider": "keenable", "query": "q", "results": [{"url": "https://example.test/a", "title": "A", "snippet": "s"}], "images": [], "answer": "", "metadata": {}}
+
+            stack.enter_context(mock.patch.object(search, "search_keenable", fake_keenable))
+            result = search.run_search_request(query="anything", provider="keenable", count=2)
+
+        self.assertEqual(result["provider"], "keenable")
+        # Adapter kwargs are sourced from the resolved keenable config section.
+        self.assertIn("api_url", seen)
+        self.assertIn("timeout", seen)
+        self.assertIn("public", seen)
+
+    def test_extract_dispatch_uses_module_level_monkeypatch(self):
+        seen = {}
+
+        def fake_tavily_extract(urls, key, *args, **kwargs):
+            seen["urls"] = urls
+            seen.update(kwargs)
+            return {"provider": "tavily", "results": [{"url": urls[0], "title": "T", "content": "c", "raw_content": "c"}]}
+
+        with mock.patch.dict("os.environ", {"TAVILY_API_KEY": "tavily-test-key"}):
+            with mock.patch.object(search, "extract_tavily", fake_tavily_extract):
+                result = search.extract_plus(["https://example.com"], provider="tavily")
+
+        self.assertEqual(result["provider"], "tavily")
+        self.assertEqual(seen["urls"], ["https://example.com"])
+        self.assertIn("api_url", seen)
+        self.assertIn("timeout", seen)
+
+
+class ToolSchemaRegistryDerivationTests(unittest.TestCase):
+    def test_tool_schema_provider_enums_are_registry_derived(self):
+        registered = {}
+
+        class Ctx:
+            def register_tool(self, **kwargs):
+                registered[kwargs["name"]] = kwargs
+
+        plugin.register(Ctx())
+
+        search_enum = registered["web_search_plus"]["schema"]["parameters"]["properties"]["provider"]["enum"]
+        extract_enum = registered["web_extract_plus"]["schema"]["parameters"]["properties"]["provider"]["enum"]
+        self.assertEqual(search_enum, ["auto", *provider_registry.SEARCH_PROVIDER_IDS])
+        self.assertEqual(extract_enum, ["auto", *provider_registry.EXTRACT_PROVIDER_IDS])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adding a provider currently takes ~8 touchpoints across 7 files — which is exactly how `keenable` was once forgotten in routing. This PR replaces the hand-maintained dispatch surfaces with registry-driven tables, cutting a new provider to **3 mandatory touchpoints in 3 files**, with completeness enforced by tests.

- New `provider_dispatch.py`: `SEARCH_DISPATCH` (14 providers) and `EXTRACT_DISPATCH` (7 providers) with one adapter per provider; the kwargs-building is carried over 1:1 from the old chains.
- The 14-branch if/elif chain in `search.py` and the extract chain in `extract.py` become table lookups with a clear `Unknown provider` error.
- Adapters resolve provider functions **late** through the calling module's namespace (same seam pattern as `bench.py`), so all existing module-level monkeypatch seams (`search.search_you`, `search.extract_firecrawl`, …) keep working — **zero existing tests modified, all 384 still green**.
- The `web_search_plus`/`web_extract_plus` tool-schema provider enums are now derived from `provider_registry` instead of hardcoded literal lists (identical sets, deterministic order).
- New bidirectional completeness tests: every search/extract-capable `ProviderSpec` has a dispatch adapter and vice versa, plus golden kwarg-parity tests per adapter — a new provider can never again be silently missing on one surface.
- `docs/ARCHITECTURE.md` "Extending with a new provider" rewritten for the new flow.
- `routing.py` is intentionally untouched: its `available_providers` list deliberately excludes `parallel`/`keenable`, so deriving it from the registry would be a behavior change — left for a separate, explicit decision.

## Behavior

No behavior change. Verified beyond the test suite by running an identical mocked-provider script (5 search providers incl. exa deep/time_range variants, plus extract) against both this branch and `main` — payloads and provider kwargs byte-identical.

## Tests

- 12 new tests in `tests/test_provider_dispatch.py` (completeness both directions, kwarg parity for all 14+7 adapters, monkeypatch-seam checks, schema-enum == registry).
- `python -m pytest tests/ -q` → 396 passed (384 baseline unchanged + 12 new)
- `ruff check .` → clean; both `gen_*_docs.py --check` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)