### PR TITLE
Set up development environment (AGENTS.md + Cursor Cloud instructions)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single product: the **web-search-plus** Hermes Agent plugin (Python 3.8+,
+**stdlib-only runtime**). There is no backend service, database, Docker stack, or build step —
+everything is plain Python modules loaded directly.
+
+### Dev dependencies
+
+Only `pytest` and `ruff` are needed for development (installed by the update script). They land in
+`~/.local/bin`, which is **not on `PATH`**. Invoke them as modules to avoid PATH issues:
+
+- Lint: `python3 -m ruff check .`
+- Tests: `python3 -m pytest tests/ -q`
+- Compile check (mirrors CI): `python3 -m py_compile search.py __init__.py daemon_tasks.py http_client.py cache.py config.py env_loader.py provider_health.py provider_stats.py quality.py research.py routing.py providers.py extract.py scripts/golden_eval.py`
+
+The CI definition lives in `.github/workflows/ci.yml` (ruff + pytest + py_compile).
+
+### Running the app (CLI)
+
+There is no long-running server. The product is exercised via two CLIs:
+
+- `python3 setup.py status|list|setup` — provider onboarding / inspection (see `setup.py`, `README.md`).
+- `python3 search.py --query "..." [--provider ...] [--quality-report]` — web search.
+- `python3 search.py doctor` — environment/provider diagnostics.
+
+### Live search without any API keys
+
+Providers normally need API keys (`SERPER_API_KEY`, `TAVILY_API_KEY`, `LINKUP_API_KEY`, etc.; see
+`.env.template`). For a keyless end-to-end smoke test, use the Keenable public tier:
+
+```bash
+export KEENABLE_ALLOW_PUBLIC=1
+export WSP_CACHE_DIR=/tmp/wsp_cache   # avoids writing to ~/.hermes
+python3 search.py --query "Hermes Agent latest release" --provider keenable --quality-report
+```
+
+Note: the keyless tier sends queries/URLs to an unauthenticated shared service with no SLA and is
+rate-limited — fine for smoke tests, not for load. Set `WSP_CACHE_DIR` (or `WEB_SEARCH_PLUS_CONFIG`)
+when running from a flat checkout so state doesn't default to `~/.hermes/plugins`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the **web-search-plus** Hermes plugin (Python 3.8+, stdlib-only runtime; dev deps `pytest` + `ruff`) and documents it for future cloud agents.

- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering how to lint/test/compile and how to run the CLI, including a keyless live-search smoke test via the Keenable public tier.
- Configure the update script to install dev dependencies (`pytest`, `ruff`, plus `requirements.txt` if present).

No application code was modified.

## Verification

- `python3 -m ruff check .` — All checks passed
- `python3 -m pytest tests/ -q` — 468 passed
- `py_compile` of all CI modules — OK
- Live keyless search returned real results:

```
$ KEENABLE_ALLOW_PUBLIC=1 WSP_CACHE_DIR=/tmp/wsp_cache python3 search.py --query "Hermes Agent latest release" --provider keenable --quality-report
{ "provider": "keenable", "query": "Hermes Agent latest release", "results": [ {"title": "Releases · NousResearch/hermes-agent", ...} ] }
```

[wsp_smoke_test.log](https://cursor.com/agents/bc-9b91f355-f0a4-4c90-8b52-e1786b6ac189/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwsp_smoke_test.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b91f355-f0a4-4c90-8b52-e1786b6ac189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b91f355-f0a4-4c90-8b52-e1786b6ac189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

