### PR TITLE
Fix Parallel extract full-content budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### 🔧 Improved
+- Behavior change: raised Parallel extraction's default `full_content` budget to 60k characters per result / 120k total so long pages are evaluated fairly against other extraction providers instead of being silently capped at 6k. Operators that need smaller Parallel payloads can set `parallel.max_chars_per_result` and `parallel.max_chars_total` in `config.json`.
 - Added `scripts/prepare_release.py`: bumps every release-version surface in one step (plugin.yaml, `__version__`, header docstrings, User-Agent, the test gate, and the CHANGELOG section) with a dry-run default and loud failure on surface drift, so a half-done version bump can no longer turn CI red. The hardcoded release gate now lives in exactly one place (`tests/test_release_metadata.py`), and it also covers the User-Agent and `__init__.py` docstring; the package-import and http-client tests read the expected version dynamically from `plugin.yaml`.
 
 ## [v2.9.0] — 2026-07-03

--- a/config.py
+++ b/config.py
@@ -111,8 +111,8 @@ DEFAULT_CONFIG = {
         "timeout": 45,
         "extract_timeout": 60,
         "client_model": None,
-        "max_chars_total": 12000,
-        "max_chars_per_result": 6000
+        "max_chars_total": 120000,
+        "max_chars_per_result": 60000
     },
     "kilo-perplexity": {
         "api_url": "https://api.kilo.ai/api/gateway/chat/completions",

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -364,6 +364,8 @@ Parameters:
 
 Auto extraction currently tries Tavily, Exa, Linkup, Parallel, Firecrawl, and You.com when keys are available, then Keenable (only if a key is set or its public tier is opted in), and finally Serper as the last resort. Tavily is the fast reliable default; Exa is the fast docs/academic backup; Linkup stays the clean long-form fallback; Firecrawl remains the robust scraper safety net; Serper's webpage scraper (`https://scrape.serper.dev`, overridable via config `serper.scrape_url`, timeout via `serper.extract_timeout`) closes the chain so a Serper-only setup still gets extraction.
 
+Parallel extraction explicitly requests `full_content`. Its default budget is 60,000 characters per result and 120,000 characters total so long documents are not unfairly shortened compared with other extraction providers. Operators can override those request-side limits in `config.json` with `parallel.max_chars_per_result` and `parallel.max_chars_total`.
+
 Large extracted pages are not returned as raw token bombs. `web_extract_plus` sanitizes inline base64 images, stores the full cleaned text under `cache/web`, and returns a bounded head/tail preview with a footer containing the stored file path plus an exact `read_file(path=..., offset=..., limit=500)` call for paging into the omitted middle. Configure the inline budget in `config.json`:
 
 ```json

--- a/provider_dispatch.py
+++ b/provider_dispatch.py
@@ -319,8 +319,8 @@ def _call_parallel_extract(extract_module, prov, urls, key, output_format, inclu
         api_url=parallel.get("extract_url", "https://api.parallel.ai/v1/extract"),
         timeout=int(parallel.get("extract_timeout", parallel.get("timeout", 60))),
         client_model=parallel.get("client_model"),
-        max_chars_total=int(parallel.get("max_chars_total", 12000)),
-        max_chars_per_result=int(parallel.get("max_chars_per_result", 6000)),
+        max_chars_total=int(parallel.get("max_chars_total", 120000)),
+        max_chars_per_result=int(parallel.get("max_chars_per_result", 60000)),
     )
 
 

--- a/providers.py
+++ b/providers.py
@@ -996,14 +996,15 @@ def extract_parallel(
     api_url: str = "https://api.parallel.ai/v1/extract",
     timeout: int = 60,
     client_model: Optional[str] = None,
-    max_chars_total: int = 12000,
-    max_chars_per_result: int = 6000,
+    max_chars_total: int = 120000,
+    max_chars_per_result: int = 60000,
 ) -> dict:
     """Extract URL content using Parallel Extract.
 
-    Parallel returns excerpts by default; request full_content explicitly and
-    normalize it into the common markdown/content shape. HTML/raw-image options
-    are accepted for tool compatibility but ignored when unsupported upstream.
+    Parallel returns excerpts by default; request full_content explicitly with a
+    peer-level character budget so long pages are not unfairly truncated versus
+    other extraction providers. HTML/raw-image options are accepted for tool
+    compatibility but ignored when unsupported upstream.
     """
     headers = {"x-api-key": api_key, "Content-Type": "application/json"}
     body: Dict[str, Any] = {

--- a/tests/test_parallel_provider.py
+++ b/tests/test_parallel_provider.py
@@ -89,6 +89,15 @@ def test_extract_parallel_requests_full_content_and_normalizes_results():
     assert body["advanced_settings"]["full_content"]["max_chars_per_result"] == 567
 
 
+def test_extract_parallel_defaults_use_peer_level_full_content_budget():
+    with mock.patch.object(search, "make_request", return_value={"results": []}) as mock_request:
+        search.extract_parallel(["https://docs.parallel.ai/getting-started/overview"], "parallel-test-key")
+
+    body = mock_request.call_args.args[2]
+    assert body["max_chars_total"] == 120000
+    assert body["advanced_settings"]["full_content"]["max_chars_per_result"] == 60000
+
+
 def test_parallel_is_explicit_provider_but_blocked_from_auto_by_default():
     config = search._deepcopy_default_config()
     assert "parallel" in config["auto_routing"]["provider_priority"]

--- a/tests/test_provider_dispatch.py
+++ b/tests/test_provider_dispatch.py
@@ -136,6 +136,27 @@ class ExtractAdapterKwargParityTests(unittest.TestCase):
             self.assertEqual(call_args, (["https://example.com"], "test-key", "markdown", False, False, False), provider)
             self.assertEqual(set(call_kwargs), EXPECTED_EXTRACT_KWARGS[provider], provider)
 
+    def test_parallel_adapter_uses_peer_level_default_full_content_budget(self):
+        config = search._deepcopy_default_config()
+        recorder = _Recorder()
+
+        provider_dispatch.EXTRACT_DISPATCH["parallel"](
+            {"extract_parallel": recorder},
+            "parallel",
+            ["https://example.com/long"],
+            "test-key",
+            "markdown",
+            False,
+            False,
+            False,
+            config,
+            False,
+        )
+
+        kwargs = recorder.calls[0][1]
+        self.assertEqual(kwargs["max_chars_total"], 120000)
+        self.assertEqual(kwargs["max_chars_per_result"], 60000)
+
 
 class DispatchMonkeypatchSeamTests(unittest.TestCase):
     """Dispatch must resolve provider functions late through search.py."""


### PR DESCRIPTION
## Summary
- raise Parallel extraction's default `full_content` budget from 6k per result / 12k total to 60k per result / 120k total
- keep the limits configurable through `parallel.max_chars_per_result` and `parallel.max_chars_total`
- document the behavior and add regression coverage for direct provider calls and dispatch defaults

## Why
Parallel extraction explicitly requests `full_content`, but Web Search Plus was sending a much smaller request-side character budget than the other extraction providers. That made Parallel look weaker on long documents because results were being silently shortened by configuration rather than provider capability.

## Verification
- `python3 -m pytest tests/test_parallel_provider.py tests/test_provider_dispatch.py -q` → 20 passed
- Live Parallel smoke on long docs:
  - RFC 9110: 6,000 chars with old cap, 60,000 chars with new default
  - arXiv HTML paper: 6,000 chars with old cap, 39,781 chars with new default
- `python3 -m compileall -q .`
- `python3 -m pytest tests/ -q` → 468 passed
- `ruff check .`
- `git diff --check`