### PR TITLE
chore(release): prepare Web Search Plus v2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,25 @@
 
 ## [Unreleased]
 
+## [v2.9.1] — 2026-07-10
+
+### Credits
+- #82 by @robbyczgw-cla — synchronized the last stale v2.9.0 User-Agent version surface.
+- #83 by @robbyczgw-cla — added the atomic release-version preparation helper and regression tests.
+- #84 by @robbyczgw-cla — aligned Serper extraction documentation and streamlined the README.
+- #86 by @robbyczgw-cla — raised Parallel extraction content budgets for fair long-page handling.
+- v2.9.1 maintenance by @robbyczgw-cla — protected shared provider/usage state from cache stats and clear operations.
+
 ### 🔧 Improved
-- Behavior change: raised Parallel extraction's default `full_content` budget to 60k characters per result / 120k total so long pages are evaluated fairly against other extraction providers instead of being silently capped at 6k. Operators that need smaller Parallel payloads can set `parallel.max_chars_per_result` and `parallel.max_chars_total` in `config.json`.
-- Added `scripts/prepare_release.py`: bumps every release-version surface in one step (plugin.yaml, `__version__`, header docstrings, User-Agent, the test gate, and the CHANGELOG section) with a dry-run default and loud failure on surface drift, so a half-done version bump can no longer turn CI red. The hardcoded release gate now lives in exactly one place (`tests/test_release_metadata.py`), and it also covers the User-Agent and `__init__.py` docstring; the package-import and http-client tests read the expected version dynamically from `plugin.yaml`.
+- Raised Parallel extraction's default `full_content` budget to 60k characters per result / 120k total so long pages are evaluated fairly against other extraction providers instead of being silently capped at 6k. Operators that need smaller Parallel payloads can set `parallel.max_chars_per_result` and `parallel.max_chars_total` in `config.json`. (#86)
+- Added `scripts/prepare_release.py`: bumps every release-version surface in one step (plugin.yaml, `__version__`, header docstrings, User-Agent, the test gate, and the CHANGELOG section) with a dry-run default and loud failure on surface drift. The hardcoded release gate now lives in exactly one place (`tests/test_release_metadata.py`), while package-import and HTTP-client tests read the expected version dynamically from `plugin.yaml`. (#83)
+
+### 🐛 Fixed
+- Synchronized the default HTTP User-Agent with v2.9.0, closing the last stale release-version surface left after that tag. (#82)
+- Cache statistics and clearing now recognize only complete WSP search-cache envelopes. Shared state such as `provider_stats.json`, `provider_health.json`, host-written `usage_events.json`, unrelated JSON, and corrupt foreign files is ignored and preserved byte-for-byte instead of being counted, deleted, or crashing cache stats.
+
+### 📚 Docs
+- Marked Serper extraction consistently across the README, architecture, and user guide, and slimmed the README into a clearer product landing page. (#84)
 
 ## [v2.9.0] — 2026-07-03
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v2.9.0
+web-search-plus — Hermes Plugin v2.9.1
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "2.9.0"
+__version__ = "2.9.1"
 
 import argparse
 import getpass

--- a/cache.py
+++ b/cache.py
@@ -156,6 +156,28 @@ def _atomic_write_json(path: Path, data: Dict[str, Any]) -> None:
         raise
 
 
+_SEARCH_CACHE_MARKER_FIELDS = frozenset({
+    "_cache_timestamp",
+    "_cache_key",
+    "_cache_query",
+    "_cache_provider",
+})
+
+
+def _read_search_cache_envelope(path: Path) -> Optional[Dict[str, Any]]:
+    """Return a WSP search-cache envelope, or ``None`` for shared foreign state."""
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            payload = json.load(f)
+    except (json.JSONDecodeError, IOError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if not _SEARCH_CACHE_MARKER_FIELDS.issubset(payload):
+        return None
+    return payload
+
+
 def cache_get(query: str, provider: str, max_results: int, ttl: int = DEFAULT_CACHE_TTL, params: Optional[Dict[str, Any]] = None) -> Optional[Dict[str, Any]]:
     """
     Retrieve cached search results if they exist and are not expired.
@@ -255,7 +277,8 @@ def cache_clear() -> Dict[str, Any]:
     web_text_tmp_size_freed = 0
 
     for cache_file in CACHE_DIR.glob("*.json"):
-        if cache_file.name == PROVIDER_HEALTH_FILENAME:
+        cached = _read_search_cache_envelope(cache_file)
+        if cached is None:
             continue
         try:
             size_freed += cache_file.stat().st_size
@@ -321,21 +344,22 @@ def cache_stats() -> Dict[str, Any]:
             "exists": False,
         }
 
-    entries = [p for p in CACHE_DIR.glob("*.json") if p.name != PROVIDER_HEALTH_FILENAME]
     total_size = 0
+    entry_count = 0
     oldest_time = None
     newest_time = None
     oldest_query = None
     newest_query = None
     provider_counts = {}
 
-    for cache_file in entries:
+    for cache_file in CACHE_DIR.glob("*.json"):
+        cached = _read_search_cache_envelope(cache_file)
+        if cached is None:
+            continue
         try:
             stat = cache_file.stat()
             total_size += stat.st_size
-
-            with open(cache_file, "r", encoding="utf-8") as f:
-                cached = json.load(f)
+            entry_count += 1
 
             ts = cached.get("_cache_timestamp", 0)
             query = cached.get("_cache_query", "unknown")
@@ -349,13 +373,13 @@ def cache_stats() -> Dict[str, Any]:
             if newest_time is None or ts > newest_time:
                 newest_time = ts
                 newest_query = query
-        except (json.JSONDecodeError, IOError):
+        except IOError:
             pass
 
     web_stats = _web_text_cache_stats()
     total_with_web = total_size + web_stats["web_text_size_bytes"]
     return {
-        "total_entries": len(entries),
+        "total_entries": entry_count,
         "total_size_bytes": total_size,
         "total_size_kb": round(total_size / 1024, 2),
         "total_size_bytes_including_web": total_with_web,

--- a/cache.py
+++ b/cache.py
@@ -169,7 +169,7 @@ def _read_search_cache_envelope(path: Path) -> Optional[Dict[str, Any]]:
     try:
         with open(path, "r", encoding="utf-8") as f:
             payload = json.load(f)
-    except (json.JSONDecodeError, IOError):
+    except (ValueError, OSError):
         return None
     if not isinstance(payload, dict):
         return None

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.9.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/2.9.1"
 
 
 class ProviderRequestError(Exception):

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "2.9.0"
+version: "2.9.1"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 2.9.0
+Version: 2.9.1
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, Perplexity, Kilo Perplexity, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable, Serper.

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -73,6 +73,44 @@ class CacheLifecycleTests(unittest.TestCase):
         self.assertEqual(result["web_text_cleared"], 0)
         self.assertEqual(result["web_text_errors"], 0)
 
+    def test_cache_stats_counts_only_marker_carrying_cache_envelopes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            with mock.patch.object(cache, "CACHE_DIR", cache_dir):
+                cache.cache_put("query", "linkup", 3, {"results": ["ok"]})
+                (cache_dir / "usage_events.json").write_text('[{"event": "x"}]\n', encoding="utf-8")
+                (cache_dir / "provider_stats.json").write_text('{"linkup": []}\n', encoding="utf-8")
+                (cache_dir / "unrelated.json").write_text(
+                    '{"owner": "host", "_cache_timestamp": 1}\n', encoding="utf-8"
+                )
+                (cache_dir / "corrupt.json").write_text("{not json", encoding="utf-8")
+
+                stats = cache.cache_stats()
+
+        self.assertEqual(stats["total_entries"], 1)
+        self.assertEqual(stats["providers"], {"linkup": 1})
+
+    def test_cache_clear_preserves_foreign_json_state_byte_for_byte(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            foreign_payloads = {
+                "usage_events.json": '[{"event": "x"}]\n',
+                "provider_stats.json": '{"linkup": []}\n',
+                "provider_health.json": '{"keep": true}\n',
+                "unrelated.json": '{"owner": "host", "_cache_timestamp": 1}\n',
+                "corrupt.json": "{not json",
+            }
+            with mock.patch.object(cache, "CACHE_DIR", cache_dir):
+                cache.cache_put("query", "linkup", 3, {"results": ["ok"]})
+                for name, payload in foreign_payloads.items():
+                    (cache_dir / name).write_text(payload, encoding="utf-8")
+
+                result = cache.cache_clear()
+
+                self.assertEqual(result["cleared"], 1)
+                for name, payload in foreign_payloads.items():
+                    self.assertEqual((cache_dir / name).read_text(encoding="utf-8"), payload)
+
     def test_web_text_stats_ignore_but_clear_orphan_tmp_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_dir = Path(tmpdir)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -111,6 +111,34 @@ class CacheLifecycleTests(unittest.TestCase):
                 for name, payload in foreign_payloads.items():
                     self.assertEqual((cache_dir / name).read_text(encoding="utf-8"), payload)
 
+    def test_cache_stats_ignores_invalid_utf8_foreign_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            invalid_bytes = b"\xff\xfe\x00not-utf8"
+            with mock.patch.object(cache, "CACHE_DIR", cache_dir):
+                cache.cache_put("query", "linkup", 3, {"results": ["ok"]})
+                invalid = cache_dir / "binary.json"
+                invalid.write_bytes(invalid_bytes)
+
+                stats = cache.cache_stats()
+
+                self.assertEqual(stats["total_entries"], 1)
+                self.assertEqual(invalid.read_bytes(), invalid_bytes)
+
+    def test_cache_clear_preserves_invalid_utf8_foreign_json(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_dir = Path(tmpdir)
+            invalid_bytes = b"\xff\xfe\x00not-utf8"
+            with mock.patch.object(cache, "CACHE_DIR", cache_dir):
+                cache.cache_put("query", "linkup", 3, {"results": ["ok"]})
+                invalid = cache_dir / "binary.json"
+                invalid.write_bytes(invalid_bytes)
+
+                result = cache.cache_clear()
+
+                self.assertEqual(result["cleared"], 1)
+                self.assertEqual(invalid.read_bytes(), invalid_bytes)
+
     def test_web_text_stats_ignore_but_clear_orphan_tmp_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             cache_dir = Path(tmpdir)

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "2.9.0"
+EXPECTED_VERSION = "2.9.1"
 
 
 def _load_plugin_module():


### PR DESCRIPTION
## Summary

Web Search Plus v2.9.1 is a focused maintenance release that protects operator state, improves long-page extraction fairness, and makes future releases harder to prepare incorrectly.

- Make cache statistics and clearing operate only on complete WSP search-cache envelopes. Shared `provider_stats.json`, `provider_health.json`, host-written `usage_events.json`, unrelated JSON, and corrupt foreign files are ignored and preserved.
- Raise Parallel extraction's default `full_content` budget to 60k characters per result / 120k total, with config overrides for operators who want smaller payloads. This can increase transferred content, latency, and provider usage compared with the previous 6k ceiling. (#86)
- Add the atomic `scripts/prepare_release.py` helper so every version surface is updated together. (#83)
- Synchronize the final stale v2.9.0 User-Agent surface. (#82)
- Align Serper extraction documentation and streamline the README. (#84)
- Move all release surfaces and metadata to `2.9.1`.

## Release inventory

- #82 by @robbyczgw-cla — User-Agent release-surface synchronization.
- #83 by @robbyczgw-cla — atomic release preparation helper and tests.
- #84 by @robbyczgw-cla — Serper extraction documentation and README cleanup.
- #86 by @robbyczgw-cla — Parallel extraction full-content budgets.
- v2.9.1 maintenance by @robbyczgw-cla — shared cache-state ownership fix and release preparation.

Open feature PRs #74, #76, #78, and #87 are deliberately not part of this patch release.

## Verification

- `472 passed`
- `ruff check .` clean
- `python3 -m compileall -q .` clean
- provider and Routing v2 generated-doc drift checks clean
- `git diff --check` clean
- added-line privacy/secret/path scan clean
- real-cache-copy regression: 1,437 WSP envelopes and 33 stored web pages exercised; foreign state, including invalid UTF-8 JSON bytes, remained hash-identical
- fresh-clone verification passed on candidate `b446bc856d39b55a94fe20f3073d4372af83908e`

## Scope safety

This release does not change provider counts, routing defaults, credential handling, or the public tool schema.