### PR TITLE
fix: bump DEFAULT_USER_AGENT to 2.9.0 (last stale release surface)

### DIFF
--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.8.1"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.9.0"
 
 
 class ProviderRequestError(Exception):

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -53,7 +53,7 @@ def test_http_client_provider_request_error_exports_retry_metadata():
 
 
 def test_default_user_agent_uses_release_version():
-    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.8.1"
+    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.9.0"
 
 
 def _make_http_error(code: int, headers=None, body: bytes = b"{}") -> HTTPError:


### PR DESCRIPTION
## Summary

**Rescoped after `main` moved:** the direct main-side sync (`0d8b0f3`) already fixed `search.py` and the test constants, so this PR shrank from 5 files to the one surface that fix also missed — the **User-Agent**, which still identified v2.9.0 as `ClawdBot-WebSearchPlus/2.8.1` to every provider API (its test expected the stale value too, which is why CI is green despite it).

- `http_client.py`: `DEFAULT_USER_AGENT` → `2.9.0`
- `tests/test_http_client_module.py`: expected UA → `2.9.0`

That this is the *third* half-done bump surface in one release cycle is exactly what #83 (one-step `prepare_release.py` + a single version gate that also covers the UA) is for — merge this first, then #83.

## Tests

- `python -m pytest tests/ -q` → 459 passed
- `ruff check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)