### PR TITLE
feat: make extract provider priority configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### ✨ Added
+- Added independent `auto_routing.extract_provider_priority` configuration for `web_extract_plus(provider="auto")`, with `setup.py config set-extract-priority ...`. The existing Tavily-first registry order remains the public default; partial lists append missing extract-capable providers, and search `provider_priority` remains independent.
+
 ## [v2.9.1] — 2026-07-10
 
 ### Credits

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Most web-search tools fail in one of two boring ways: they hard-code a single pr
 - **Routing v2 is conservative.** You.com, Serper, Exa, Firecrawl, Tavily, and Linkup form the default auto-search pool; everything else stays explicit/guarded until you opt in.
 - **Large pages stay usable.** Long extracts return a compact head/tail preview plus a `read_file` footer for the full cleaned text, instead of dumping token bombs into the agent context.
 - **Freshness, verticals, and locale are explicit.** `day`/`week`/`month`/`year` recency, `search_type="news"`, and `country`/`language` defaults with query-language auto-detection — providers that cannot apply a filter report that in metadata instead of silently dropping it.
-- **Provider quality is measurable.** The built-in bench compares configured providers on success rate, latency, result volume, and snippet coverage, then suggests a provider-priority order without writing config automatically.
+- **Provider quality is measurable.** The built-in bench compares configured search providers on success rate, latency, result volume, and snippet coverage, then suggests a search-provider priority order without writing config automatically.
 - **Costs and safety stay bounded.** Research mode caps provider work and keeps partial results, failed providers go on cooldown, and extraction rejects private/internal target URLs before provider dispatch.
 
 ---
@@ -122,7 +122,7 @@ web_extract_plus(urls=["https://docs.linkup.so"], provider="linkup", render_js=F
 # → Linkup fetch endpoint
 ```
 
-Auto extraction tries Tavily → Exa → Linkup → Parallel → Firecrawl → You.com for configured keys, then Keenable (only if configured), and finally Serper's webpage scraper as the last-resort safety net. Large pages use truncate-and-store output handling: a bounded head/tail preview inline, the full cleaned text stored under `cache/web/`, and a ready-to-run `read_file` call in the footer for paging into the omitted middle.
+Auto extraction defaults to Tavily → Exa → Linkup → Parallel → Firecrawl → You.com → Keenable → Serper for configured providers. Operators can change only the extraction order with `setup.py config set-extract-priority serper,parallel,...`; omitted extraction providers are appended in the default registry order. This is separate from search `provider_priority`. Large pages use truncate-and-store output handling: a bounded head/tail preview inline, the full cleaned text stored under `cache/web/`, and a ready-to-run `read_file` call in the footer for paging into the omitted middle.
 
 Full parameter tables for both tools, freshness/vertical/locale semantics, and cache management live in the [User Guide](docs/USER_GUIDE.md#using-web_search_plus).
 

--- a/__init__.py
+++ b/__init__.py
@@ -168,6 +168,7 @@ def _get_hermes_env_path() -> Path:
 
 _SETUP_PROVIDER_NAMES = set(PROVIDER_SPECS)
 _DEFAULT_PROVIDER_PRIORITY = list(DEFAULT_PROVIDER_PRIORITY)
+_DEFAULT_EXTRACT_PROVIDER_PRIORITY = list(EXTRACT_PROVIDER_IDS)
 _DEFAULT_AUTO_ALLOW = dict(DEFAULT_AUTO_ALLOW)
 _ROUTING_PROVIDER_NAMES = set(PROVIDER_SPECS)
 
@@ -360,6 +361,7 @@ def _default_behavior_config() -> Dict[str, Any]:
             "enabled": True,
             "fallback_provider": "serper",
             "provider_priority": list(_DEFAULT_PROVIDER_PRIORITY),
+            "extract_provider_priority": list(_DEFAULT_EXTRACT_PROVIDER_PRIORITY),
             "disabled_providers": [],
             "auto_allow": dict(_DEFAULT_AUTO_ALLOW),
             "confidence_threshold": 0.3,
@@ -406,6 +408,26 @@ def _normalize_provider_csv(value: str, *, routing: bool = True) -> List[str]:
     return providers
 
 
+def _normalize_extract_provider_csv(value: str) -> List[str]:
+    providers: List[str] = []
+    seen = set()
+    extract_providers = set(_DEFAULT_EXTRACT_PROVIDER_PRIORITY)
+    for raw in (value or "").split(","):
+        if not raw.strip():
+            continue
+        provider = _normalize_routing_provider(raw)
+        if provider not in extract_providers:
+            raise SystemExit(f"Provider does not support extraction: {provider}")
+        if provider in seen:
+            print(f"warning: duplicate extract provider ignored: {provider}", file=sys.stderr)
+            continue
+        seen.add(provider)
+        providers.append(provider)
+    if not providers:
+        raise SystemExit("At least one extract provider is required.")
+    return providers
+
+
 def _append_missing_default_providers(providers: List[str]) -> List[str]:
     seen = set(providers)
     merged = list(providers)
@@ -414,6 +436,11 @@ def _append_missing_default_providers(providers: List[str]) -> List[str]:
             seen.add(provider)
             merged.append(provider)
     return merged
+
+
+def _append_missing_extract_providers(providers: List[str]) -> List[str]:
+    seen = set(providers)
+    return list(providers) + [provider for provider in _DEFAULT_EXTRACT_PROVIDER_PRIORITY if provider not in seen]
 
 
 def _merge_behavior_config(user_config: Mapping[str, Any]) -> Dict[str, Any]:
@@ -436,6 +463,12 @@ def _merge_behavior_config(user_config: Mapping[str, Any]) -> Dict[str, Any]:
         else:
             priority = _normalize_provider_csv(",".join(str(p) for p in auto_user["provider_priority"]), routing=True)
         auto["provider_priority"] = _append_missing_default_providers(priority) if auto.get("enabled", True) is not False else priority
+    if auto_user.get("extract_provider_priority"):
+        if isinstance(auto_user["extract_provider_priority"], str):
+            extract_priority = _normalize_extract_provider_csv(auto_user["extract_provider_priority"])
+        else:
+            extract_priority = _normalize_extract_provider_csv(",".join(str(p) for p in auto_user["extract_provider_priority"]))
+        auto["extract_provider_priority"] = _append_missing_extract_providers(extract_priority)
     if "disabled_providers" in auto_user:
         disabled = auto_user.get("disabled_providers") or []
         if isinstance(disabled, str):
@@ -543,7 +576,8 @@ def _routing_summary(config: Mapping[str, Any]) -> str:
         f"  auto-routing: {'on' if auto.get('enabled', True) else 'off'}",
         f"  default provider: {config.get('default_provider') or 'none'}",
         f"  fallback provider: {auto.get('fallback_provider', 'serper')}",
-        "  priority: " + ", ".join(auto.get("provider_priority", _DEFAULT_PROVIDER_PRIORITY)),
+        "  search priority: " + ", ".join(auto.get("provider_priority", _DEFAULT_PROVIDER_PRIORITY)),
+        "  extract priority: " + ", ".join(auto.get("extract_provider_priority", _DEFAULT_EXTRACT_PROVIDER_PRIORITY)),
         "  disabled: " + (", ".join(auto.get("disabled_providers", [])) or "none"),
         "  auto-allow false: " + (
             ", ".join(p for p, allowed in sorted((auto.get("auto_allow") or {}).items()) if allowed is False) or "none"
@@ -819,10 +853,14 @@ def _web_search_plus_cli_setup(parser: argparse.ArgumentParser) -> None:
     set_fallback.add_argument("provider")
     set_fallback.add_argument("--config-path")
     set_fallback.add_argument("--dry-run", action="store_true")
-    set_priority = config_subs.add_parser("set-priority", help="Set comma-separated auto-routing priority")
+    set_priority = config_subs.add_parser("set-priority", help="Set comma-separated search auto-routing priority")
     set_priority.add_argument("providers")
     set_priority.add_argument("--config-path")
     set_priority.add_argument("--dry-run", action="store_true")
+    set_extract_priority = config_subs.add_parser("set-extract-priority", help="Set comma-separated extraction auto-routing priority")
+    set_extract_priority.add_argument("providers")
+    set_extract_priority.add_argument("--config-path")
+    set_extract_priority.add_argument("--dry-run", action="store_true")
     disable = config_subs.add_parser("disable", help="Disable a provider for auto-routing")
     disable.add_argument("provider")
     disable.add_argument("--config-path")
@@ -901,6 +939,8 @@ def _handle_config_command(args: Any) -> None:
         config["auto_routing"]["fallback_provider"] = _normalize_routing_provider(getattr(args, "provider"))
     elif subcommand == "set-priority":
         config["auto_routing"]["provider_priority"] = _normalize_provider_csv(getattr(args, "providers"), routing=True)
+    elif subcommand == "set-extract-priority":
+        config["auto_routing"]["extract_provider_priority"] = _normalize_extract_provider_csv(getattr(args, "providers"))
     elif subcommand == "disable":
         provider = _normalize_routing_provider(getattr(args, "provider"))
         disabled = list(config["auto_routing"].get("disabled_providers", []))

--- a/config.py
+++ b/config.py
@@ -10,7 +10,13 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from env_loader import clean_env_value as _shared_clean_env_value, is_truthy, load_env_files
-from provider_registry import DEFAULT_AUTO_ALLOW, DEFAULT_PROVIDER_PRIORITY, PROVIDER_SPECS, keyless_public_env_var
+from provider_registry import (
+    DEFAULT_AUTO_ALLOW,
+    DEFAULT_PROVIDER_PRIORITY,
+    EXTRACT_PROVIDER_IDS,
+    PROVIDER_SPECS,
+    keyless_public_env_var,
+)
 
 
 class ProviderConfigError(Exception):
@@ -55,6 +61,7 @@ DEFAULT_CONFIG = {
         # Low-trust / experimental providers can stay configured for explicit use
         # without being selected automatically.
         "provider_priority": list(DEFAULT_PROVIDER_PRIORITY),
+        "extract_provider_priority": list(EXTRACT_PROVIDER_IDS),
         "disabled_providers": [],
         "auto_allow": dict(DEFAULT_AUTO_ALLOW),
         "confidence_threshold": 0.3,  # Below this, note low confidence
@@ -201,6 +208,36 @@ def _append_missing_default_providers(providers: List[str]) -> List[str]:
     return merged
 
 
+def _normalize_extract_provider_list_config(value: Any) -> List[str]:
+    if isinstance(value, str):
+        raw_values = [item.strip() for item in value.split(",")]
+    elif isinstance(value, list):
+        raw_values = [str(item).strip() for item in value]
+    else:
+        raise ValueError("extract provider list must be a string or list")
+    providers = []
+    seen = set()
+    extract_providers = set(EXTRACT_PROVIDER_IDS)
+    for raw in raw_values:
+        if not raw:
+            continue
+        provider = _normalize_routing_provider_config(raw)
+        if provider not in extract_providers:
+            raise ValueError(f"provider does not support extraction: {provider}")
+        if provider in seen:
+            continue
+        seen.add(provider)
+        providers.append(provider)
+    if not providers:
+        raise ValueError("extract provider list cannot be empty")
+    return providers
+
+
+def _append_missing_extract_providers(providers: List[str]) -> List[str]:
+    seen = set(providers)
+    return list(providers) + [provider for provider in EXTRACT_PROVIDER_IDS if provider not in seen]
+
+
 def _validate_runtime_config(config: Dict[str, Any]) -> Dict[str, Any]:
     auto = config.get("auto_routing", {})
     if not isinstance(auto, dict):
@@ -212,6 +249,11 @@ def _validate_runtime_config(config: Dict[str, Any]) -> Dict[str, Any]:
     if auto.get("provider_priority"):
         priority = _normalize_routing_provider_list_config(auto["provider_priority"])
         auto["provider_priority"] = _append_missing_default_providers(priority) if auto.get("enabled", True) is not False else priority
+    if auto.get("extract_provider_priority"):
+        extract_priority = _normalize_extract_provider_list_config(auto["extract_provider_priority"])
+        auto["extract_provider_priority"] = _append_missing_extract_providers(extract_priority)
+    else:
+        auto["extract_provider_priority"] = list(EXTRACT_PROVIDER_IDS)
     if "disabled_providers" in auto:
         disabled = auto.get("disabled_providers") or []
         if disabled:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,7 +63,8 @@ Default routing config includes:
   "auto_routing": {
     "enabled": true,
     "fallback_provider": "serper",
-    "provider_priority": ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "parallel", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng"],
+    "provider_priority": ["you", "serper", "exa", "firecrawl", "tavily", "linkup", "parallel", "brave", "serpbase", "querit", "kilo-perplexity", "perplexity", "searxng", "keenable"],
+    "extract_provider_priority": ["tavily", "exa", "linkup", "parallel", "firecrawl", "you", "keenable", "serper"],
     "disabled_providers": [],
     "auto_allow": {
       "serpbase": false,
@@ -78,7 +79,7 @@ Default routing config includes:
 }
 ```
 
-Secrets and routing are separate so users can configure a provider key without automatically letting that provider receive automatic traffic.
+Secrets and routing are separate so users can configure a provider key without automatically letting that provider receive automatic traffic. Search `provider_priority` and `extract_provider_priority` are independent: search ranking does not silently reorder URL extraction. A partial extraction list is normalized and completed with missing extract-capable providers in registry order.
 
 ## Routing engine
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -28,7 +28,7 @@ The default auto-search pool is conservative: You.com, Serper, Exa, Firecrawl, T
 
 For the exact flow, see [Architecture](ARCHITECTURE.md#routing-engine).
 
-## Which provider order should I use?
+## Which search or extraction provider order should I use?
 
 Measure instead of guessing: run the built-in provider bench, which races your configured providers against a small fixed query suite and recommends an `auto_routing.provider_priority` order ranked by success rate, median latency, and simple quality signals:
 
@@ -38,7 +38,15 @@ python ~/.hermes/plugins/web-search-plus/setup.py bench
 python3 search.py --bench
 ```
 
-The bench never changes your config — it prints the recommended priority plus the exact `config set-priority` command to apply it. Bench runs call providers directly, so they do not trigger cooldowns or feed adaptive routing statistics, but they do spend a few real API calls per provider. See [User Guide → Bench your providers](USER_GUIDE.md#bench-your-providers).
+The bench never changes your config — it prints the recommended **search** priority plus the exact `config set-priority` command to apply it. Bench runs call providers directly, so they do not trigger cooldowns or feed adaptive routing statistics, but they do spend a few real API calls per provider.
+
+Extraction has a separate order because search quality and extraction quality are different jobs. Configure it independently:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py config set-extract-priority serper,parallel,tavily,exa,linkup,firecrawl,you,keenable
+```
+
+This writes `auto_routing.extract_provider_priority`; it never changes search `provider_priority`. Omitted extract-capable providers are appended in registry order. See [User Guide → Bench your providers](USER_GUIDE.md#bench-your-providers).
 
 ## How do I force one provider?
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -142,10 +142,11 @@ Turn query-based auto-routing back on:
 python ~/.hermes/plugins/web-search-plus/setup.py config set-routing on
 ```
 
-Tune automatic routing and fallback:
+Tune automatic search routing, extraction routing, and fallback:
 
 ```bash
 python ~/.hermes/plugins/web-search-plus/setup.py config set-priority you,serper,exa,firecrawl,tavily,linkup
+python ~/.hermes/plugins/web-search-plus/setup.py config set-extract-priority serper,parallel,tavily,exa,linkup,firecrawl,you,keenable
 python ~/.hermes/plugins/web-search-plus/setup.py config set-fallback serper
 python ~/.hermes/plugins/web-search-plus/setup.py config disable perplexity
 python ~/.hermes/plugins/web-search-plus/setup.py config enable perplexity
@@ -161,7 +162,8 @@ python ~/.hermes/plugins/web-search-plus/setup.py config set-default you --dry-r
 Semantics worth knowing:
 
 - `set-default <provider>` disables auto-routing and makes `--provider auto` resolve to that provider; `set-routing on` restores query-based routing while keeping the saved default for later.
-- `set-priority` accepts comma-separated provider names, normalizes case/whitespace, and ignores duplicates with a warning.
+- `set-priority` changes search auto-routing and fallback priority only.
+- `set-extract-priority` changes `provider="auto"` extraction order only. It accepts extract-capable providers, removes duplicates, and appends omitted extract providers in registry order.
 - `set-auto-allow <provider> off` keeps a configured provider available for explicit calls while preventing auto-routing/fallback from selecting it.
 - `config reset --yes` backs up the existing file before writing fresh defaults.
 
@@ -362,7 +364,7 @@ Parameters:
 | `include_raw_html` | boolean | `false` | Include raw HTML when supported |
 | `render_js` | boolean | `false` | Render JavaScript before extraction when supported |
 
-Auto extraction currently tries Tavily, Exa, Linkup, Parallel, Firecrawl, and You.com when keys are available, then Keenable (only if a key is set or its public tier is opted in), and finally Serper as the last resort. Tavily is the fast reliable default; Exa is the fast docs/academic backup; Linkup stays the clean long-form fallback; Firecrawl remains the robust scraper safety net; Serper's webpage scraper (`https://scrape.serper.dev`, overridable via config `serper.scrape_url`, timeout via `serper.extract_timeout`) closes the chain so a Serper-only setup still gets extraction.
+Auto extraction defaults to Tavily, Exa, Linkup, Parallel, Firecrawl, You.com, Keenable, then Serper when those providers are configured. Change only this order with `setup.py config set-extract-priority ...`; the setting is stored as `auto_routing.extract_provider_priority` and does not inherit search `provider_priority`. Partial lists are completed with missing extract providers in registry order. Serper's webpage scraper (`https://scrape.serper.dev`, overridable via config `serper.scrape_url`, timeout via `serper.extract_timeout`) remains the public default's last-resort fallback. Each URL is returned independently; one failed URL does not discard successful results from the same call.
 
 Parallel extraction explicitly requests `full_content`. Its default budget is 60,000 characters per result and 120,000 characters total so long documents are not unfairly shortened compared with other extraction providers. Operators can override those request-side limits in `config.json` with `parallel.max_chars_per_result` and `parallel.max_chars_total`.
 

--- a/extract.py
+++ b/extract.py
@@ -32,6 +32,39 @@ from provider_registry import EXTRACT_PROVIDER_IDS
 EXTRACT_PROVIDER_PRIORITY = list(EXTRACT_PROVIDER_IDS)
 
 
+def resolve_extract_provider_priority(config: Optional[Dict[str, Any]] = None) -> List[str]:
+    """Return the configured extract order, completed with registry defaults.
+
+    Runtime callers may pass hand-built config dictionaries, so invalid,
+    duplicate, and search-only entries are ignored defensively here. Persisted
+    config is validated more strictly by config.py and setup.py.
+    """
+    auto_config = config.get("auto_routing", {}) if isinstance(config, dict) else {}
+    if not isinstance(auto_config, dict):
+        auto_config = {}
+    raw_priority = auto_config.get("extract_provider_priority")
+    if isinstance(raw_priority, str):
+        raw_values = raw_priority.split(",")
+    elif isinstance(raw_priority, (list, tuple)):
+        raw_values = raw_priority
+    else:
+        raw_values = []
+
+    providers: List[str] = []
+    seen = set()
+    allowed = set(EXTRACT_PROVIDER_PRIORITY)
+    for raw_provider in raw_values:
+        provider = str(raw_provider).strip().lower()
+        if provider not in allowed or provider in seen:
+            continue
+        seen.add(provider)
+        providers.append(provider)
+    for provider in EXTRACT_PROVIDER_PRIORITY:
+        if provider not in seen:
+            providers.append(provider)
+    return providers
+
+
 class ExtractUrlSecurityError(ValueError):
     """Raised when an extraction target URL points at an internal resource."""
 
@@ -124,7 +157,7 @@ def extract_plus(
         }
     auto_config = config.get("auto_routing", {})
     disabled_providers = set(auto_config.get("disabled_providers", []))
-    base_providers = EXTRACT_PROVIDER_PRIORITY if selected == "auto" else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
+    base_providers = resolve_extract_provider_priority(config) if selected == "auto" else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
     providers = [p for p in base_providers if p == selected or p not in disabled_providers]
     errors = []
     cooldown_skips = []

--- a/search.py
+++ b/search.py
@@ -509,6 +509,7 @@ def _sync_extract_dependencies() -> None:
 
 
 EXTRACT_PROVIDER_PRIORITY = _extract.EXTRACT_PROVIDER_PRIORITY
+resolve_extract_provider_priority = _extract.resolve_extract_provider_priority
 
 
 PROVIDER_DOCTOR_CATALOG = doctor_catalog()

--- a/tests/test_extract_plus.py
+++ b/tests/test_extract_plus.py
@@ -207,6 +207,58 @@ class ExtractPlusCoreTests(unittest.TestCase):
     def test_extract_provider_priority_prefers_fast_clean_extractors(self):
         self.assertEqual(search.EXTRACT_PROVIDER_PRIORITY, ["tavily", "exa", "linkup", "parallel", "firecrawl", "you", "keenable", "serper"])
 
+    def test_extract_plus_auto_honors_extract_provider_priority(self):
+        config = {
+            "auto_routing": {
+                "extract_provider_priority": ["serper", "parallel"],
+                "disabled_providers": [],
+            }
+        }
+        with mock.patch.dict(os.environ, {"SERPER_API_KEY": "serper-test", "PARALLEL_API_KEY": "parallel-test"}, clear=True):
+            with mock.patch("search.extract_serper", return_value={"provider": "serper", "results": []}) as mock_serper:
+                with mock.patch("search.extract_parallel") as mock_parallel:
+                    result = search.extract_plus(["https://example.com"], provider="auto", config=config)
+
+        self.assertEqual(result["provider"], "serper")
+        mock_serper.assert_called_once()
+        mock_parallel.assert_not_called()
+
+    def test_extract_priority_partial_invalid_values_are_ignored_and_filled(self):
+        config = {
+            "auto_routing": {
+                "extract_provider_priority": ["serper", "not-a-provider", "serper"],
+                "disabled_providers": [],
+            }
+        }
+
+        self.assertEqual(
+            search.resolve_extract_provider_priority(config),
+            ["serper", "tavily", "exa", "linkup", "parallel", "firecrawl", "you", "keenable"],
+        )
+
+    def test_extract_priority_ignores_search_only_providers(self):
+        config = {
+            "auto_routing": {
+                "extract_provider_priority": ["serper", "brave", "parallel"],
+                "disabled_providers": [],
+            }
+        }
+
+        self.assertEqual(
+            search.resolve_extract_provider_priority(config),
+            ["serper", "parallel", "tavily", "exa", "linkup", "firecrawl", "you", "keenable"],
+        )
+
+    def test_search_provider_priority_does_not_change_extract_order(self):
+        config = {
+            "auto_routing": {
+                "provider_priority": ["serper", "tavily"],
+                "disabled_providers": [],
+            }
+        }
+
+        self.assertEqual(search.resolve_extract_provider_priority(config), search.EXTRACT_PROVIDER_PRIORITY)
+
     def test_extract_plus_auto_prefers_tavily_over_exa(self):
         with mock.patch.dict(os.environ, {"EXA_API_KEY": "exa-test", "TAVILY_API_KEY": "tvly-test"}, clear=True):
             with mock.patch("search.extract_exa", return_value={"provider": "exa", "results": []}) as mock_exa:

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -401,6 +401,7 @@ def test_default_behavior_config_blocks_low_trust_auto_providers():
     config = wsp._default_behavior_config()
 
     assert config["auto_routing"]["provider_priority"][:6] == ["you", "serper", "exa", "firecrawl", "tavily", "linkup"]
+    assert config["auto_routing"]["extract_provider_priority"] == list(wsp.EXTRACT_PROVIDER_IDS)
     assert config["auto_routing"]["auto_allow"]["serpbase"] is False
     assert config["auto_routing"]["auto_allow"]["querit"] is False
     assert config["auto_routing"]["auto_allow"]["brave"] is False
@@ -568,6 +569,41 @@ def test_config_show_human_contains_routing_summary(tmp_path, capsys):
     assert "Routing:" in out
     assert "auto-routing: on" in out
     assert "fallback provider: linkup" in out
+    assert "search priority:" in out
+    assert "extract priority:" in out
+
+
+def test_config_set_extract_priority_writes_isolated_complete_order(tmp_path):
+    config_path = tmp_path / "config.json"
+    parser = wsp.argparse.ArgumentParser()
+    wsp._web_search_plus_cli_setup(parser)
+    args = parser.parse_args([
+        "config", "set-extract-priority", "serper,parallel",
+        "--config-path", str(config_path),
+    ])
+
+    args.func(args)
+
+    data = json.loads(config_path.read_text())
+    assert data["auto_routing"]["extract_provider_priority"] == [
+        "serper", "parallel", "tavily", "exa", "linkup", "firecrawl", "you", "keenable"
+    ]
+    assert data["auto_routing"]["provider_priority"] == list(wsp._DEFAULT_PROVIDER_PRIORITY)
+
+
+def test_config_set_extract_priority_rejects_search_only_provider_without_writing(tmp_path):
+    config_path = tmp_path / "config.json"
+    parser = wsp.argparse.ArgumentParser()
+    wsp._web_search_plus_cli_setup(parser)
+    args = parser.parse_args([
+        "config", "set-extract-priority", "serper,brave",
+        "--config-path", str(config_path),
+    ])
+
+    with pytest.raises(SystemExit, match="does not support extraction"):
+        args.func(args)
+
+    assert not config_path.exists()
 
 
 def test_no_secret_leaks_across_status_and_config_commands(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- add independent `auto_routing.extract_provider_priority` configuration for `web_extract_plus(provider="auto")`
- preserve the existing Tavily-first registry order when the new key is absent, while completing partial configured lists with missing extract-capable providers
- add `setup.py config set-extract-priority ...`, separate search/extract priority status output, documentation, and Unreleased changelog notes

## Behavior

- search `provider_priority` no longer needs to double as an extraction control and does not influence extraction
- explicit `provider=...` extraction remains the first attempt and keeps the existing fallback chain
- persisted config rejects search-only providers; defensive runtime resolution ignores invalid and duplicate hand-built entries

## Verification

- `478 passed`
- `python3 -m compileall -q .`
- `ruff check .`
- generated provider and routing documentation checks
- `git diff --check`
- public diff privacy/secret scan
- live temporary-config extraction: `provider="auto"` selected Serper on the first attempt with `routing.provider="serper"` and `fallback_used=false`
- unset-key default serialized byte-for-byte identically to the pre-change registry order
