### PR TITLE
feat(v3): freeze search and extract contract

### DIFF
--- a/contract_v3.py
+++ b/contract_v3.py
@@ -1,0 +1,398 @@
+"""Frozen Web Search Plus v3 contract DTOs.
+
+This module is deliberately provider- and policy-agnostic. It defines the
+wire-level request/response vocabulary used by the engine, compatibility
+projections, golden fixtures, and external adapters.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+
+CONTRACT_VERSION = "3.0"
+
+
+class StrEnum(str, Enum):
+    def __str__(self) -> str:
+        return self.value
+
+
+class Capability(StrEnum):
+    SEARCH = "search"
+    EXTRACT = "extract"
+
+
+class ResponseStatus(StrEnum):
+    OK = "ok"
+    DEGRADED = "degraded"
+    FAILED = "failed"
+
+
+class ErrorClass(StrEnum):
+    INVALID_REQUEST = "invalid_request"
+    UNSUPPORTED = "unsupported"
+    CONFIG = "config"
+    AUTH = "auth"
+    QUOTA = "quota"
+    RATE_LIMIT = "rate_limit"
+    TRANSIENT = "transient"
+    TIMEOUT = "timeout"
+    PROVIDER_CONTRACT = "provider_contract"
+    CONTENT = "content"
+    SECURITY = "security"
+    BUDGET = "budget"
+    CANCELLED = "cancelled"
+    INTERNAL = "internal"
+
+
+class AttemptOutcome(StrEnum):
+    SUCCESS = "success"
+    PARTIAL = "partial"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class SkipReason(StrEnum):
+    DISABLED = "disabled"
+    UNSUPPORTED_CAPABILITY = "unsupported_capability"
+    NOT_CONFIGURED = "not_configured"
+    MISSING_CREDENTIALS = "missing_credentials"
+    AUTH_BLOCKED = "auth_blocked"
+    QUOTA_BLOCKED = "quota_blocked"
+    RATE_LIMITED = "rate_limited"
+    CIRCUIT_OPEN = "circuit_open"
+    BUDGET_BLOCKED = "budget_blocked"
+    POLICY_EXCLUDED = "policy_excluded"
+    DEADLINE_EXCEEDED = "deadline_exceeded"
+
+
+class FallbackReason(StrEnum):
+    NONE = "none"
+    SELECTED_FAILED = "selected_failed"
+    SELECTED_SKIPPED = "selected_skipped"
+    INSUFFICIENT_RESULTS = "insufficient_results"
+    PARTIAL_CONTENT = "partial_content"
+    BUDGET_CHAIN = "budget_chain"
+
+
+class CacheDisposition(StrEnum):
+    FRESH_HIT = "fresh_hit"
+    STALE_HIT = "stale_hit"
+    MISS = "miss"
+    BYPASSED = "bypassed"
+    UNAVAILABLE = "unavailable"
+
+
+class CircuitState(StrEnum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+    BLOCKED_AUTH = "blocked_auth"
+    BLOCKED_QUOTA = "blocked_quota"
+    UNKNOWN = "unknown"
+
+
+def _plain(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, list):
+        return [_plain(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _plain(item) for key, item in value.items() if item is not None}
+    if hasattr(value, "to_dict"):
+        return value.to_dict()
+    return value
+
+
+@dataclass(frozen=True)
+class ErrorV3:
+    error_class: ErrorClass
+    code: str
+    message: str
+    retryable: bool = False
+    provider: Optional[str] = None
+    http_status: Optional[int] = None
+    retry_after_seconds: Optional[float] = None
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return _plain(self.__dict__)
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "ErrorV3":
+        return cls(
+            error_class=ErrorClass(payload["error_class"]),
+            code=str(payload["code"]),
+            message=str(payload["message"]),
+            retryable=bool(payload.get("retryable", False)),
+            provider=payload.get("provider"),
+            http_status=payload.get("http_status"),
+            retry_after_seconds=payload.get("retry_after_seconds"),
+            details=dict(payload.get("details") or {}),
+        )
+
+
+@dataclass(frozen=True)
+class ProviderAttemptV3:
+    attempt_id: str
+    provider: str
+    capability: Capability
+    outcome: AttemptOutcome
+    retry_count: int = 0
+    result_count: int = 0
+    started_at: Optional[str] = None
+    duration_ms: Optional[int] = None
+    error: Optional[ErrorV3] = None
+    skip_reason: Optional[SkipReason] = None
+    budget_decision: Optional[str] = None
+    circuit_state_before: CircuitState = CircuitState.UNKNOWN
+    circuit_state_after: CircuitState = CircuitState.UNKNOWN
+
+    def __post_init__(self) -> None:
+        if self.retry_count < 0 or self.result_count < 0:
+            raise ValueError("retry_count and result_count must be non-negative")
+        if self.outcome is AttemptOutcome.SKIPPED and self.skip_reason is None:
+            raise ValueError("skipped attempts require skip_reason")
+        if self.outcome is AttemptOutcome.FAILED and self.error is None:
+            raise ValueError("failed attempts require error")
+        if (
+            self.outcome in {AttemptOutcome.SUCCESS, AttemptOutcome.PARTIAL}
+            and self.skip_reason is not None
+        ):
+            raise ValueError("executed attempts cannot carry skip_reason")
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = _plain(self.__dict__)
+        return {key: value for key, value in payload.items() if value is not None}
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "ProviderAttemptV3":
+        return cls(
+            attempt_id=str(payload["attempt_id"]),
+            provider=str(payload["provider"]),
+            capability=Capability(payload["capability"]),
+            outcome=AttemptOutcome(payload["outcome"]),
+            retry_count=int(payload.get("retry_count", 0)),
+            result_count=int(payload.get("result_count", 0)),
+            started_at=payload.get("started_at"),
+            duration_ms=payload.get("duration_ms"),
+            error=ErrorV3.from_dict(payload["error"]) if payload.get("error") else None,
+            skip_reason=SkipReason(payload["skip_reason"])
+            if payload.get("skip_reason")
+            else None,
+            budget_decision=payload.get("budget_decision"),
+            circuit_state_before=CircuitState(
+                payload.get("circuit_state_before", "unknown")
+            ),
+            circuit_state_after=CircuitState(
+                payload.get("circuit_state_after", "unknown")
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class RequestV3:
+    capability: Capability
+    input: Dict[str, Any]
+    request_id: Optional[str] = None
+    options: Dict[str, Any] = field(default_factory=dict)
+    cache: Dict[str, Any] = field(default_factory=dict)
+    routing: Dict[str, Any] = field(default_factory=dict)
+    budget: Dict[str, Any] = field(default_factory=dict)
+    client: Dict[str, Any] = field(default_factory=dict)
+    contract_version: str = CONTRACT_VERSION
+
+    def __post_init__(self) -> None:
+        if self.contract_version != CONTRACT_VERSION:
+            raise ValueError(f"unsupported contract_version: {self.contract_version}")
+        if self.capability is Capability.SEARCH:
+            query = self.input.get("query")
+            if not isinstance(query, str) or not query.strip() or "urls" in self.input:
+                raise ValueError(
+                    "search input requires non-empty query and forbids urls"
+                )
+        elif self.capability is Capability.EXTRACT:
+            urls = self.input.get("urls")
+            if (
+                not isinstance(urls, list)
+                or not urls
+                or not all(isinstance(url, str) and url for url in urls)
+                or "query" in self.input
+            ):
+                raise ValueError(
+                    "extract input requires non-empty urls and forbids query"
+                )
+
+    @classmethod
+    def search(
+        cls,
+        query: str,
+        *,
+        request_id: Optional[str] = None,
+        max_results: int = 5,
+        freshness: Optional[str] = None,
+        accept_features: Optional[List[str]] = None,
+    ) -> "RequestV3":
+        options: Dict[str, Any] = {"max_results": max_results}
+        if freshness is not None:
+            options["freshness"] = freshness
+        client = {
+            "accept_contract_versions": [CONTRACT_VERSION],
+            "accept_features": list(accept_features or []),
+        }
+        return cls(
+            Capability.SEARCH,
+            {"query": query},
+            request_id=request_id,
+            options=options,
+            client=client,
+        )
+
+    @classmethod
+    def extract(
+        cls,
+        urls: List[str],
+        *,
+        request_id: Optional[str] = None,
+        output_format: str = "markdown",
+        include_images: bool = False,
+    ) -> "RequestV3":
+        return cls(
+            Capability.EXTRACT,
+            {"urls": list(urls)},
+            request_id=request_id,
+            options={"output_format": output_format, "include_images": include_images},
+            client={
+                "accept_contract_versions": [CONTRACT_VERSION],
+                "accept_features": [],
+            },
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = {
+            "contract_version": self.contract_version,
+            "request_id": self.request_id,
+            "capability": self.capability,
+            "input": self.input,
+            "options": self.options,
+            "cache": self.cache,
+            "routing": self.routing,
+            "budget": self.budget,
+            "client": self.client,
+        }
+        return {
+            key: _plain(value)
+            for key, value in payload.items()
+            if value not in (None, {})
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "RequestV3":
+        return cls(
+            capability=Capability(payload["capability"]),
+            input=dict(payload["input"]),
+            request_id=payload.get("request_id"),
+            options=dict(payload.get("options") or {}),
+            cache=dict(payload.get("cache") or {}),
+            routing=dict(payload.get("routing") or {}),
+            budget=dict(payload.get("budget") or {}),
+            client=dict(payload.get("client") or {}),
+            contract_version=str(payload.get("contract_version", "")),
+        )
+
+
+@dataclass(frozen=True)
+class ResponseV3:
+    request_id: str
+    capability: Capability
+    status: ResponseStatus
+    results: List[Dict[str, Any]]
+    provider_attempts: List[ProviderAttemptV3]
+    routing_receipt: Dict[str, Any]
+    cache_status: Dict[str, Any]
+    limits_applied: Dict[str, Any] = field(default_factory=dict)
+    dedup_clusters: List[Dict[str, Any]] = field(default_factory=list)
+    source_independence_estimate: Optional[Dict[str, Any]] = None
+    warnings: List[Dict[str, Any]] = field(default_factory=list)
+    error: Optional[ErrorV3] = None
+    contract_version: str = CONTRACT_VERSION
+
+    def __post_init__(self) -> None:
+        if self.contract_version != CONTRACT_VERSION:
+            raise ValueError(f"unsupported contract_version: {self.contract_version}")
+        required_receipt_fields = {
+            "policy_id",
+            "policy_revision",
+            "mode",
+            "candidate_order",
+            "selected_provider",
+            "fallback_reason",
+        }
+        if not required_receipt_fields.issubset(self.routing_receipt):
+            raise ValueError("routing_receipt is missing frozen required fields")
+        if self.status is ResponseStatus.FAILED and self.error is None:
+            raise ValueError("failed response requires error")
+        if self.status is not ResponseStatus.FAILED and self.error is not None:
+            raise ValueError("top-level error is reserved for failed responses")
+
+    def to_dict(self) -> Dict[str, Any]:
+        payload = {
+            "contract_version": self.contract_version,
+            "request_id": self.request_id,
+            "capability": self.capability,
+            "status": self.status,
+            "results": self.results,
+            "provider_attempts": [
+                attempt.to_dict() for attempt in self.provider_attempts
+            ],
+            "routing_receipt": self.routing_receipt,
+            "cache_status": self.cache_status,
+            "limits_applied": self.limits_applied,
+            "dedup_clusters": self.dedup_clusters,
+            "source_independence_estimate": self.source_independence_estimate,
+            "warnings": self.warnings,
+            "error": self.error,
+        }
+        required_empty_fields = {
+            "results",
+            "provider_attempts",
+            "routing_receipt",
+            "cache_status",
+            "limits_applied",
+            "dedup_clusters",
+            "warnings",
+        }
+        return {
+            key: _plain(value)
+            for key, value in payload.items()
+            if value not in (None, {}, []) or key in required_empty_fields
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "ResponseV3":
+        return cls(
+            request_id=str(payload["request_id"]),
+            capability=Capability(payload["capability"]),
+            status=ResponseStatus(payload["status"]),
+            results=[dict(item) for item in payload.get("results", [])],
+            provider_attempts=[
+                ProviderAttemptV3.from_dict(item)
+                for item in payload.get("provider_attempts", [])
+            ],
+            routing_receipt=dict(payload["routing_receipt"]),
+            cache_status=dict(payload["cache_status"]),
+            limits_applied=dict(payload.get("limits_applied") or {}),
+            dedup_clusters=[dict(item) for item in payload.get("dedup_clusters", [])],
+            source_independence_estimate=(
+                dict(payload["source_independence_estimate"])
+                if payload.get("source_independence_estimate") is not None
+                else None
+            ),
+            warnings=[dict(item) for item in payload.get("warnings", [])],
+            error=ErrorV3.from_dict(payload["error"]) if payload.get("error") else None,
+            contract_version=str(payload.get("contract_version", "")),
+        )

--- a/contract_v3.py
+++ b/contract_v3.py
@@ -31,6 +31,15 @@ class ResponseStatus(StrEnum):
     FAILED = "failed"
 
 
+class DegradedReason(StrEnum):
+    SERVED_STALE = "wsp.cache.served_stale"
+    CONTENT_TRUNCATED = "wsp.content.truncated"
+    URLS_OMITTED = "wsp.extract.urls_omitted"
+    PARTIAL_EXTRACTION = "wsp.extract.partial"
+    BUDGET_LIMITED = "wsp.budget.limited"
+    FINGERPRINTING_REDUCED = "wsp.independence.method_degraded"
+
+
 class ErrorClass(StrEnum):
     INVALID_REQUEST = "invalid_request"
     UNSUPPORTED = "unsupported"
@@ -334,6 +343,17 @@ class ResponseV3:
         }
         if not required_receipt_fields.issubset(self.routing_receipt):
             raise ValueError("routing_receipt is missing frozen required fields")
+        if self.status is ResponseStatus.DEGRADED:
+            accepted_codes = {reason.value for reason in DegradedReason}
+            warning_codes = {
+                warning.get("code")
+                for warning in self.warnings
+                if isinstance(warning, dict)
+            }
+            if not accepted_codes.intersection(warning_codes):
+                raise ValueError(
+                    "degraded response requires an enumerated degrade warning"
+                )
         if self.status is ResponseStatus.FAILED and self.error is None:
             raise ValueError("failed response requires error")
         if self.status is not ResponseStatus.FAILED and self.error is not None:

--- a/docs/v3-contract-freeze.md
+++ b/docs/v3-contract-freeze.md
@@ -1,0 +1,383 @@
+# Web Search Plus v3 contract freeze — M0 engine side
+
+Status: **engine-owner field freeze candidate**. The field names, enum namespaces, and projection/cache rules below are frozen on the engine side. Items under **Joint decisions required** need engine-owner and policy-owner sign-off before the six golden fixtures become normative.
+
+Canonical artifacts:
+
+- `contract_v3.py` — Python DTOs and enum namespace
+- `schemas/v3/request.schema.json` — self-contained Draft 2020-12 RequestV3 schema
+- `schemas/v3/response.schema.json` — self-contained Draft 2020-12 ResponseV3 schema
+- `scripts/gen_contract_v3_schemas.py` — schema generator sourcing enum values from the DTO module
+
+## Charter boundary
+
+The engine exposes exactly two capabilities:
+
+- `search`
+- `extract`
+
+It does not synthesize answers, judge truth, generate claims, verify claims, or watch sources. `verify` and `watch` may consume this contract from separate components but are never values of `Capability`.
+
+Mechanical extraction offsets are in 3.0. Semantic spans, claim/evidence mapping, schema-directed extraction, and relevance interpretation are 3.1 or later.
+
+## RequestV3 field freeze
+
+Required:
+
+- `contract_version: "3.0"`
+- `capability: "search" | "extract"`
+- `input: SearchInput | ExtractInput`
+
+Optional:
+
+- `request_id: string` — caller-supplied correlation ID; engine generates one when absent
+- `options: SearchOptions | ExtractOptions`
+- `cache: CacheRequest`
+- `routing: RoutingRequest`
+- `budget: BudgetRequest`
+- `client: ClientNegotiation`
+
+Unknown top-level and nested fields are rejected.
+
+### SearchInput
+
+Required:
+
+- `query: string`, non-empty
+
+Forbidden:
+
+- `urls`
+
+### ExtractInput
+
+Required:
+
+- `urls: URI[]`, 1–32 unique URLs
+
+Forbidden:
+
+- `query`
+
+### SearchOptions
+
+All optional:
+
+- `max_results: integer`, 1–50
+- `freshness: day | week | month | year`
+- `time_range: day | week | month | year`
+- `search_type: search | news`
+- `include_domains: string[]`
+- `exclude_domains: string[]`
+- `locale.country: ISO-3166 alpha-2`
+- `locale.language: ISO-639-1`
+
+### ExtractOptions
+
+All optional:
+
+- `output_format: markdown | html`
+- `include_images: boolean`
+- `include_raw_html: boolean`
+- `render_js: boolean`
+
+### CacheRequest
+
+All optional:
+
+- `mode: prefer | bypass | only`
+- `ttl_seconds: integer >= 0`
+- `allow_stale_seconds: integer >= 0`
+
+`only` never performs provider egress. A miss in `only` mode produces a failed response with an explicit cache error.
+
+### RoutingRequest
+
+All optional:
+
+- `mode: auto | fixed`
+- `provider: string`
+- `allow_fallback: boolean`
+- `policy_mode: classic | shadow`
+
+`shadow` never changes execution order. Classic remains authoritative in 3.0. Fixed mode requires a provider at semantic-validation time.
+
+### BudgetRequest
+
+All optional:
+
+- `max_provider_attempts: integer`, 1–32
+- `max_wall_time_ms: integer >= 1`
+- `max_cost_microunits: integer >= 0`
+
+`max_cost_microunits` is enforced only from operator/provider-known costs. Unknown provider costs are not invented; the admission decision and limitation are reported.
+
+### ClientNegotiation
+
+All optional:
+
+- `accept_contract_versions: unique array of "3.0" | "2.x"`
+- `accept_features: unique array of:`
+  - `provider_attempts`
+  - `dedup_clusters`
+  - `source_independence_estimate`
+  - `mechanical_text_offsets`
+  - `stale_cache`
+
+## ResponseV3 field freeze
+
+Required on every response:
+
+- `contract_version: "3.0"`
+- `request_id: string`
+- `capability: search | extract`
+- `status: ok | degraded | failed`
+- `results: SearchResultV3[] | ExtractResultV3[]`
+- `provider_attempts: ProviderAttemptV3[]`
+- `routing_receipt: RoutingReceipt`
+- `cache_status: CacheStatus`
+- `limits_applied: object`
+- `dedup_clusters: object[]`
+- `warnings: WarningV3[]`
+
+Optional:
+
+- `source_independence_estimate: IndependenceEstimate`
+- `error: ErrorV3` — required only for `status=failed`, forbidden otherwise
+
+### SearchResultV3
+
+Required:
+
+- `result_id: string`
+- `status: "ok"`
+- `title: string`
+- `url: URI`
+- `canonical_url: URI`
+- `provenance: ProvenanceObservation[]`, non-empty
+
+Optional:
+
+- `snippet: string`
+- `published_at: RFC-3339 date-time`
+- `cluster_id: string`
+
+### ExtractResultV3
+
+Required for all items:
+
+- `result_id: string`
+- `status: ok | failed`
+- `url: URI`
+- `canonical_url: URI`
+- `provenance: ProvenanceObservation[]`, non-empty
+
+Required when `status=ok`:
+
+- `text: string`
+- `offset_unit: "unicode_codepoint"`
+- `segments: TextSegmentV3[]`
+
+Required when `status=failed`:
+
+- `error: ErrorV3`
+
+A segment contains only `segment_id`, `start`, and `end`. It does not contain a claim, relevance score, semantic type, interpretation, or generated summary. Intervals are intended to be half-open `[start, end)`; see the joint-decision list.
+
+### ProvenanceObservation
+
+Required:
+
+- `provider: string`
+- `source_url: URI`
+- `retrieved_at: RFC-3339 date-time`
+
+Optional:
+
+- `provider_rank: integer >= 1`
+- `provider_result_id: string`
+
+### RoutingReceipt
+
+Required:
+
+- `policy_id: string`
+- `policy_revision: string`
+- `mode: classic | shadow`
+- `candidate_order: string[]`
+- `selected_provider: string | null`
+- `fallback_reason: FallbackReason`
+
+Optional:
+
+- `shadow: object` — proposed decision and comparison metadata only; never authoritative execution state
+
+### CacheStatus
+
+Required:
+
+- `disposition: fresh_hit | stale_hit | miss | bypassed | unavailable`
+
+Optional:
+
+- `entry_id: string`
+- `age_seconds: integer >= 0`
+- `ttl_seconds: integer >= 0`
+- `served_stale: boolean`
+- `source_contract_version: 3.0 | 2.x`
+- `write_error: string`
+
+## Frozen error and attempt namespace
+
+### ErrorClass
+
+- `invalid_request`
+- `unsupported`
+- `config`
+- `auth`
+- `quota`
+- `rate_limit`
+- `transient`
+- `timeout`
+- `provider_contract`
+- `content`
+- `security`
+- `budget`
+- `cancelled`
+- `internal`
+
+### ErrorV3
+
+Required:
+
+- `error_class: ErrorClass`
+- `code: string` matching `wsp.<namespace>.<specific>`
+- `message: non-empty string`
+- `retryable: boolean`
+
+Optional:
+
+- `provider: string`
+- `http_status: 100–599`
+- `retry_after_seconds: number >= 0`
+- `details: object`
+
+Provider-native codes may appear only under `details.provider_code`; they never become stable WSP error codes.
+
+### AttemptOutcome
+
+- `success`
+- `partial`
+- `skipped`
+- `failed`
+- `cancelled`
+
+A failed attempt requires `error`. A skipped attempt requires `skip_reason`.
+
+### SkipReason
+
+- `disabled`
+- `unsupported_capability`
+- `not_configured`
+- `missing_credentials`
+- `auth_blocked`
+- `quota_blocked`
+- `rate_limited`
+- `circuit_open`
+- `budget_blocked`
+- `policy_excluded`
+- `deadline_exceeded`
+
+### FallbackReason
+
+- `none`
+- `selected_failed`
+- `selected_skipped`
+- `insufficient_results`
+- `partial_content`
+- `budget_chain`
+
+### CircuitState
+
+- `closed`
+- `open`
+- `half_open`
+- `blocked_auth`
+- `blocked_quota`
+- `unknown`
+
+## v2 compatibility projection rules
+
+There is one v3 execution pipeline. Compatibility is projection only:
+
+```text
+legacy request -> RequestV3 -> v3 engine -> ResponseV3 -> legacy response
+```
+
+### Legacy request projection
+
+- Existing search CLI/tool fields map into `SearchInput`, `SearchOptions`, `CacheRequest`, and `RoutingRequest`.
+- Existing extract fields map into `ExtractInput` and `ExtractOptions`.
+- Missing v3-only fields receive engine defaults.
+- Explicit-provider calls preserve current strict/fallback semantics.
+- Invalid legacy combinations fail before provider egress.
+
+### Legacy search response projection
+
+- `results` maps from SearchResultV3 with v3-only IDs/provenance removed unless already representable.
+- `provider` is the selected successful provider.
+- Existing `routing` is projected from RoutingReceipt and ProviderAttemptV3.
+- `fallback_errors` is projected from failed attempts.
+- `cooldown_skips` is projected from skipped attempts with `circuit_open`.
+- `cached` and `cache_age_seconds` are projected from CacheStatus.
+- `quality_report` remains a projection/output option, not an alternate execution path.
+
+### Legacy extract response projection
+
+- `results[].content` is projected from `ExtractResultV3.text`.
+- Existing per-result errors are projected from failed ExtractResultV3 items.
+- Existing `routing.provider`, `requested_provider`, `fallback_used`, and `fallback_errors` derive from RoutingReceipt and ProviderAttemptV3.
+
+Projection must be deterministic and side-effect free. Legacy projections never write legacy cache entries.
+
+## Cache-v3 migration rules
+
+1. v3 cache keys are namespaced and include `contract_version`, capability, normalized request, output-affecting options, locale, bounds, and the authoritative classic provider plan where it affects content.
+2. Cache control, debug verbosity, telemetry settings, request IDs, and shadow-policy output do not alter content identity and therefore do not enter the content key.
+3. v3 writes only v3 envelopes. It never mutates or overwrites v2 files.
+4. A v2 search envelope may be read through a best-effort legacy reader when its marker set is complete and its request semantics can be represented losslessly.
+5. A legacy hit returns `source_contract_version="2.x"`; it is not silently rewritten during the request.
+6. Extract full-text files require v3 sidecar metadata before they can satisfy mechanical-offset or provenance guarantees. Bare v2 markdown files cannot masquerade as full v3 cache hits.
+7. Stale data is served only when the request allows it. The response becomes `degraded`, with `disposition="stale_hit"`, `served_stale=true`, and a warning.
+8. Cache corruption is `unavailable`, never a provider-health failure.
+9. Cache clear/stats operate only on positively identified WSP-owned envelopes and preserve health, telemetry, SQLite state, and foreign files.
+10. No eager cache migration. Entries migrate naturally on new successful writes.
+
+## Joint decisions required before M0 sign-off
+
+1. **Offset semantics:** approve Unicode code-point, zero-based, half-open `[start,end)` offsets. Alternative byte offsets would change every extract fixture.
+2. **Degraded semantics:** proposed rule — successful fallback alone remains `ok`; stale serving, omitted URLs, truncation, budget-limited execution, partial extraction, or reduced fingerprinting become `degraded`.
+3. **Error code registry:** approve stable engine-owned `wsp.<namespace>.<specific>` codes, with provider-native codes only in `details.provider_code`.
+4. **Telemetry privacy:** proposed default — no raw query, URL, snippet, extracted text, API key, endpoint credentials, or raw provider body in persistent routing telemetry. Store a rotating-salt request fingerprint plus derived routing features. Explicit debug capture is opt-in and TTL-bound.
+5. **Legacy cache read window:** proposed rule — support compatible v2 reads through the 3.0 minor line, remove no earlier than 3.1 with measured usage and release notes.
+6. **Source-independence omission:** proposed rule — omit the object when no trustworthy estimate can be computed; do not emit a fake zero.
+
+## M0 exit test contract
+
+The policy-owner's six fixtures must each validate against `response.schema.json`:
+
+- search success
+- extract success
+- cache hit
+- fallback
+- degraded
+- total failure
+
+Boundary tests must additionally prove:
+
+- `Capability` rejects `verify`, `watch`, and `answer`
+- Extract segments contain only mechanical offsets
+- top-level `error` appears only on failed responses
+- provider-native errors cannot expand the stable ErrorClass enum
+- shadow routing cannot change `candidate_order` used for execution
+- v2 projection is deterministic and does not write a second execution path

--- a/docs/v3-contract-freeze.md
+++ b/docs/v3-contract-freeze.md
@@ -1,6 +1,6 @@
 # Web Search Plus v3 contract freeze — M0 engine side
 
-Status: **engine-owner field freeze candidate**. The field names, enum namespaces, and projection/cache rules below are frozen on the engine side. Items under **Joint decisions required** need engine-owner and policy-owner sign-off before the six golden fixtures become normative.
+Status: **M0 FROZEN — engine-owner and policy-owner co-signed.** The field names, enum namespaces, projection/cache rules, six golden fixtures, and resolved joint decisions below are normative for M1. Any change now requires an explicit contract amendment and fixture update.
 
 Canonical artifacts:
 
@@ -176,13 +176,14 @@ Required when `status=ok`:
 
 - `text: string`
 - `offset_unit: "unicode_codepoint"`
+- `text_normalization: "NFC"`
 - `segments: TextSegmentV3[]`
 
 Required when `status=failed`:
 
 - `error: ErrorV3`
 
-A segment contains only `segment_id`, `start`, and `end`. It does not contain a claim, relevance score, semantic type, interpretation, or generated summary. Intervals are intended to be half-open `[start, end)`; see the joint-decision list.
+Before offsets are calculated, `text` is normalized to Unicode NFC. A segment contains only `segment_id`, `start`, and `end`. It does not contain a claim, relevance score, semantic type, interpretation, or generated summary. Offsets are zero-based Unicode code-point indexes into that exact NFC string and use half-open intervals `[start, end)`.
 
 ### ProvenanceObservation
 
@@ -353,14 +354,23 @@ Projection must be deterministic and side-effect free. Legacy projections never 
 9. Cache clear/stats operate only on positively identified WSP-owned envelopes and preserve health, telemetry, SQLite state, and foreign files.
 10. No eager cache migration. Entries migrate naturally on new successful writes.
 
-## Joint decisions required before M0 sign-off
+## Resolved joint decisions for M0 sign-off
 
-1. **Offset semantics:** approve Unicode code-point, zero-based, half-open `[start,end)` offsets. Alternative byte offsets would change every extract fixture.
-2. **Degraded semantics:** proposed rule — successful fallback alone remains `ok`; stale serving, omitted URLs, truncation, budget-limited execution, partial extraction, or reduced fingerprinting become `degraded`.
-3. **Error code registry:** approve stable engine-owned `wsp.<namespace>.<specific>` codes, with provider-native codes only in `details.provider_code`.
-4. **Telemetry privacy:** proposed default — no raw query, URL, snippet, extracted text, API key, endpoint credentials, or raw provider body in persistent routing telemetry. Store a rotating-salt request fingerprint plus derived routing features. Explicit debug capture is opt-in and TTL-bound.
-5. **Legacy cache read window:** proposed rule — support compatible v2 reads through the 3.0 minor line, remove no earlier than 3.1 with measured usage and release notes.
-6. **Source-independence omission:** proposed rule — omit the object when no trustworthy estimate can be computed; do not emit a fake zero.
+1. **Offset semantics:** Unicode NFC text, zero-based Unicode code-point indexes, half-open `[start,end)` intervals.
+2. **Degraded semantics:** successful fallback alone remains `ok`; stale serving, omitted URLs, truncation, budget-limited execution, partial extraction, or reduced fingerprinting become `degraded`. Every degraded response carries at least one enumerated degrade reason in `warnings[].code`.
+3. **Error code registry:** stable engine-owned `wsp.<namespace>.<specific>` codes, with provider-native codes only in `details.provider_code`.
+4. **Telemetry privacy:** no raw query, URL, snippet, extracted text, API key, endpoint credentials, or raw provider body in persistent routing telemetry by default. Store a rotating-salt request fingerprint plus derived routing features. Explicit debug capture is opt-in and TTL-bound.
+5. **Legacy cache read window:** support compatible v2 reads through the 3.0 minor line, remove no earlier than 3.1 with measured usage and release notes.
+6. **Source-independence omission:** omit the object when no trustworthy estimate can be computed; never emit a fake zero. URL-only mode may emit a real estimate with `method_degraded=true`.
+
+### Enumerated degrade warning codes
+
+- `wsp.cache.served_stale`
+- `wsp.content.truncated`
+- `wsp.extract.urls_omitted`
+- `wsp.extract.partial`
+- `wsp.budget.limited`
+- `wsp.independence.method_degraded`
 
 ## M0 exit test contract
 
@@ -380,4 +390,4 @@ Boundary tests must additionally prove:
 - top-level `error` appears only on failed responses
 - provider-native errors cannot expand the stable ErrorClass enum
 - shadow routing cannot change `candidate_order` used for execution
-- v2 projection is deterministic and does not write a second execution path
+- M0 proves the contract-level single-authority invariant: only `classic` and `shadow` modes exist, and shadow never controls execution. M1 must add the runtime proof that v2 projection is deterministic and does not create a second execution path.

--- a/schemas/v3/request.schema.json
+++ b/schemas/v3/request.schema.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://websearchplus.xyz/schema/v3/request.schema.json",
+  "title": "RequestV3",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "capability",
+    "input"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": "3.0"
+    },
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "capability": {
+      "$ref": "#/$defs/Capability"
+    },
+    "input": {
+      "type": "object"
+    },
+    "options": {
+      "type": "object"
+    },
+    "cache": {
+      "$ref": "#/$defs/CacheRequest"
+    },
+    "routing": {
+      "$ref": "#/$defs/RoutingRequest"
+    },
+    "budget": {
+      "$ref": "#/$defs/BudgetRequest"
+    },
+    "client": {
+      "$ref": "#/$defs/ClientNegotiation"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "capability": {
+            "const": "search"
+          }
+        },
+        "required": [
+          "capability"
+        ]
+      },
+      "then": {
+        "properties": {
+          "input": {
+            "$ref": "#/$defs/SearchInput"
+          },
+          "options": {
+            "$ref": "#/$defs/SearchOptions"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "capability": {
+            "const": "extract"
+          }
+        },
+        "required": [
+          "capability"
+        ]
+      },
+      "then": {
+        "properties": {
+          "input": {
+            "$ref": "#/$defs/ExtractInput"
+          },
+          "options": {
+            "$ref": "#/$defs/ExtractOptions"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "Capability": {
+      "type": "string",
+      "enum": [
+        "search",
+        "extract"
+      ]
+    },
+    "SearchInput": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "query"
+      ]
+    },
+    "ExtractInput": {
+      "type": "object",
+      "properties": {
+        "urls": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 32,
+          "items": {
+            "type": "string",
+            "format": "uri"
+          },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "urls"
+      ]
+    },
+    "SearchOptions": {
+      "type": "object",
+      "properties": {
+        "max_results": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50
+        },
+        "freshness": {
+          "type": "string",
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "year"
+          ]
+        },
+        "time_range": {
+          "type": "string",
+          "enum": [
+            "day",
+            "week",
+            "month",
+            "year"
+          ]
+        },
+        "search_type": {
+          "type": "string",
+          "enum": [
+            "search",
+            "news"
+          ]
+        },
+        "include_domains": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "exclude_domains": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "locale": {
+          "type": "object",
+          "properties": {
+            "country": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2}$"
+            },
+            "language": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2}$"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ExtractOptions": {
+      "type": "object",
+      "properties": {
+        "output_format": {
+          "type": "string",
+          "enum": [
+            "markdown",
+            "html"
+          ]
+        },
+        "include_images": {
+          "type": "boolean"
+        },
+        "include_raw_html": {
+          "type": "boolean"
+        },
+        "render_js": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "CacheRequest": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "prefer",
+            "bypass",
+            "only"
+          ]
+        },
+        "ttl_seconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "allow_stale_seconds": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "RoutingRequest": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "fixed"
+          ]
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "allow_fallback": {
+          "type": "boolean"
+        },
+        "policy_mode": {
+          "type": "string",
+          "enum": [
+            "classic",
+            "shadow"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "BudgetRequest": {
+      "type": "object",
+      "properties": {
+        "max_provider_attempts": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 32
+        },
+        "max_wall_time_ms": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_cost_microunits": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "ClientNegotiation": {
+      "type": "object",
+      "properties": {
+        "accept_contract_versions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "3.0",
+              "2.x"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "accept_features": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "provider_attempts",
+              "dedup_clusters",
+              "source_independence_estimate",
+              "mechanical_text_offsets",
+              "stale_cache"
+            ]
+          },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/v3/response.schema.json
+++ b/schemas/v3/response.schema.json
@@ -1,0 +1,738 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://websearchplus.xyz/schema/v3/response.schema.json",
+  "title": "ResponseV3",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract_version",
+    "request_id",
+    "capability",
+    "status",
+    "results",
+    "provider_attempts",
+    "routing_receipt",
+    "cache_status",
+    "limits_applied",
+    "warnings"
+  ],
+  "properties": {
+    "contract_version": {
+      "const": "3.0"
+    },
+    "request_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "capability": {
+      "$ref": "#/$defs/Capability"
+    },
+    "status": {
+      "$ref": "#/$defs/ResponseStatus"
+    },
+    "results": {
+      "type": "array"
+    },
+    "provider_attempts": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/ProviderAttemptV3"
+      }
+    },
+    "routing_receipt": {
+      "$ref": "#/$defs/RoutingReceipt"
+    },
+    "cache_status": {
+      "$ref": "#/$defs/CacheStatus"
+    },
+    "limits_applied": {
+      "type": "object"
+    },
+    "dedup_clusters": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "source_independence_estimate": {
+      "$ref": "#/$defs/IndependenceEstimate"
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WarningV3"
+      }
+    },
+    "error": {
+      "$ref": "#/$defs/ErrorV3"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "capability": {
+            "const": "search"
+          }
+        },
+        "required": [
+          "capability"
+        ]
+      },
+      "then": {
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/SearchResultV3"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "capability": {
+            "const": "extract"
+          }
+        },
+        "required": [
+          "capability"
+        ]
+      },
+      "then": {
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/$defs/ExtractResultV3"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "failed"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "error"
+        ]
+      },
+      "else": {
+        "not": {
+          "required": [
+            "error"
+          ]
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "Capability": {
+      "type": "string",
+      "enum": [
+        "search",
+        "extract"
+      ]
+    },
+    "ResponseStatus": {
+      "type": "string",
+      "enum": [
+        "ok",
+        "degraded",
+        "failed"
+      ]
+    },
+    "ErrorClass": {
+      "type": "string",
+      "enum": [
+        "invalid_request",
+        "unsupported",
+        "config",
+        "auth",
+        "quota",
+        "rate_limit",
+        "transient",
+        "timeout",
+        "provider_contract",
+        "content",
+        "security",
+        "budget",
+        "cancelled",
+        "internal"
+      ]
+    },
+    "AttemptOutcome": {
+      "type": "string",
+      "enum": [
+        "success",
+        "partial",
+        "skipped",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "SkipReason": {
+      "type": "string",
+      "enum": [
+        "disabled",
+        "unsupported_capability",
+        "not_configured",
+        "missing_credentials",
+        "auth_blocked",
+        "quota_blocked",
+        "rate_limited",
+        "circuit_open",
+        "budget_blocked",
+        "policy_excluded",
+        "deadline_exceeded"
+      ]
+    },
+    "FallbackReason": {
+      "type": "string",
+      "enum": [
+        "none",
+        "selected_failed",
+        "selected_skipped",
+        "insufficient_results",
+        "partial_content",
+        "budget_chain"
+      ]
+    },
+    "CacheDisposition": {
+      "type": "string",
+      "enum": [
+        "fresh_hit",
+        "stale_hit",
+        "miss",
+        "bypassed",
+        "unavailable"
+      ]
+    },
+    "CircuitState": {
+      "type": "string",
+      "enum": [
+        "closed",
+        "open",
+        "half_open",
+        "blocked_auth",
+        "blocked_quota",
+        "unknown"
+      ]
+    },
+    "ErrorV3": {
+      "type": "object",
+      "properties": {
+        "error_class": {
+          "$ref": "#/$defs/ErrorClass"
+        },
+        "code": {
+          "type": "string",
+          "pattern": "^wsp\\.[a-z0-9_]+(?:\\.[a-z0-9_]+)*$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "http_status": {
+          "type": "integer",
+          "minimum": 100,
+          "maximum": 599
+        },
+        "retry_after_seconds": {
+          "type": "number",
+          "minimum": 0
+        },
+        "details": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "error_class",
+        "code",
+        "message",
+        "retryable"
+      ]
+    },
+    "ProviderAttemptV3": {
+      "type": "object",
+      "properties": {
+        "attempt_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "capability": {
+          "$ref": "#/$defs/Capability"
+        },
+        "outcome": {
+          "$ref": "#/$defs/AttemptOutcome"
+        },
+        "retry_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "result_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "started_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "duration_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "error": {
+          "$ref": "#/$defs/ErrorV3"
+        },
+        "skip_reason": {
+          "$ref": "#/$defs/SkipReason"
+        },
+        "budget_decision": {
+          "type": "string",
+          "enum": [
+            "allowed",
+            "reserved",
+            "blocked",
+            "unknown"
+          ]
+        },
+        "circuit_state_before": {
+          "$ref": "#/$defs/CircuitState"
+        },
+        "circuit_state_after": {
+          "$ref": "#/$defs/CircuitState"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "attempt_id",
+        "provider",
+        "capability",
+        "outcome",
+        "retry_count",
+        "result_count",
+        "circuit_state_before",
+        "circuit_state_after"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "const": "failed"
+              }
+            },
+            "required": [
+              "outcome"
+            ]
+          },
+          "then": {
+            "required": [
+              "error"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "outcome": {
+                "const": "skipped"
+              }
+            },
+            "required": [
+              "outcome"
+            ]
+          },
+          "then": {
+            "required": [
+              "skip_reason"
+            ]
+          }
+        }
+      ]
+    },
+    "ProvenanceObservation": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "retrieved_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "provider_rank": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "provider_result_id": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "provider",
+        "source_url",
+        "retrieved_at"
+      ]
+    },
+    "TextSegmentV3": {
+      "type": "object",
+      "properties": {
+        "segment_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "start": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "end": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "segment_id",
+        "start",
+        "end"
+      ]
+    },
+    "SearchResultV3": {
+      "type": "object",
+      "properties": {
+        "result_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "const": "ok"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "canonical_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "snippet": {
+          "type": "string"
+        },
+        "published_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "cluster_id": {
+          "type": "string"
+        },
+        "provenance": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/ProvenanceObservation"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "result_id",
+        "status",
+        "title",
+        "url",
+        "canonical_url",
+        "provenance"
+      ]
+    },
+    "ExtractResultV3": {
+      "type": "object",
+      "properties": {
+        "result_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "ok",
+            "failed"
+          ]
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "canonical_url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "text": {
+          "type": "string"
+        },
+        "offset_unit": {
+          "const": "unicode_codepoint"
+        },
+        "segments": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/TextSegmentV3"
+          }
+        },
+        "provenance": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/ProvenanceObservation"
+          }
+        },
+        "error": {
+          "$ref": "#/$defs/ErrorV3"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "result_id",
+        "status",
+        "url",
+        "canonical_url",
+        "provenance"
+      ],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "ok"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "required": [
+              "text",
+              "offset_unit",
+              "segments"
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "status": {
+                "const": "failed"
+              }
+            },
+            "required": [
+              "status"
+            ]
+          },
+          "then": {
+            "required": [
+              "error"
+            ]
+          }
+        }
+      ]
+    },
+    "CacheStatus": {
+      "type": "object",
+      "properties": {
+        "disposition": {
+          "$ref": "#/$defs/CacheDisposition"
+        },
+        "entry_id": {
+          "type": "string"
+        },
+        "age_seconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "ttl_seconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "served_stale": {
+          "type": "boolean"
+        },
+        "source_contract_version": {
+          "type": "string",
+          "enum": [
+            "3.0",
+            "2.x"
+          ]
+        },
+        "write_error": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "disposition"
+      ]
+    },
+    "RoutingReceipt": {
+      "type": "object",
+      "properties": {
+        "policy_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "policy_revision": {
+          "type": "string",
+          "minLength": 1
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "classic",
+            "shadow"
+          ]
+        },
+        "candidate_order": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "selected_provider": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "fallback_reason": {
+          "$ref": "#/$defs/FallbackReason"
+        },
+        "shadow": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "policy_id",
+        "policy_revision",
+        "mode",
+        "candidate_order",
+        "selected_provider",
+        "fallback_reason"
+      ]
+    },
+    "IndependenceEstimate": {
+      "type": "object",
+      "properties": {
+        "score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "unique_cluster_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "result_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "source_family_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "provider_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "method": {
+          "type": "string"
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "method_degraded": {
+          "type": "boolean"
+        },
+        "limitations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "score",
+        "unique_cluster_count",
+        "result_count",
+        "source_family_count",
+        "provider_count",
+        "method",
+        "confidence",
+        "method_degraded",
+        "limitations"
+      ]
+    },
+    "WarningV3": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^wsp\\.[a-z0-9_]+(?:\\.[a-z0-9_]+)*$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1
+        },
+        "details": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "code",
+        "message"
+      ]
+    }
+  }
+}

--- a/schemas/v3/response.schema.json
+++ b/schemas/v3/response.schema.json
@@ -14,6 +14,7 @@
     "routing_receipt",
     "cache_status",
     "limits_applied",
+    "dedup_clusters",
     "warnings"
   ],
   "properties": {
@@ -135,6 +136,36 @@
           ]
         }
       }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "degraded"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "properties": {
+          "warnings": {
+            "contains": {
+              "type": "object",
+              "required": [
+                "code"
+              ],
+              "properties": {
+                "code": {
+                  "$ref": "#/$defs/DegradedReason"
+                }
+              }
+            },
+            "minContains": 1
+          }
+        }
+      }
     }
   ],
   "$defs": {
@@ -151,6 +182,17 @@
         "ok",
         "degraded",
         "failed"
+      ]
+    },
+    "DegradedReason": {
+      "type": "string",
+      "enum": [
+        "wsp.cache.served_stale",
+        "wsp.content.truncated",
+        "wsp.extract.urls_omitted",
+        "wsp.extract.partial",
+        "wsp.budget.limited",
+        "wsp.independence.method_degraded"
       ]
     },
     "ErrorClass": {
@@ -508,6 +550,9 @@
         "offset_unit": {
           "const": "unicode_codepoint"
         },
+        "text_normalization": {
+          "const": "NFC"
+        },
         "segments": {
           "type": "array",
           "items": {
@@ -549,6 +594,7 @@
             "required": [
               "text",
               "offset_unit",
+              "text_normalization",
               "segments"
             ]
           }

--- a/scripts/gen_contract_v3_schemas.py
+++ b/scripts/gen_contract_v3_schemas.py
@@ -1,0 +1,488 @@
+#!/usr/bin/env python3
+"""Generate self-contained Draft 2020-12 schemas for the frozen v3 contract."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from contract_v3 import (  # noqa: E402
+    AttemptOutcome,
+    CacheDisposition,
+    Capability,
+    CircuitState,
+    ErrorClass,
+    FallbackReason,
+    ResponseStatus,
+    SkipReason,
+)
+
+OUT = ROOT / "schemas" / "v3"
+
+
+def enum_schema(enum_cls):
+    return {"type": "string", "enum": [item.value for item in enum_cls]}
+
+
+def obj(properties, required=(), *, additional=False):
+    value = {
+        "type": "object",
+        "properties": properties,
+        "additionalProperties": additional,
+    }
+    if required:
+        value["required"] = list(required)
+    return value
+
+
+error = obj(
+    {
+        "error_class": {"$ref": "#/$defs/ErrorClass"},
+        "code": {"type": "string", "pattern": "^wsp\\.[a-z0-9_]+(?:\\.[a-z0-9_]+)*$"},
+        "message": {"type": "string", "minLength": 1},
+        "retryable": {"type": "boolean"},
+        "provider": {"type": "string", "minLength": 1},
+        "http_status": {"type": "integer", "minimum": 100, "maximum": 599},
+        "retry_after_seconds": {"type": "number", "minimum": 0},
+        "details": {"type": "object"},
+    },
+    ("error_class", "code", "message", "retryable"),
+)
+
+attempt = obj(
+    {
+        "attempt_id": {"type": "string", "minLength": 1},
+        "provider": {"type": "string", "minLength": 1},
+        "capability": {"$ref": "#/$defs/Capability"},
+        "outcome": {"$ref": "#/$defs/AttemptOutcome"},
+        "retry_count": {"type": "integer", "minimum": 0},
+        "result_count": {"type": "integer", "minimum": 0},
+        "started_at": {"type": "string", "format": "date-time"},
+        "duration_ms": {"type": "integer", "minimum": 0},
+        "error": {"$ref": "#/$defs/ErrorV3"},
+        "skip_reason": {"$ref": "#/$defs/SkipReason"},
+        "budget_decision": {
+            "type": "string",
+            "enum": ["allowed", "reserved", "blocked", "unknown"],
+        },
+        "circuit_state_before": {"$ref": "#/$defs/CircuitState"},
+        "circuit_state_after": {"$ref": "#/$defs/CircuitState"},
+    },
+    (
+        "attempt_id",
+        "provider",
+        "capability",
+        "outcome",
+        "retry_count",
+        "result_count",
+        "circuit_state_before",
+        "circuit_state_after",
+    ),
+)
+attempt["allOf"] = [
+    {
+        "if": {"properties": {"outcome": {"const": "failed"}}, "required": ["outcome"]},
+        "then": {"required": ["error"]},
+    },
+    {
+        "if": {
+            "properties": {"outcome": {"const": "skipped"}},
+            "required": ["outcome"],
+        },
+        "then": {"required": ["skip_reason"]},
+    },
+]
+
+request_defs = {
+    "Capability": enum_schema(Capability),
+    "SearchInput": obj({"query": {"type": "string", "minLength": 1}}, ("query",)),
+    "ExtractInput": obj(
+        {
+            "urls": {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 32,
+                "items": {"type": "string", "format": "uri"},
+                "uniqueItems": True,
+            }
+        },
+        ("urls",),
+    ),
+    "SearchOptions": obj(
+        {
+            "max_results": {"type": "integer", "minimum": 1, "maximum": 50},
+            "freshness": {"type": "string", "enum": ["day", "week", "month", "year"]},
+            "time_range": {"type": "string", "enum": ["day", "week", "month", "year"]},
+            "search_type": {"type": "string", "enum": ["search", "news"]},
+            "include_domains": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "uniqueItems": True,
+            },
+            "exclude_domains": {
+                "type": "array",
+                "items": {"type": "string", "minLength": 1},
+                "uniqueItems": True,
+            },
+            "locale": obj(
+                {
+                    "country": {"type": "string", "pattern": "^[A-Za-z]{2}$"},
+                    "language": {"type": "string", "pattern": "^[A-Za-z]{2}$"},
+                }
+            ),
+        }
+    ),
+    "ExtractOptions": obj(
+        {
+            "output_format": {"type": "string", "enum": ["markdown", "html"]},
+            "include_images": {"type": "boolean"},
+            "include_raw_html": {"type": "boolean"},
+            "render_js": {"type": "boolean"},
+        }
+    ),
+    "CacheRequest": obj(
+        {
+            "mode": {"type": "string", "enum": ["prefer", "bypass", "only"]},
+            "ttl_seconds": {"type": "integer", "minimum": 0},
+            "allow_stale_seconds": {"type": "integer", "minimum": 0},
+        }
+    ),
+    "RoutingRequest": obj(
+        {
+            "mode": {"type": "string", "enum": ["auto", "fixed"]},
+            "provider": {"type": "string", "minLength": 1},
+            "allow_fallback": {"type": "boolean"},
+            "policy_mode": {"type": "string", "enum": ["classic", "shadow"]},
+        }
+    ),
+    "BudgetRequest": obj(
+        {
+            "max_provider_attempts": {"type": "integer", "minimum": 1, "maximum": 32},
+            "max_wall_time_ms": {"type": "integer", "minimum": 1},
+            "max_cost_microunits": {"type": "integer", "minimum": 0},
+        }
+    ),
+    "ClientNegotiation": obj(
+        {
+            "accept_contract_versions": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "enum": ["3.0", "2.x"]},
+                "uniqueItems": True,
+            },
+            "accept_features": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "provider_attempts",
+                        "dedup_clusters",
+                        "source_independence_estimate",
+                        "mechanical_text_offsets",
+                        "stale_cache",
+                    ],
+                },
+                "uniqueItems": True,
+            },
+        }
+    ),
+}
+
+request_schema = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://websearchplus.xyz/schema/v3/request.schema.json",
+    "title": "RequestV3",
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["contract_version", "capability", "input"],
+    "properties": {
+        "contract_version": {"const": "3.0"},
+        "request_id": {"type": "string", "minLength": 1},
+        "capability": {"$ref": "#/$defs/Capability"},
+        "input": {"type": "object"},
+        "options": {"type": "object"},
+        "cache": {"$ref": "#/$defs/CacheRequest"},
+        "routing": {"$ref": "#/$defs/RoutingRequest"},
+        "budget": {"$ref": "#/$defs/BudgetRequest"},
+        "client": {"$ref": "#/$defs/ClientNegotiation"},
+    },
+    "allOf": [
+        {
+            "if": {
+                "properties": {"capability": {"const": "search"}},
+                "required": ["capability"],
+            },
+            "then": {
+                "properties": {
+                    "input": {"$ref": "#/$defs/SearchInput"},
+                    "options": {"$ref": "#/$defs/SearchOptions"},
+                }
+            },
+        },
+        {
+            "if": {
+                "properties": {"capability": {"const": "extract"}},
+                "required": ["capability"],
+            },
+            "then": {
+                "properties": {
+                    "input": {"$ref": "#/$defs/ExtractInput"},
+                    "options": {"$ref": "#/$defs/ExtractOptions"},
+                }
+            },
+        },
+    ],
+    "$defs": request_defs,
+}
+
+response_defs = {
+    "Capability": enum_schema(Capability),
+    "ResponseStatus": enum_schema(ResponseStatus),
+    "ErrorClass": enum_schema(ErrorClass),
+    "AttemptOutcome": enum_schema(AttemptOutcome),
+    "SkipReason": enum_schema(SkipReason),
+    "FallbackReason": enum_schema(FallbackReason),
+    "CacheDisposition": enum_schema(CacheDisposition),
+    "CircuitState": enum_schema(CircuitState),
+    "ErrorV3": error,
+    "ProviderAttemptV3": attempt,
+    "ProvenanceObservation": obj(
+        {
+            "provider": {"type": "string", "minLength": 1},
+            "source_url": {"type": "string", "format": "uri"},
+            "retrieved_at": {"type": "string", "format": "date-time"},
+            "provider_rank": {"type": "integer", "minimum": 1},
+            "provider_result_id": {"type": "string"},
+        },
+        ("provider", "source_url", "retrieved_at"),
+    ),
+    "TextSegmentV3": obj(
+        {
+            "segment_id": {"type": "string", "minLength": 1},
+            "start": {"type": "integer", "minimum": 0},
+            "end": {"type": "integer", "minimum": 0},
+        },
+        ("segment_id", "start", "end"),
+    ),
+    "SearchResultV3": obj(
+        {
+            "result_id": {"type": "string", "minLength": 1},
+            "status": {"const": "ok"},
+            "title": {"type": "string"},
+            "url": {"type": "string", "format": "uri"},
+            "canonical_url": {"type": "string", "format": "uri"},
+            "snippet": {"type": "string"},
+            "published_at": {"type": "string", "format": "date-time"},
+            "cluster_id": {"type": "string"},
+            "provenance": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"$ref": "#/$defs/ProvenanceObservation"},
+            },
+        },
+        ("result_id", "status", "title", "url", "canonical_url", "provenance"),
+    ),
+    "ExtractResultV3": obj(
+        {
+            "result_id": {"type": "string", "minLength": 1},
+            "status": {"type": "string", "enum": ["ok", "failed"]},
+            "title": {"type": "string"},
+            "url": {"type": "string", "format": "uri"},
+            "canonical_url": {"type": "string", "format": "uri"},
+            "text": {"type": "string"},
+            "offset_unit": {"const": "unicode_codepoint"},
+            "segments": {"type": "array", "items": {"$ref": "#/$defs/TextSegmentV3"}},
+            "provenance": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"$ref": "#/$defs/ProvenanceObservation"},
+            },
+            "error": {"$ref": "#/$defs/ErrorV3"},
+        },
+        ("result_id", "status", "url", "canonical_url", "provenance"),
+    ),
+    "CacheStatus": obj(
+        {
+            "disposition": {"$ref": "#/$defs/CacheDisposition"},
+            "entry_id": {"type": "string"},
+            "age_seconds": {"type": "integer", "minimum": 0},
+            "ttl_seconds": {"type": "integer", "minimum": 0},
+            "served_stale": {"type": "boolean"},
+            "source_contract_version": {"type": "string", "enum": ["3.0", "2.x"]},
+            "write_error": {"type": "string"},
+        },
+        ("disposition",),
+    ),
+    "RoutingReceipt": obj(
+        {
+            "policy_id": {"type": "string", "minLength": 1},
+            "policy_revision": {"type": "string", "minLength": 1},
+            "mode": {"type": "string", "enum": ["classic", "shadow"]},
+            "candidate_order": {"type": "array", "items": {"type": "string"}},
+            "selected_provider": {"type": ["string", "null"]},
+            "fallback_reason": {"$ref": "#/$defs/FallbackReason"},
+            "shadow": {"type": "object"},
+        },
+        (
+            "policy_id",
+            "policy_revision",
+            "mode",
+            "candidate_order",
+            "selected_provider",
+            "fallback_reason",
+        ),
+    ),
+    "IndependenceEstimate": obj(
+        {
+            "score": {"type": "number", "minimum": 0, "maximum": 1},
+            "unique_cluster_count": {"type": "integer", "minimum": 0},
+            "result_count": {"type": "integer", "minimum": 0},
+            "source_family_count": {"type": "integer", "minimum": 0},
+            "provider_count": {"type": "integer", "minimum": 0},
+            "method": {"type": "string"},
+            "confidence": {"type": "string", "enum": ["low", "medium", "high"]},
+            "method_degraded": {"type": "boolean"},
+            "limitations": {"type": "array", "items": {"type": "string"}},
+        },
+        (
+            "score",
+            "unique_cluster_count",
+            "result_count",
+            "source_family_count",
+            "provider_count",
+            "method",
+            "confidence",
+            "method_degraded",
+            "limitations",
+        ),
+    ),
+    "WarningV3": obj(
+        {
+            "code": {
+                "type": "string",
+                "pattern": "^wsp\\.[a-z0-9_]+(?:\\.[a-z0-9_]+)*$",
+            },
+            "message": {"type": "string", "minLength": 1},
+            "details": {"type": "object"},
+        },
+        ("code", "message"),
+    ),
+}
+response_defs["ExtractResultV3"]["allOf"] = [
+    {
+        "if": {"properties": {"status": {"const": "ok"}}, "required": ["status"]},
+        "then": {"required": ["text", "offset_unit", "segments"]},
+    },
+    {
+        "if": {"properties": {"status": {"const": "failed"}}, "required": ["status"]},
+        "then": {"required": ["error"]},
+    },
+]
+
+response_schema = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://websearchplus.xyz/schema/v3/response.schema.json",
+    "title": "ResponseV3",
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "contract_version",
+        "request_id",
+        "capability",
+        "status",
+        "results",
+        "provider_attempts",
+        "routing_receipt",
+        "cache_status",
+        "limits_applied",
+        "warnings",
+    ],
+    "properties": {
+        "contract_version": {"const": "3.0"},
+        "request_id": {"type": "string", "minLength": 1},
+        "capability": {"$ref": "#/$defs/Capability"},
+        "status": {"$ref": "#/$defs/ResponseStatus"},
+        "results": {"type": "array"},
+        "provider_attempts": {
+            "type": "array",
+            "items": {"$ref": "#/$defs/ProviderAttemptV3"},
+        },
+        "routing_receipt": {"$ref": "#/$defs/RoutingReceipt"},
+        "cache_status": {"$ref": "#/$defs/CacheStatus"},
+        "limits_applied": {"type": "object"},
+        "dedup_clusters": {"type": "array", "items": {"type": "object"}},
+        "source_independence_estimate": {"$ref": "#/$defs/IndependenceEstimate"},
+        "warnings": {"type": "array", "items": {"$ref": "#/$defs/WarningV3"}},
+        "error": {"$ref": "#/$defs/ErrorV3"},
+    },
+    "allOf": [
+        {
+            "if": {
+                "properties": {"capability": {"const": "search"}},
+                "required": ["capability"],
+            },
+            "then": {
+                "properties": {
+                    "results": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/SearchResultV3"},
+                    }
+                }
+            },
+        },
+        {
+            "if": {
+                "properties": {"capability": {"const": "extract"}},
+                "required": ["capability"],
+            },
+            "then": {
+                "properties": {
+                    "results": {
+                        "type": "array",
+                        "items": {"$ref": "#/$defs/ExtractResultV3"},
+                    }
+                }
+            },
+        },
+        {
+            "if": {
+                "properties": {"status": {"const": "failed"}},
+                "required": ["status"],
+            },
+            "then": {"required": ["error"]},
+            "else": {"not": {"required": ["error"]}},
+        },
+    ],
+    "$defs": response_defs,
+}
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--check",
+    action="store_true",
+    help="fail when committed schemas differ from generated output",
+)
+args = parser.parse_args()
+
+OUT.mkdir(parents=True, exist_ok=True)
+stale = []
+for name, schema in (
+    ("request.schema.json", request_schema),
+    ("response.schema.json", response_schema),
+):
+    path = OUT / name
+    rendered = json.dumps(schema, indent=2, ensure_ascii=False) + "\n"
+    if args.check:
+        if not path.exists() or path.read_text(encoding="utf-8") != rendered:
+            stale.append(str(path))
+    else:
+        path.write_text(rendered, encoding="utf-8")
+        print(f"generated {path}")
+
+if stale:
+    parser.error("stale generated schemas: " + ", ".join(stale))
+if args.check:
+    print("contract v3 schemas are current")

--- a/scripts/gen_contract_v3_schemas.py
+++ b/scripts/gen_contract_v3_schemas.py
@@ -14,6 +14,7 @@ from contract_v3 import (  # noqa: E402
     CacheDisposition,
     Capability,
     CircuitState,
+    DegradedReason,
     ErrorClass,
     FallbackReason,
     ResponseStatus,
@@ -241,6 +242,7 @@ request_schema = {
 response_defs = {
     "Capability": enum_schema(Capability),
     "ResponseStatus": enum_schema(ResponseStatus),
+    "DegradedReason": enum_schema(DegradedReason),
     "ErrorClass": enum_schema(ErrorClass),
     "AttemptOutcome": enum_schema(AttemptOutcome),
     "SkipReason": enum_schema(SkipReason),
@@ -294,6 +296,7 @@ response_defs = {
             "canonical_url": {"type": "string", "format": "uri"},
             "text": {"type": "string"},
             "offset_unit": {"const": "unicode_codepoint"},
+            "text_normalization": {"const": "NFC"},
             "segments": {"type": "array", "items": {"$ref": "#/$defs/TextSegmentV3"}},
             "provenance": {
                 "type": "array",
@@ -374,7 +377,7 @@ response_defs = {
 response_defs["ExtractResultV3"]["allOf"] = [
     {
         "if": {"properties": {"status": {"const": "ok"}}, "required": ["status"]},
-        "then": {"required": ["text", "offset_unit", "segments"]},
+        "then": {"required": ["text", "offset_unit", "text_normalization", "segments"]},
     },
     {
         "if": {"properties": {"status": {"const": "failed"}}, "required": ["status"]},
@@ -398,6 +401,7 @@ response_schema = {
         "routing_receipt",
         "cache_status",
         "limits_applied",
+        "dedup_clusters",
         "warnings",
     ],
     "properties": {
@@ -454,6 +458,24 @@ response_schema = {
             },
             "then": {"required": ["error"]},
             "else": {"not": {"required": ["error"]}},
+        },
+        {
+            "if": {
+                "properties": {"status": {"const": "degraded"}},
+                "required": ["status"],
+            },
+            "then": {
+                "properties": {
+                    "warnings": {
+                        "contains": {
+                            "type": "object",
+                            "required": ["code"],
+                            "properties": {"code": {"$ref": "#/$defs/DegradedReason"}},
+                        },
+                        "minContains": 1,
+                    }
+                }
+            },
         },
     ],
     "$defs": response_defs,

--- a/tests/fixtures/v3/01_search_success.json
+++ b/tests/fixtures/v3/01_search_success.json
@@ -1,0 +1,84 @@
+{
+  "contract_version": "3.0",
+  "request_id": "req_search_0001",
+  "capability": "search",
+  "status": "ok",
+  "results": [
+    {
+      "result_id": "res_1",
+      "status": "ok",
+      "title": "Example Domain",
+      "url": "https://example.com/article",
+      "canonical_url": "https://example.com/article",
+      "snippet": "An illustrative first result.",
+      "published_at": "2026-07-10T12:00:00Z",
+      "cluster_id": "dc_1",
+      "provenance": [
+        {
+          "provider": "serper",
+          "source_url": "https://example.com/article",
+          "retrieved_at": "2026-07-12T08:30:00Z",
+          "provider_rank": 1
+        }
+      ]
+    },
+    {
+      "result_id": "res_2",
+      "status": "ok",
+      "title": "Another Source",
+      "url": "https://news.example.org/story",
+      "canonical_url": "https://news.example.org/story",
+      "snippet": "A second, distinct-domain result.",
+      "cluster_id": "dc_2",
+      "provenance": [
+        {
+          "provider": "serper",
+          "source_url": "https://news.example.org/story",
+          "retrieved_at": "2026-07-12T08:30:00Z",
+          "provider_rank": 2
+        }
+      ]
+    }
+  ],
+  "provider_attempts": [
+    {
+      "attempt_id": "att_1",
+      "provider": "serper",
+      "capability": "search",
+      "outcome": "success",
+      "retry_count": 0,
+      "result_count": 2,
+      "started_at": "2026-07-12T08:30:00Z",
+      "duration_ms": 420,
+      "budget_decision": "allowed",
+      "circuit_state_before": "closed",
+      "circuit_state_after": "closed"
+    }
+  ],
+  "routing_receipt": {
+    "policy_id": "classic",
+    "policy_revision": "1",
+    "mode": "classic",
+    "candidate_order": ["serper", "brave"],
+    "selected_provider": "serper",
+    "fallback_reason": "none"
+  },
+  "cache_status": { "disposition": "miss" },
+  "limits_applied": { "max_results": 10 },
+  "dedup_clusters": [
+    { "cluster_id": "dc_1", "canonical_result_id": "res_1", "member_result_ids": ["res_1"], "providers": ["serper"] },
+    { "cluster_id": "dc_2", "canonical_result_id": "res_2", "member_result_ids": ["res_2"], "providers": ["serper"] }
+  ],
+  "source_independence_estimate": {
+    "score": 0.7,
+    "unique_cluster_count": 2,
+    "result_count": 2,
+    "source_family_count": 2,
+    "provider_count": 1,
+    "method": "url+snippet-minhash-v1",
+    "confidence": "medium",
+    "method_degraded": false,
+    "limitations": ["shared upstream indexes may be undetectable"]
+  },
+  "warnings": []
+}

--- a/tests/fixtures/v3/02_extract_success.json
+++ b/tests/fixtures/v3/02_extract_success.json
@@ -1,0 +1,56 @@
+{
+  "contract_version": "3.0",
+  "request_id": "req_extract_0001",
+  "capability": "extract",
+  "status": "ok",
+  "results": [
+    {
+      "result_id": "ex_1",
+      "status": "ok",
+      "title": "Example Document",
+      "url": "https://example.com/doc",
+      "canonical_url": "https://example.com/doc",
+      "text": "Hello world. This is a document.",
+      "offset_unit": "unicode_codepoint",
+      "text_normalization": "NFC",
+      "segments": [
+        { "segment_id": "seg_1", "start": 0, "end": 12 },
+        { "segment_id": "seg_2", "start": 12, "end": 32 }
+      ],
+      "provenance": [
+        {
+          "provider": "tavily",
+          "source_url": "https://example.com/doc",
+          "retrieved_at": "2026-07-12T08:31:00Z"
+        }
+      ]
+    }
+  ],
+  "provider_attempts": [
+    {
+      "attempt_id": "att_1",
+      "provider": "tavily",
+      "capability": "extract",
+      "outcome": "success",
+      "retry_count": 0,
+      "result_count": 1,
+      "started_at": "2026-07-12T08:31:00Z",
+      "duration_ms": 800,
+      "budget_decision": "allowed",
+      "circuit_state_before": "closed",
+      "circuit_state_after": "closed"
+    }
+  ],
+  "routing_receipt": {
+    "policy_id": "classic",
+    "policy_revision": "1",
+    "mode": "classic",
+    "candidate_order": ["tavily"],
+    "selected_provider": "tavily",
+    "fallback_reason": "none"
+  },
+  "cache_status": { "disposition": "miss" },
+  "limits_applied": {},
+  "dedup_clusters": [],
+  "warnings": []
+}

--- a/tests/fixtures/v3/03_cache_hit.json
+++ b/tests/fixtures/v3/03_cache_hit.json
@@ -1,0 +1,47 @@
+{
+  "contract_version": "3.0",
+  "request_id": "req_cache_0001",
+  "capability": "search",
+  "status": "ok",
+  "results": [
+    {
+      "result_id": "res_1",
+      "status": "ok",
+      "title": "Cached Result",
+      "url": "https://example.com/",
+      "canonical_url": "https://example.com/",
+      "snippet": "Served from a fresh cache entry.",
+      "cluster_id": "dc_1",
+      "provenance": [
+        {
+          "provider": "serper",
+          "source_url": "https://example.com/",
+          "retrieved_at": "2026-07-12T08:00:00Z",
+          "provider_rank": 1
+        }
+      ]
+    }
+  ],
+  "provider_attempts": [],
+  "routing_receipt": {
+    "policy_id": "classic",
+    "policy_revision": "1",
+    "mode": "classic",
+    "candidate_order": [],
+    "selected_provider": null,
+    "fallback_reason": "none"
+  },
+  "cache_status": {
+    "disposition": "fresh_hit",
+    "entry_id": "ce_abc123",
+    "age_seconds": 120,
+    "ttl_seconds": 3600,
+    "served_stale": false,
+    "source_contract_version": "3.0"
+  },
+  "limits_applied": { "max_results": 10 },
+  "dedup_clusters": [
+    { "cluster_id": "dc_1", "canonical_result_id": "res_1", "member_result_ids": ["res_1"], "providers": ["serper"] }
+  ],
+  "warnings": []
+}

--- a/tests/fixtures/v3/04_fallback.json
+++ b/tests/fixtures/v3/04_fallback.json
@@ -1,0 +1,81 @@
+{
+  "contract_version": "3.0",
+  "request_id": "req_fallback_0001",
+  "capability": "search",
+  "status": "ok",
+  "results": [
+    {
+      "result_id": "res_1",
+      "status": "ok",
+      "title": "Served by fallback provider",
+      "url": "https://example.net/x",
+      "canonical_url": "https://example.net/x",
+      "snippet": "Primary failed; fallback served this.",
+      "cluster_id": "dc_1",
+      "provenance": [
+        {
+          "provider": "brave",
+          "source_url": "https://example.net/x",
+          "retrieved_at": "2026-07-12T08:32:02Z",
+          "provider_rank": 1
+        }
+      ]
+    }
+  ],
+  "provider_attempts": [
+    {
+      "attempt_id": "att_1",
+      "provider": "serper",
+      "capability": "search",
+      "outcome": "failed",
+      "retry_count": 1,
+      "result_count": 0,
+      "started_at": "2026-07-12T08:32:00Z",
+      "duration_ms": 1500,
+      "budget_decision": "allowed",
+      "circuit_state_before": "closed",
+      "circuit_state_after": "open",
+      "error": {
+        "error_class": "transient",
+        "code": "wsp.transient.upstream_5xx",
+        "message": "Provider returned HTTP 503.",
+        "retryable": true,
+        "provider": "serper",
+        "http_status": 503
+      }
+    },
+    {
+      "attempt_id": "att_2",
+      "provider": "brave",
+      "capability": "search",
+      "outcome": "success",
+      "retry_count": 0,
+      "result_count": 1,
+      "started_at": "2026-07-12T08:32:02Z",
+      "duration_ms": 600,
+      "budget_decision": "allowed",
+      "circuit_state_before": "closed",
+      "circuit_state_after": "closed"
+    }
+  ],
+  "routing_receipt": {
+    "policy_id": "classic",
+    "policy_revision": "1",
+    "mode": "classic",
+    "candidate_order": ["serper", "brave"],
+    "selected_provider": "brave",
+    "fallback_reason": "selected_failed",
+    "shadow": {
+      "policy_id": "policy-core-v2",
+      "policy_revision": "0.3.1",
+      "proposed_order": ["brave", "serper"],
+      "note": "observation only; not executed"
+    }
+  },
+  "cache_status": { "disposition": "miss" },
+  "limits_applied": { "max_results": 10 },
+  "dedup_clusters": [
+    { "cluster_id": "dc_1", "canonical_result_id": "res_1", "member_result_ids": ["res_1"], "providers": ["brave"] }
+  ],
+  "warnings": []
+}

--- a/tests/fixtures/v3/05_degraded.json
+++ b/tests/fixtures/v3/05_degraded.json
@@ -1,0 +1,74 @@
+{
+  "contract_version": "3.0",
+  "request_id": "req_degraded_0001",
+  "capability": "search",
+  "status": "degraded",
+  "results": [
+    {
+      "result_id": "res_1",
+      "status": "ok",
+      "title": "Stale cached result",
+      "url": "https://example.com/old",
+      "canonical_url": "https://example.com/old",
+      "snippet": "Live fetch failed; served from stale cache.",
+      "cluster_id": "dc_1",
+      "provenance": [
+        {
+          "provider": "serper",
+          "source_url": "https://example.com/old",
+          "retrieved_at": "2026-07-12T06:00:00Z",
+          "provider_rank": 1
+        }
+      ]
+    }
+  ],
+  "provider_attempts": [
+    {
+      "attempt_id": "att_1",
+      "provider": "serper",
+      "capability": "search",
+      "outcome": "failed",
+      "retry_count": 1,
+      "result_count": 0,
+      "started_at": "2026-07-12T08:33:00Z",
+      "duration_ms": 2000,
+      "budget_decision": "allowed",
+      "circuit_state_before": "closed",
+      "circuit_state_after": "open",
+      "error": {
+        "error_class": "timeout",
+        "code": "wsp.timeout.provider_deadline",
+        "message": "Provider exceeded the wall-time deadline.",
+        "retryable": true,
+        "provider": "serper"
+      }
+    }
+  ],
+  "routing_receipt": {
+    "policy_id": "classic",
+    "policy_revision": "1",
+    "mode": "classic",
+    "candidate_order": ["serper"],
+    "selected_provider": null,
+    "fallback_reason": "selected_failed"
+  },
+  "cache_status": {
+    "disposition": "stale_hit",
+    "entry_id": "ce_old789",
+    "age_seconds": 9000,
+    "ttl_seconds": 3600,
+    "served_stale": true,
+    "source_contract_version": "3.0"
+  },
+  "limits_applied": { "max_results": 10 },
+  "dedup_clusters": [
+    { "cluster_id": "dc_1", "canonical_result_id": "res_1", "member_result_ids": ["res_1"], "providers": ["serper"] }
+  ],
+  "warnings": [
+    {
+      "code": "wsp.cache.served_stale",
+      "message": "Live fetch failed; served stale cache entry (age 9000s exceeds ttl 3600s).",
+      "details": { "age_seconds": 9000, "ttl_seconds": 3600 }
+    }
+  ]
+}

--- a/tests/fixtures/v3/06_total_failure.json
+++ b/tests/fixtures/v3/06_total_failure.json
@@ -1,0 +1,64 @@
+{
+  "contract_version": "3.0",
+  "request_id": "req_failure_0001",
+  "capability": "search",
+  "status": "failed",
+  "results": [],
+  "provider_attempts": [
+    {
+      "attempt_id": "att_1",
+      "provider": "serper",
+      "capability": "search",
+      "outcome": "failed",
+      "retry_count": 2,
+      "result_count": 0,
+      "started_at": "2026-07-12T08:34:00Z",
+      "duration_ms": 3000,
+      "budget_decision": "allowed",
+      "circuit_state_before": "closed",
+      "circuit_state_after": "blocked_auth",
+      "error": {
+        "error_class": "auth",
+        "code": "wsp.auth.invalid_key",
+        "message": "Provider rejected the credentials.",
+        "retryable": false,
+        "provider": "serper",
+        "http_status": 401,
+        "details": { "provider_code": "E_SERPER_AUTH_42" }
+      }
+    },
+    {
+      "attempt_id": "att_2",
+      "provider": "brave",
+      "capability": "search",
+      "outcome": "skipped",
+      "retry_count": 0,
+      "result_count": 0,
+      "skip_reason": "circuit_open",
+      "budget_decision": "unknown",
+      "circuit_state_before": "open",
+      "circuit_state_after": "open"
+    }
+  ],
+  "routing_receipt": {
+    "policy_id": "classic",
+    "policy_revision": "1",
+    "mode": "classic",
+    "candidate_order": ["serper", "brave"],
+    "selected_provider": null,
+    "fallback_reason": "selected_failed"
+  },
+  "cache_status": { "disposition": "miss" },
+  "limits_applied": { "max_results": 10 },
+  "dedup_clusters": [],
+  "warnings": [
+    { "code": "wsp.search.no_results", "message": "All providers failed or were skipped." }
+  ],
+  "error": {
+    "error_class": "transient",
+    "code": "wsp.search.all_providers_failed",
+    "message": "No provider produced results (serper auth-failed, brave circuit-open).",
+    "retryable": true,
+    "details": { "attempts": 2 }
+  }
+}

--- a/tests/test_contract_v3.py
+++ b/tests/test_contract_v3.py
@@ -1,0 +1,210 @@
+import json
+import unittest
+from pathlib import Path
+
+from contract_v3 import (
+    AttemptOutcome,
+    CacheDisposition,
+    Capability,
+    ErrorClass,
+    FallbackReason,
+    ProviderAttemptV3,
+    RequestV3,
+    ResponseStatus,
+    ResponseV3,
+    SkipReason,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_DIR = ROOT / "schemas" / "v3"
+CLASSIC_RECEIPT = {
+    "policy_id": "classic-fallback-chain",
+    "policy_revision": "v2.9.1",
+    "mode": "classic",
+    "candidate_order": ["serper"],
+    "selected_provider": "serper",
+    "fallback_reason": "none",
+}
+
+
+class ContractV3Tests(unittest.TestCase):
+    def test_enum_namespace_is_frozen(self):
+        self.assertEqual([item.value for item in Capability], ["search", "extract"])
+        self.assertEqual(
+            [item.value for item in ErrorClass],
+            [
+                "invalid_request",
+                "unsupported",
+                "config",
+                "auth",
+                "quota",
+                "rate_limit",
+                "transient",
+                "timeout",
+                "provider_contract",
+                "content",
+                "security",
+                "budget",
+                "cancelled",
+                "internal",
+            ],
+        )
+        self.assertEqual(
+            [item.value for item in AttemptOutcome],
+            ["success", "partial", "skipped", "failed", "cancelled"],
+        )
+        self.assertEqual(
+            [item.value for item in SkipReason],
+            [
+                "disabled",
+                "unsupported_capability",
+                "not_configured",
+                "missing_credentials",
+                "auth_blocked",
+                "quota_blocked",
+                "rate_limited",
+                "circuit_open",
+                "budget_blocked",
+                "policy_excluded",
+                "deadline_exceeded",
+            ],
+        )
+        self.assertEqual(
+            [item.value for item in FallbackReason],
+            [
+                "none",
+                "selected_failed",
+                "selected_skipped",
+                "insufficient_results",
+                "partial_content",
+                "budget_chain",
+            ],
+        )
+
+    def test_search_request_roundtrip(self):
+        request = RequestV3.search(
+            query="latest model release",
+            request_id="req_search_1",
+            max_results=5,
+            freshness="week",
+            accept_features=["provider_attempts", "dedup_clusters"],
+        )
+        payload = request.to_dict()
+        self.assertEqual(payload["contract_version"], "3.0")
+        self.assertEqual(payload["capability"], "search")
+        self.assertEqual(payload["input"]["query"], "latest model release")
+        self.assertNotIn("urls", payload["input"])
+        self.assertEqual(RequestV3.from_dict(payload), request)
+
+    def test_extract_request_roundtrip(self):
+        request = RequestV3.extract(
+            urls=["https://example.com/a"],
+            request_id="req_extract_1",
+            output_format="markdown",
+            include_images=False,
+        )
+        payload = request.to_dict()
+        self.assertEqual(payload["capability"], "extract")
+        self.assertEqual(payload["input"]["urls"], ["https://example.com/a"])
+        self.assertNotIn("query", payload["input"])
+        self.assertEqual(RequestV3.from_dict(payload), request)
+
+    def test_cross_capability_input_is_rejected(self):
+        with self.assertRaises(ValueError):
+            RequestV3.from_dict(
+                {
+                    "contract_version": "3.0",
+                    "capability": "search",
+                    "input": {"urls": ["https://example.com"]},
+                }
+            )
+
+    def test_attempt_error_and_skip_invariants(self):
+        with self.assertRaises(ValueError):
+            ProviderAttemptV3(
+                attempt_id="a1",
+                provider="serper",
+                capability=Capability.SEARCH,
+                outcome=AttemptOutcome.FAILED,
+            )
+        with self.assertRaises(ValueError):
+            ProviderAttemptV3(
+                attempt_id="a2",
+                provider="serper",
+                capability=Capability.SEARCH,
+                outcome=AttemptOutcome.SKIPPED,
+            )
+
+    def test_response_roundtrip_and_failed_response_requires_error(self):
+        response = ResponseV3(
+            request_id="req_search_1",
+            capability=Capability.SEARCH,
+            status=ResponseStatus.OK,
+            results=[],
+            provider_attempts=[],
+            routing_receipt=CLASSIC_RECEIPT,
+            cache_status={"disposition": CacheDisposition.MISS.value},
+        )
+        self.assertEqual(ResponseV3.from_dict(response.to_dict()), response)
+        with self.assertRaises(ValueError):
+            ResponseV3(
+                request_id="req_failed",
+                capability=Capability.SEARCH,
+                status=ResponseStatus.FAILED,
+                results=[],
+                provider_attempts=[],
+                routing_receipt=CLASSIC_RECEIPT,
+                cache_status={"disposition": CacheDisposition.MISS.value},
+            )
+
+    def test_schema_enum_values_match_python(self):
+        request_schema = json.loads((SCHEMA_DIR / "request.schema.json").read_text())
+        response_schema = json.loads((SCHEMA_DIR / "response.schema.json").read_text())
+        self.assertEqual(
+            request_schema["$defs"]["Capability"]["enum"],
+            [item.value for item in Capability],
+        )
+        defs = response_schema["$defs"]
+        self.assertEqual(
+            defs["Capability"]["enum"], [item.value for item in Capability]
+        )
+        self.assertEqual(
+            defs["ErrorClass"]["enum"], [item.value for item in ErrorClass]
+        )
+        self.assertEqual(
+            defs["AttemptOutcome"]["enum"], [item.value for item in AttemptOutcome]
+        )
+        self.assertEqual(
+            defs["SkipReason"]["enum"], [item.value for item in SkipReason]
+        )
+        self.assertEqual(
+            defs["FallbackReason"]["enum"], [item.value for item in FallbackReason]
+        )
+
+    def test_golden_skeletons_validate_when_jsonschema_is_available(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema is optional")
+        request_schema = json.loads((SCHEMA_DIR / "request.schema.json").read_text())
+        response_schema = json.loads((SCHEMA_DIR / "response.schema.json").read_text())
+        jsonschema.Draft202012Validator.check_schema(request_schema)
+        jsonschema.Draft202012Validator.check_schema(response_schema)
+        jsonschema.validate(RequestV3.search("test query").to_dict(), request_schema)
+        jsonschema.validate(
+            ResponseV3(
+                request_id="req_1",
+                capability=Capability.SEARCH,
+                status=ResponseStatus.OK,
+                results=[],
+                provider_attempts=[],
+                routing_receipt=CLASSIC_RECEIPT,
+                cache_status={"disposition": CacheDisposition.MISS.value},
+            ).to_dict(),
+            response_schema,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contract_v3.py
+++ b/tests/test_contract_v3.py
@@ -1,4 +1,5 @@
 import json
+import unicodedata
 import unittest
 from pathlib import Path
 
@@ -6,6 +7,7 @@ from contract_v3 import (
     AttemptOutcome,
     CacheDisposition,
     Capability,
+    DegradedReason,
     ErrorClass,
     FallbackReason,
     ProviderAttemptV3,
@@ -31,6 +33,17 @@ CLASSIC_RECEIPT = {
 class ContractV3Tests(unittest.TestCase):
     def test_enum_namespace_is_frozen(self):
         self.assertEqual([item.value for item in Capability], ["search", "extract"])
+        self.assertEqual(
+            [item.value for item in DegradedReason],
+            [
+                "wsp.cache.served_stale",
+                "wsp.content.truncated",
+                "wsp.extract.urls_omitted",
+                "wsp.extract.partial",
+                "wsp.budget.limited",
+                "wsp.independence.method_degraded",
+            ],
+        )
         self.assertEqual(
             [item.value for item in ErrorClass],
             [
@@ -158,6 +171,35 @@ class ContractV3Tests(unittest.TestCase):
                 cache_status={"disposition": CacheDisposition.MISS.value},
             )
 
+    def test_degraded_response_requires_enumerated_warning(self):
+        with self.assertRaises(ValueError):
+            ResponseV3(
+                request_id="req_degraded",
+                capability=Capability.SEARCH,
+                status=ResponseStatus.DEGRADED,
+                results=[],
+                provider_attempts=[],
+                routing_receipt=CLASSIC_RECEIPT,
+                cache_status={"disposition": CacheDisposition.STALE_HIT.value},
+                warnings=[{"code": "wsp.warning.misc", "message": "not typed"}],
+            )
+        response = ResponseV3(
+            request_id="req_degraded",
+            capability=Capability.SEARCH,
+            status=ResponseStatus.DEGRADED,
+            results=[],
+            provider_attempts=[],
+            routing_receipt=CLASSIC_RECEIPT,
+            cache_status={"disposition": CacheDisposition.STALE_HIT.value},
+            warnings=[
+                {
+                    "code": DegradedReason.SERVED_STALE.value,
+                    "message": "served stale cache",
+                }
+            ],
+        )
+        self.assertEqual(response.status, ResponseStatus.DEGRADED)
+
     def test_schema_enum_values_match_python(self):
         request_schema = json.loads((SCHEMA_DIR / "request.schema.json").read_text())
         response_schema = json.loads((SCHEMA_DIR / "response.schema.json").read_text())
@@ -168,6 +210,11 @@ class ContractV3Tests(unittest.TestCase):
         defs = response_schema["$defs"]
         self.assertEqual(
             defs["Capability"]["enum"], [item.value for item in Capability]
+        )
+        self.assertIn("dedup_clusters", response_schema["required"])
+        self.assertEqual(
+            defs["DegradedReason"]["enum"],
+            [item.value for item in DegradedReason],
         )
         self.assertEqual(
             defs["ErrorClass"]["enum"], [item.value for item in ErrorClass]
@@ -204,6 +251,36 @@ class ContractV3Tests(unittest.TestCase):
             ).to_dict(),
             response_schema,
         )
+        fixture_dir = ROOT / "tests" / "fixtures" / "v3"
+        for fixture_path in sorted(fixture_dir.glob("*.json")):
+            with self.subTest(fixture=fixture_path.name):
+                jsonschema.validate(
+                    json.loads(fixture_path.read_text()), response_schema
+                )
+
+    def test_schema_enforces_nfc_marker_and_typed_degrade_reason(self):
+        try:
+            import jsonschema
+        except ImportError:
+            self.skipTest("jsonschema is optional")
+        response_schema = json.loads((SCHEMA_DIR / "response.schema.json").read_text())
+        fixture_dir = ROOT / "tests" / "fixtures" / "v3"
+
+        extract_payload = json.loads(
+            (fixture_dir / "02_extract_success.json").read_text()
+        )
+        self.assertEqual(
+            unicodedata.normalize("NFC", extract_payload["results"][0]["text"]),
+            extract_payload["results"][0]["text"],
+        )
+        extract_payload["results"][0].pop("text_normalization")
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(extract_payload, response_schema)
+
+        degraded_payload = json.loads((fixture_dir / "05_degraded.json").read_text())
+        degraded_payload["warnings"][0]["code"] = "wsp.warning.misc"
+        with self.assertRaises(jsonschema.ValidationError):
+            jsonschema.validate(degraded_payload, response_schema)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Freeze the Web Search Plus 3.0 request/response contract as typed Python models and generated JSON Schemas.
- Add source-only golden fixtures covering search, extract, cache-hit, fallback, degraded, and total-failure responses.
- Add drift and cross-validation tests so prose, Python validation, generated schemas, and fixtures cannot silently diverge.

## Contract guarantees

- Search and extract responses carry source observations rather than synthesized answers or claims.
- Provider attempts, routing receipts, cache disposition, degradation reasons, and typed errors have closed wire shapes.
- Request and response schema generation is deterministic and checked into the repository.
- Python and independent JSON Schema validation agree on every committed golden fixture.
- Unicode offsets are defined against NFC-normalized code points.

## Review boundary

This is **slice 2 of the Web Search Plus 3.0 release train** and targets `release/v3.0.0` after the source-only charter slice.

Included here:

- `contract_v3.py` typed contract namespace;
- generated request and response JSON Schemas;
- deterministic schema generator and drift check;
- normative contract-freeze documentation;
- six golden response fixtures and boundary tests.

Intentionally deferred:

- runtime orchestration and legacy projections;
- attempt/state/cache ownership;
- bounded extraction context;
- Operator Console and migration tooling.

## Validation

- Python 3.8: `498 passed`
- Python 3.11: `498 passed, 6 subtests passed`
- Ruff: passed
- Compileall: passed on Python 3.8 and 3.11
- Contract schema drift check: passed
- Provider and routing docs drift checks: passed
- `git diff --check`: passed
- Public privacy/credential scan: passed

## Merge plan

This slice will be squash-merged into `release/v3.0.0`. Runtime code introduced by later slices must consume this contract without loosening its source-only guarantees.
