### PR TITLE
feat: add prepare_release.py so version bumps hit every surface at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### 🔧 Improved
+- Added `scripts/prepare_release.py`: bumps every release-version surface in one step (plugin.yaml, `__version__`, header docstrings, User-Agent, the test gate, and the CHANGELOG section) with a dry-run default and loud failure on surface drift, so a half-done version bump can no longer turn CI red. The hardcoded release gate now lives in exactly one place (`tests/test_release_metadata.py`), and it also covers the User-Agent and `__init__.py` docstring; the package-import and http-client tests read the expected version dynamically from `plugin.yaml`.
+
 ## [v2.9.0] — 2026-07-03
 
 ### Credits
@@ -21,8 +26,6 @@
 ### 🐛 Fixed
 - Plugin discovery no longer depends on the current working directory when Hermes loads the flat plugin from outside the plugin directory. (#75)
 - `serper.type = "news"` (and the new `search_type="news"`) no longer returns silently empty results: Serper `/news` answers carry results under `news` instead of `organic`, and the parser now reads the right field, including `date`, `source`, thumbnail, and position metadata.
-
-## [Unreleased]
 
 ## [v2.8.1] — 2026-07-02
 

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Bump every release-version surface of Web Search Plus in one step.
+
+The repo intentionally keeps one hardcoded release gate
+(``tests/test_release_metadata.py: EXPECTED_VERSION``) that asserts all
+user-visible version surfaces stay in sync. Historically the bump was done by
+hand and missed surfaces twice (v2.8.0 left a stale docstring, v2.9.0 left the
+User-Agent and test literals behind, turning CI red on main). This script makes
+a half-bump impossible: it rewrites every surface atomically or fails loudly.
+
+Surfaces updated:
+
+- ``plugin.yaml``                        version: "X.Y.Z"
+- ``__init__.py``                        __version__ and the header docstring
+- ``search.py``                          header docstring "Version: X.Y.Z"
+- ``http_client.py``                     DEFAULT_USER_AGENT suffix
+- ``tests/test_release_metadata.py``     EXPECTED_VERSION gate
+- ``CHANGELOG.md``                       moves [Unreleased] content under a new
+                                         "## [vX.Y.Z] — YYYY-MM-DD" section
+
+Usage::
+
+    python3 scripts/prepare_release.py 2.10.0            # dry-run (default)
+    python3 scripts/prepare_release.py 2.10.0 --write    # apply changes
+    python3 scripts/prepare_release.py 2.10.0 --date 2026-07-04 --write
+
+Exit codes: 0 ok, 1 usage/validation error, 2 a surface pattern was not found
+(surface drift — fix the SURFACES table before releasing).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# (relative path, pattern template, replacement template). ``{v}`` is the
+# version; each pattern must match EXACTLY once with the current version so
+# that surface drift is detected instead of silently skipped.
+SURFACES: List[Tuple[str, str, str]] = [
+    ("plugin.yaml", 'version: "{v}"', 'version: "{v}"'),
+    ("__init__.py", '__version__ = "{v}"', '__version__ = "{v}"'),
+    ("__init__.py", "Hermes Plugin v{v}", "Hermes Plugin v{v}"),
+    ("search.py", "Version: {v}", "Version: {v}"),
+    ("http_client.py", 'DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/{v}"', 'DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/{v}"'),
+    ("tests/test_release_metadata.py", 'EXPECTED_VERSION = "{v}"', 'EXPECTED_VERSION = "{v}"'),
+]
+
+CHANGELOG = "CHANGELOG.md"
+UNRELEASED_HEADER = "## [Unreleased]"
+
+
+def read_current_version(root: Path) -> str:
+    """Current release version, from plugin.yaml (the canonical surface)."""
+    text = (root / "plugin.yaml").read_text(encoding="utf-8")
+    match = re.search(r'^version:\s*"(\d+\.\d+\.\d+)"\s*$', text, re.MULTILINE)
+    if not match:
+        raise SystemExit("error: could not read current version from plugin.yaml")
+    return match.group(1)
+
+
+def plan_surface_updates(root: Path, old: str, new: str) -> List[Tuple[Path, str, str]]:
+    """Return (path, old_text, new_text) per file, or exit 2 on surface drift."""
+    updates = {}
+    for rel_path, pattern_tpl, replacement_tpl in SURFACES:
+        path = root / rel_path
+        needle = pattern_tpl.format(v=old)
+        replacement = replacement_tpl.format(v=new)
+        text = updates.get(path, [None, path.read_text(encoding="utf-8")])[1]
+        count = text.count(needle)
+        if count != 1:
+            print(
+                "error: expected exactly 1 occurrence of {!r} in {}, found {} — "
+                "update the SURFACES table in scripts/prepare_release.py".format(needle, rel_path, count),
+                file=sys.stderr,
+            )
+            raise SystemExit(2)
+        updates[path] = [rel_path, text.replace(needle, replacement)]
+    result = []
+    for path, (_, new_text) in updates.items():
+        result.append((path, path.read_text(encoding="utf-8"), new_text))
+    return result
+
+
+def plan_changelog_update(root: Path, new: str, date: str) -> Tuple[Path, str, str]:
+    """Move [Unreleased] content under a new dated release section."""
+    path = root / CHANGELOG
+    text = path.read_text(encoding="utf-8")
+    if text.count(UNRELEASED_HEADER) != 1:
+        print(
+            "error: expected exactly 1 {!r} header in {}".format(UNRELEASED_HEADER, CHANGELOG),
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    release_header = "## [v{}] — {}".format(new, date)
+    if release_header.split(" — ")[0] in text:
+        print("error: CHANGELOG already contains a section for v{}".format(new), file=sys.stderr)
+        raise SystemExit(1)
+    new_text = text.replace(
+        UNRELEASED_HEADER,
+        "{}\n\n{}".format(UNRELEASED_HEADER, release_header),
+        1,
+    )
+    return path, text, new_text
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="Bump all Web Search Plus release-version surfaces at once.")
+    parser.add_argument("version", help="new version, e.g. 2.10.0")
+    parser.add_argument("--date", default=None, help="release date YYYY-MM-DD (default: today)")
+    parser.add_argument("--write", action="store_true", help="apply changes (default is a dry run)")
+    parser.add_argument("--root", default=str(REPO_ROOT), help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+
+    root = Path(args.root)
+    new = args.version.strip().lstrip("v")
+    if not _VERSION_RE.match(new):
+        print("error: version must look like MAJOR.MINOR.PATCH, got {!r}".format(args.version), file=sys.stderr)
+        return 1
+    date = args.date or datetime.date.today().isoformat()
+    if not _DATE_RE.match(date):
+        print("error: --date must be YYYY-MM-DD, got {!r}".format(args.date), file=sys.stderr)
+        return 1
+
+    old = read_current_version(root)
+    if new == old:
+        print("error: new version {} equals the current version".format(new), file=sys.stderr)
+        return 1
+
+    changes = plan_surface_updates(root, old, new)
+    changes.append(plan_changelog_update(root, new, date))
+
+    mode = "write" if args.write else "dry-run"
+    print("prepare_release: {} -> {} ({})".format(old, new, mode))
+    for path, _old_text, new_text in changes:
+        print("  {}".format(path.relative_to(root)))
+        if args.write:
+            path.write_text(new_text, encoding="utf-8")
+
+    if args.write:
+        print("done. Now: review the CHANGELOG section, run pytest, commit, tag v{}.".format(new))
+    else:
+        print("dry run only — re-run with --write to apply.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_http_client_module.py
+++ b/tests/test_http_client_module.py
@@ -53,7 +53,15 @@ def test_http_client_provider_request_error_exports_retry_metadata():
 
 
 def test_default_user_agent_uses_release_version():
-    assert http_client.DEFAULT_USER_AGENT == "ClawdBot-WebSearchPlus/2.9.0"
+    # Dynamic on purpose: the single hardcoded release gate lives in
+    # test_release_metadata.py and covers the User-Agent as well.
+    import re
+    from pathlib import Path
+
+    plugin_yaml = (Path(__file__).resolve().parents[1] / "plugin.yaml").read_text(encoding="utf-8")
+    match = re.search(r'^version:\s*"(\d+\.\d+\.\d+)"\s*$', plugin_yaml, re.MULTILINE)
+    assert match, "could not read version from plugin.yaml"
+    assert http_client.DEFAULT_USER_AGENT == f"ClawdBot-WebSearchPlus/{match.group(1)}"
 
 
 def _make_http_error(code: int, headers=None, body: bytes = b"{}") -> HTTPError:

--- a/tests/test_plugin_package_import.py
+++ b/tests/test_plugin_package_import.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import types
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _plugin_yaml_version() -> str:
+    """These tests check import mechanics, not the release gate, so they read
+    the expected version dynamically; the single hardcoded gate lives in
+    test_release_metadata.py."""
+    text = (ROOT / "plugin.yaml").read_text(encoding="utf-8")
+    match = re.search(r'^version:\s*"(\d+\.\d+\.\d+)"\s*$', text, re.MULTILINE)
+    assert match, "could not read version from plugin.yaml"
+    return match.group(1)
 
 
 def test_plugin_loads_with_hermes_package_style_import():
@@ -35,7 +46,7 @@ def test_plugin_loads_with_hermes_package_style_import():
 
         spec.loader.exec_module(module)
 
-        assert module.__version__ == "2.9.0"
+        assert module.__version__ == _plugin_yaml_version()
         assert module._get_provider_catalog()
     finally:
         sys.modules.pop(module_name, None)
@@ -56,7 +67,7 @@ def test_plugin_loads_from_foreign_cwd_without_package_context(tmp_path, monkeyp
 
         spec.loader.exec_module(module)
 
-        assert module.__version__ == "2.9.0"
+        assert module.__version__ == _plugin_yaml_version()
         assert module._get_provider_catalog()
     finally:
         sys.modules.pop(module_name, None)

--- a/tests/test_prepare_release.py
+++ b/tests/test_prepare_release.py
@@ -1,0 +1,118 @@
+"""Tests for scripts/prepare_release.py (single-step version bump tool)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "prepare_release.py"
+spec = importlib.util.spec_from_file_location("wsp_prepare_release_under_test", SCRIPT_PATH)
+prepare_release = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(prepare_release)
+
+
+OLD = "1.2.3"
+
+
+def _make_fake_repo(root: Path, version: str = OLD) -> None:
+    (root / "tests").mkdir(parents=True)
+    (root / "plugin.yaml").write_text(f'name: web-search-plus\nversion: "{version}"\n', encoding="utf-8")
+    (root / "__init__.py").write_text(
+        f'"""web-search-plus — Hermes Plugin v{version}"""\n__version__ = "{version}"\n',
+        encoding="utf-8",
+    )
+    (root / "search.py").write_text(f'"""\nVersion: {version}\n"""\n', encoding="utf-8")
+    (root / "http_client.py").write_text(
+        f'DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/{version}"\n', encoding="utf-8"
+    )
+    (root / "tests" / "test_release_metadata.py").write_text(
+        f'EXPECTED_VERSION = "{version}"\n', encoding="utf-8"
+    )
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [Unreleased]\n\n### Added\n- something new\n\n"
+        f"## [v{version}] — 2026-01-01\n\n- old entry\n",
+        encoding="utf-8",
+    )
+
+
+def _run(root: Path, *argv: str) -> int:
+    return prepare_release.main(list(argv) + ["--root", str(root)])
+
+
+def test_dry_run_changes_nothing(tmp_path):
+    _make_fake_repo(tmp_path)
+    before = {p: p.read_text(encoding="utf-8") for p in tmp_path.rglob("*") if p.is_file()}
+
+    assert _run(tmp_path, "2.0.0", "--date", "2026-07-04") == 0
+
+    after = {p: p.read_text(encoding="utf-8") for p in tmp_path.rglob("*") if p.is_file()}
+    assert before == after
+
+
+def test_write_updates_every_surface(tmp_path):
+    _make_fake_repo(tmp_path)
+
+    assert _run(tmp_path, "2.0.0", "--date", "2026-07-04", "--write") == 0
+
+    assert 'version: "2.0.0"' in (tmp_path / "plugin.yaml").read_text(encoding="utf-8")
+    init_py = (tmp_path / "__init__.py").read_text(encoding="utf-8")
+    assert '__version__ = "2.0.0"' in init_py
+    assert "Hermes Plugin v2.0.0" in init_py
+    assert "Version: 2.0.0" in (tmp_path / "search.py").read_text(encoding="utf-8")
+    assert 'ClawdBot-WebSearchPlus/2.0.0"' in (tmp_path / "http_client.py").read_text(encoding="utf-8")
+    assert 'EXPECTED_VERSION = "2.0.0"' in (tmp_path / "tests" / "test_release_metadata.py").read_text(encoding="utf-8")
+    assert OLD not in (tmp_path / "plugin.yaml").read_text(encoding="utf-8")
+
+    changelog = (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+    # New section sits directly under a fresh empty [Unreleased] and inherits
+    # the previously unreleased content; the old release section is untouched.
+    assert "## [Unreleased]\n\n## [v2.0.0] — 2026-07-04\n\n### Added\n- something new" in changelog
+    assert f"## [v{OLD}] — 2026-01-01" in changelog
+
+
+def test_missing_surface_fails_loudly(tmp_path):
+    _make_fake_repo(tmp_path)
+    # Simulate surface drift: someone renamed the User-Agent constant.
+    (tmp_path / "http_client.py").write_text('UA = "something-else"\n', encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        _run(tmp_path, "2.0.0", "--date", "2026-07-04", "--write")
+    assert exc_info.value.code == 2
+
+
+def test_rejects_same_and_malformed_versions(tmp_path):
+    _make_fake_repo(tmp_path)
+    assert _run(tmp_path, OLD, "--date", "2026-07-04") == 1
+    assert _run(tmp_path, "2.0", "--date", "2026-07-04") == 1
+    assert _run(tmp_path, "2.0.0", "--date", "04.07.2026") == 1
+
+
+def test_rejects_duplicate_changelog_section(tmp_path):
+    _make_fake_repo(tmp_path)
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        changelog.read_text(encoding="utf-8") + "\n## [v2.0.0] — 2026-06-01\n\n- already released\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        _run(tmp_path, "2.0.0", "--date", "2026-07-04", "--write")
+    assert exc_info.value.code == 1
+
+
+def test_accepts_v_prefix(tmp_path):
+    _make_fake_repo(tmp_path)
+    assert _run(tmp_path, "v2.0.0", "--date", "2026-07-04", "--write") == 0
+    assert 'version: "2.0.0"' in (tmp_path / "plugin.yaml").read_text(encoding="utf-8")
+
+
+def test_real_repo_surfaces_match_script_table():
+    """The SURFACES table must match the actual repo — otherwise the script
+    would fail at release time. Runs the planner (read-only) on the real tree."""
+    root = Path(__file__).resolve().parents[1]
+    current = prepare_release.read_current_version(root)
+    changes = prepare_release.plan_surface_updates(root, current, "999.0.0")
+    assert changes  # every surface matched exactly once

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -19,14 +19,20 @@ def _load_plugin_module():
 
 
 def test_release_version_surfaces_are_in_sync():
+    # The one deliberately hardcoded version gate. Bump every surface at once
+    # with: python3 scripts/prepare_release.py <new-version> --write
     plugin = _load_plugin_module()
     plugin_yaml = (ROOT / "plugin.yaml").read_text()
+    init_py = (ROOT / "__init__.py").read_text()
     search_py = (ROOT / "search.py").read_text()
+    http_client_py = (ROOT / "http_client.py").read_text()
     changelog = (ROOT / "CHANGELOG.md").read_text()
 
     assert plugin.__version__ == EXPECTED_VERSION
     assert f'version: "{EXPECTED_VERSION}"' in plugin_yaml
+    assert f"Hermes Plugin v{EXPECTED_VERSION}" in init_py
     assert f"Version: {EXPECTED_VERSION}" in search_py
+    assert f'DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/{EXPECTED_VERSION}"' in http_client_py
     assert re.search(rf"^## \[v{re.escape(EXPECTED_VERSION)}\] — \d{{4}}-\d{{2}}-\d{{2}}$", changelog, re.M)
 
 


### PR DESCRIPTION
## Summary

Three half-done version bumps in one release cycle (v2.8.0: stale docstring; v2.9.0: UA + three test literals; the main-side re-sync `0d8b0f3`: UA again) — the sync test catches them only after the fact. This makes a half-bump structurally impossible.

**Stacked on #82** (the UA fix). Merge #82 first; this diff then collapses to just the new tooling.

- **`scripts/prepare_release.py`** — one command bumps every surface: `plugin.yaml`, `__version__`, both header docstrings, `DEFAULT_USER_AGENT`, the test gate, and moves the CHANGELOG `[Unreleased]` content under a new dated release section.

  ```bash
  python3 scripts/prepare_release.py 2.10.0            # dry-run (default)
  python3 scripts/prepare_release.py 2.10.0 --write    # apply
  ```

  Dry-run by default; exits loudly (code 2) when a surface pattern isn't found exactly once (surface drift), and refuses duplicate CHANGELOG sections, malformed versions, or a no-op bump.
- **Exactly one hardcoded version literal remains** — `EXPECTED_VERSION` in `test_release_metadata.py` — and that gate now also asserts the User-Agent and the `__init__.py` docstring (the two surfaces missed most often). The package-import and http-client tests read the expected version dynamically from `plugin.yaml`, so they can never again fail on a stale literal while the mechanics they actually test are fine.
- A planner test runs read-only against the real tree, so the script's `SURFACES` table can't silently drift from the repo.
- CHANGELOG housekeeping: `[Unreleased]` moved back above the v2.9.0 section.

## Tests

- 7 new tests: dry-run immutability, full-surface write, surface-drift failure, version/date validation, duplicate-section rejection, `v`-prefix tolerance, real-tree planner check.
- `python -m pytest tests/ -q` → 466 passed
- `ruff check .` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)