### PR TITLE
feat(v3): add canonical runtime and v2 projections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest ruff
+          if [ -f requirements-dev.txt ]; then
+            pip install -r requirements-dev.txt
+          else
+            pip install pytest ruff
+          fi
       - name: Ruff
         run: ruff check .
       - name: Tests

--- a/compat_v3.py
+++ b/compat_v3.py
@@ -1,0 +1,104 @@
+"""Pure compatibility projections between legacy WSP calls and v3 execution."""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Any, Dict, Mapping
+
+from contract_v3 import Capability, RequestV3
+from orchestrator_v3 import ExecutedV3
+
+
+def legacy_request_to_v3(
+    capability: Capability | str,
+    payload: Mapping[str, Any],
+    *,
+    request_id: str | None = None,
+) -> RequestV3:
+    """Project a public legacy invocation into a complete RequestV3."""
+    capability = Capability(capability)
+    provider = str(payload.get("provider") or "auto")
+    default_fallback = capability is Capability.EXTRACT or provider == "auto"
+    routing = {
+        "mode": "auto" if provider == "auto" else "fixed",
+        "provider": provider,
+        "allow_fallback": bool(payload.get("allow_fallback", default_fallback)),
+        "policy_mode": "classic",
+    }
+    cache = {
+        "mode": "bypass" if payload.get("no_cache") else "prefer",
+        "ttl_seconds": int(payload.get("cache_ttl", 3600)),
+    }
+    client = {"accept_contract_versions": ["3.0", "2.x"]}
+
+    if capability is Capability.SEARCH:
+        query = unicodedata.normalize("NFC", str(payload.get("query") or "")).strip()
+        options: Dict[str, Any] = {
+            "max_results": int(payload.get("count", payload.get("max_results", 5))),
+            "depth": str(payload.get("depth", payload.get("exa_depth", "normal"))),
+            "mode": str(payload.get("mode", "normal")),
+            "quality_report": bool(payload.get("quality_report", False)),
+            "research_time_budget": float(payload.get("research_time_budget", 55.0)),
+        }
+        for key in (
+            "freshness",
+            "time_range",
+            "search_type",
+            "include_domains",
+            "exclude_domains",
+        ):
+            value = payload.get(key)
+            if value is not None:
+                options[key] = list(value) if key.endswith("_domains") else value
+        locale = {
+            key: payload[key]
+            for key in ("country", "language")
+            if payload.get(key) not in (None, "auto")
+        }
+        if locale:
+            options["locale"] = locale
+        return RequestV3(
+            capability=capability,
+            input={"query": query},
+            request_id=request_id,
+            options=options,
+            cache=cache,
+            routing=routing,
+            client=client,
+        )
+
+    urls = payload.get("urls") or []
+    if isinstance(urls, str):
+        urls = [urls]
+    return RequestV3(
+        capability=capability,
+        input={"urls": list(urls)},
+        request_id=request_id,
+        options={
+            "output_format": str(
+                payload.get("format", payload.get("output_format", "markdown"))
+            ),
+            "include_images": bool(payload.get("include_images", False)),
+            "include_raw_html": bool(payload.get("include_raw_html", False)),
+            "render_js": bool(payload.get("render_js", False)),
+        },
+        cache=cache,
+        routing=routing,
+        client=client,
+    )
+
+
+def _project(execution: ExecutedV3, capability: Capability) -> Dict[str, Any]:
+    if execution.response.capability is not capability:
+        raise ValueError("legacy projection capability mismatch")
+    return execution.legacy_copy()
+
+
+def v3_response_to_legacy_search(execution: ExecutedV3) -> Dict[str, Any]:
+    """Return a fresh byte-equivalent copy of the legacy search payload."""
+    return _project(execution, Capability.SEARCH)
+
+
+def v3_response_to_legacy_extract(execution: ExecutedV3) -> Dict[str, Any]:
+    """Return a fresh byte-equivalent copy of the legacy extract payload."""
+    return _project(execution, Capability.EXTRACT)

--- a/docs/v3-contract-amendment-001-m1-search-parity.md
+++ b/docs/v3-contract-amendment-001-m1-search-parity.md
@@ -1,0 +1,24 @@
+# Contract Amendment 001 — M1 public search parity
+
+Status: **engine-owner candidate; policy-owner acceptance required at M1 handoff.**
+
+## Reason
+
+The co-signed M0 `SearchOptions` could not losslessly represent four inputs already exposed by the v2 Hermes tool. Omitting them would force the compatibility layer to use hidden runtime context, violating B6 because an identical `RequestV3` could then produce a different provider plan or output.
+
+## Additions
+
+`SearchOptions` gains four optional, strictly typed fields:
+
+- `depth: normal | deep | deep-reasoning`
+- `mode: normal | research`
+- `quality_report: boolean`
+- `research_time_budget: number` in the inclusive range 1–75 seconds
+
+No existing field, default, provider behavior, response field, or golden response fixture changes. Unknown fields remain rejected.
+
+## Compatibility boundary
+
+The amendment covers the public Hermes `web_search_plus` surface. Provider-specific standalone CLI tuning flags remain adapter internals and are not promoted into the provider-agnostic v3 wire contract.
+
+The byte-compatible v2 response is carried only in the internal `ExecutedV3` envelope. It is not serialized into `ResponseV3`, does not alter the response schema, and cannot become a second execution path.

--- a/docs/v3-contract-freeze.md
+++ b/docs/v3-contract-freeze.md
@@ -67,6 +67,10 @@ All optional:
 - `freshness: day | week | month | year`
 - `time_range: day | week | month | year`
 - `search_type: search | news`
+- `depth: normal | deep | deep-reasoning`
+- `mode: normal | research`
+- `quality_report: boolean`
+- `research_time_budget: number`, 1–75 seconds
 - `include_domains: string[]`
 - `exclude_domains: string[]`
 - `locale.country: ISO-3166 alpha-2`

--- a/docs/v3-m1-engine-handoff.md
+++ b/docs/v3-m1-engine-handoff.md
@@ -1,0 +1,183 @@
+# WSP 3.0 M1 engine handoff — canonical v3 runtime and v2 projection
+
+Status: **engine implementation candidate**. Local only; no push or PR.
+
+## As-built projection and execution signatures
+
+```python
+legacy_request_to_v3(
+    capability: Capability | str,
+    payload: Mapping[str, Any],
+    *,
+    request_id: str | None = None,
+) -> RequestV3
+
+v3_response_to_legacy_search(execution: ExecutedV3) -> Dict[str, Any]
+v3_response_to_legacy_extract(execution: ExecutedV3) -> Dict[str, Any]
+
+execute_v3_request(
+    request: RequestV3,
+    adapter: CapabilityAdapter,
+    config: Dict[str, Any] | None = None,
+) -> ExecutedV3
+
+run_search_request_v3(
+    request: RequestV3,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+) -> ResponseV3
+
+run_extract_request_v3(
+    request: RequestV3,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+) -> ResponseV3
+```
+
+`ExecutedV3` is an internal, non-wire envelope containing the frozen `ResponseV3`, the authoritative `ProviderPlan`, the untouched legacy payload, and the canonical stage trace. Its legacy payload is deep-copied on construction and projection. It is never serialized into `ResponseV3`.
+
+## Single-path invariant
+
+Hermes `run_search_request()` and `run_extract_request()` perform exactly:
+
+```text
+legacy input → legacy_request_to_v3() → execute_v3_request()
+             → ExecutedV3 → pure legacy projection
+```
+
+Native callers start at `execute_v3_request()` and receive its `ResponseV3`. Both modes use the same capability adapter and private provider core. B6 asserts identical `ProviderPlan` and routing receipt for an equivalent legacy-projected/native `RequestV3`, and counts one private-core invocation per request.
+
+The standalone CLI parser retains its historical import-compatible core seam for provider-specific CLI-only knobs. It uses the same private provider core but is not promoted into the provider-agnostic v3 wire surface.
+
+Legacy v2 cache behavior under the v3 runtime:
+
+- compatible v2 cache reads remain enabled and become `source_contract_version: "2.x"`;
+- v3-generated parser arguments set `_v3_no_legacy_cache_write=True`;
+- the private search core therefore never calls `cache_put()` for a v3/legacy-projected runtime request;
+- projections themselves perform no cache, provider-health, telemetry, or filesystem operations.
+
+## Round-trip examples
+
+### 1. Search success
+
+Legacy input:
+
+```json
+{"query":"latest model","provider":"serper","count":3,"freshness":"week"}
+```
+
+Projected request:
+
+```json
+{
+  "contract_version":"3.0",
+  "capability":"search",
+  "input":{"query":"latest model"},
+  "options":{"max_results":3,"depth":"normal","mode":"normal","quality_report":false,"research_time_budget":55.0,"freshness":"week"},
+  "cache":{"mode":"prefer","ttl_seconds":3600},
+  "routing":{"mode":"fixed","provider":"serper","allow_fallback":false,"policy_mode":"classic"},
+  "client":{"accept_contract_versions":["3.0","2.x"]}
+}
+```
+
+The provider core runs once. `ResponseV3.results[]` receives canonical URL, deterministic result ID and provenance. `v3_response_to_legacy_search()` returns the original core payload byte-equivalently.
+
+### 2. Extract success
+
+Legacy input:
+
+```json
+{"urls":["https://example.com/a"],"provider":"linkup","format":"markdown","include_images":false}
+```
+
+Projected request:
+
+```json
+{
+  "contract_version":"3.0",
+  "capability":"extract",
+  "input":{"urls":["https://example.com/a"]},
+  "options":{"output_format":"markdown","include_images":false,"include_raw_html":false,"render_js":false},
+  "cache":{"mode":"prefer","ttl_seconds":3600},
+  "routing":{"mode":"fixed","provider":"linkup","allow_fallback":true,"policy_mode":"classic"},
+  "client":{"accept_contract_versions":["3.0","2.x"]}
+}
+```
+
+The native result normalizes text to NFC and emits Unicode-codepoint `[start,end)` segments. The legacy projection returns the unmodified provider-core payload.
+
+### 3. Fallback
+
+Legacy input:
+
+```json
+{"query":"current facts","provider":"auto","count":5}
+```
+
+If the classic plan is `("you", "serper")`, You fails, and Serper succeeds, `ResponseV3.routing_receipt` remains authoritative:
+
+```json
+{
+  "mode":"classic",
+  "candidate_order":["you","serper"],
+  "selected_provider":"serper",
+  "fallback_reason":"selected_failed"
+}
+```
+
+`provider_attempts` records failed You then successful Serper. The legacy projection retains the existing `routing.fallback_used` and `routing.fallback_errors` structure exactly.
+
+### 4. Compatible v2 cache hit
+
+Legacy input:
+
+```json
+{"query":"cached query","provider":"serper","count":5}
+```
+
+A compatible v2 cache read maps to:
+
+```json
+{"disposition":"fresh_hit","source_contract_version":"2.x","age_seconds":12}
+```
+
+No v2 cache write occurs. The legacy projection retains `cached:true` and `cache_age_seconds` exactly as returned by the existing core.
+
+## Projection matrix
+
+### Losslessly projected from legacy request
+
+- capability (`search` or `extract`)
+- query or URLs
+- requested provider and auto/fixed routing mode
+- fallback preference
+- result count
+- freshness, time range and search vertical
+- include/exclude domains
+- country and language
+- public depth, normal/research mode, quality-report flag and research budget
+- extract format, image/raw-HTML/render-JS flags
+- cache bypass/prefer mode and TTL
+
+### Default-filled when absent
+
+- `contract_version = "3.0"`
+- `routing.policy_mode = "classic"`
+- `provider = "auto"`
+- `max_results = 5`
+- `depth = "normal"`
+- `mode = "normal"`
+- `quality_report = false`
+- `research_time_budget = 55.0`
+- extract `output_format = "markdown"`
+- extract booleans = `false`
+- cache `mode = "prefer"`, `ttl_seconds = 3600`
+- client accepts `3.0` and `2.x`
+
+### Losslessly projected to legacy response
+
+Every field and insertion order in the private provider-core payload, including provider-specific result fields, routing diagnostics, metadata, quality report, images, fallback errors, cache flags and extract content. The projection returns a deep copy, so caller mutation cannot alter the stored envelope or a later projection.
+
+## Amendment 001 requiring policy acceptance
+
+M0 lacked four public v2 search inputs. `docs/v3-contract-amendment-001-m1-search-parity.md` adds strict optional fields for `depth`, `mode`, `quality_report`, and `research_time_budget`. Without them, B6 would require hidden runtime context. ResponseV3 and all six M0 golden response fixtures remain unchanged.

--- a/extract.py
+++ b/extract.py
@@ -27,6 +27,10 @@ from providers import (  # noqa: F401 - resolved late via EXTRACT_DISPATCH/monke
 )
 from provider_dispatch import EXTRACT_DISPATCH
 from provider_registry import EXTRACT_PROVIDER_IDS
+from compat_v3 import legacy_request_to_v3, v3_response_to_legacy_extract
+from contract_v3 import Capability, RequestV3, ResponseV3
+from orchestrator_v3 import CapabilityAdapter, ProviderPlan, execute_v3_request
+from runtime_v3 import response_from_legacy
 
 
 EXTRACT_PROVIDER_PRIORITY = list(EXTRACT_PROVIDER_IDS)
@@ -132,7 +136,7 @@ def _validate_extract_urls(urls: List[str], config: Optional[Dict[str, Any]] = N
     return urls
 
 
-def extract_plus(
+def _extract_plus_core(
     urls: List[str],
     provider: str = "auto",
     output_format: str = "markdown",
@@ -209,3 +213,78 @@ def extract_plus(
     if cooldown_skips:
         error_result["cooldown_skips"] = cooldown_skips
     return error_result
+
+
+def _plan_extract_v3(request: RequestV3, config: Dict[str, Any]) -> ProviderPlan:
+    selected = str(request.routing.get("provider") or "auto")
+    disabled = set((config.get("auto_routing") or {}).get("disabled_providers", []))
+    if selected == "auto":
+        candidates = [provider for provider in resolve_extract_provider_priority(config) if provider not in disabled]
+        chosen = candidates[0] if candidates else EXTRACT_PROVIDER_PRIORITY[0]
+    else:
+        candidates = [selected] + [provider for provider in EXTRACT_PROVIDER_PRIORITY if provider != selected and provider not in disabled]
+        chosen = selected
+    if not request.routing.get("allow_fallback", True):
+        candidates = [chosen]
+    return ProviderPlan(tuple(candidates or [chosen]), chosen)
+
+
+def _execute_extract_v3(request: RequestV3, _plan: ProviderPlan, config: Dict[str, Any]) -> Dict[str, Any]:
+    options = request.options
+    return _extract_plus_core(
+        urls=list(request.input["urls"]),
+        provider=str(request.routing.get("provider") or "auto"),
+        output_format=str(options.get("output_format", "markdown")),
+        include_images=bool(options.get("include_images", False)),
+        include_raw_html=bool(options.get("include_raw_html", False)),
+        render_js=bool(options.get("render_js", False)),
+        config=dict(config),
+    )
+
+
+def _extract_adapter() -> CapabilityAdapter:
+    return CapabilityAdapter(
+        capability=Capability.EXTRACT,
+        plan=_plan_extract_v3,
+        execute=_execute_extract_v3,
+        normalize=response_from_legacy,
+    )
+
+
+def run_extract_request_v3(
+    request: RequestV3,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+) -> ResponseV3:
+    """Execute a native extract RequestV3 through the canonical orchestrator."""
+    runtime_config = config or load_config()
+    return execute_v3_request(request, _extract_adapter(), runtime_config).response
+
+
+def extract_plus(
+    urls: List[str],
+    provider: str = "auto",
+    output_format: str = "markdown",
+    include_images: bool = False,
+    include_raw_html: bool = False,
+    render_js: bool = False,
+    config: Optional[Dict[str, Any]] = None,
+) -> dict:
+    """Legacy extract projection over the sole native v3 execution path."""
+    selected = provider or "auto"
+    if not urls:
+        return {"provider": selected, "results": [], "error": "No URLs provided", "requested_provider": selected}
+    runtime_config = config or load_config()
+    request = legacy_request_to_v3(
+        Capability.EXTRACT,
+        {
+            "urls": urls,
+            "provider": provider,
+            "output_format": output_format,
+            "include_images": include_images,
+            "include_raw_html": include_raw_html,
+            "render_js": render_js,
+        },
+    )
+    execution = execute_v3_request(request, _extract_adapter(), runtime_config)
+    return v3_response_to_legacy_extract(execution)

--- a/orchestrator_v3.py
+++ b/orchestrator_v3.py
@@ -1,0 +1,105 @@
+"""Canonical Web Search Plus v3 orchestration boundary.
+
+The orchestrator owns the sole execution entrance. Capability adapters contain
+provider-specific calls and normalization only; legacy callers are projected to
+RequestV3 before they can reach this function.
+"""
+
+from __future__ import annotations
+
+import copy
+import unicodedata
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Dict, Tuple
+
+from contract_v3 import Capability, RequestV3, ResponseV3
+
+
+PIPELINE_STAGES: Tuple[str, ...] = (
+    "normalize",
+    "validate",
+    "cache_lookup",
+    "candidate_plan",
+    "admission",
+    "provider_attempt",
+    "error_classification",
+    "retry_circuit_update",
+    "fallback",
+    "result_normalization",
+    "dedup_fingerprint",
+    "cache_write",
+    "response_v3",
+)
+
+
+@dataclass(frozen=True)
+class ProviderPlan:
+    candidate_order: Tuple[str, ...]
+    selected_provider: str
+    mode: str = "classic"
+
+    def __post_init__(self) -> None:
+        if self.mode not in {"classic", "shadow"}:
+            raise ValueError("provider plan mode must be classic or shadow")
+        if not self.candidate_order:
+            raise ValueError("provider plan requires candidates")
+        if self.selected_provider not in self.candidate_order:
+            raise ValueError("selected provider must be in candidate_order")
+
+
+PlanFn = Callable[[RequestV3, Dict[str, Any]], ProviderPlan]
+ExecuteFn = Callable[[RequestV3, ProviderPlan, Dict[str, Any]], Dict[str, Any]]
+NormalizeFn = Callable[[RequestV3, ProviderPlan, Dict[str, Any]], ResponseV3]
+
+
+@dataclass(frozen=True)
+class CapabilityAdapter:
+    capability: Capability
+    plan: PlanFn
+    execute: ExecuteFn
+    normalize: NormalizeFn
+
+
+@dataclass(frozen=True)
+class ExecutedV3:
+    response: ResponseV3
+    plan: ProviderPlan
+    legacy_payload: Dict[str, Any]
+    stage_trace: Tuple[str, ...] = PIPELINE_STAGES
+
+    def legacy_copy(self) -> Dict[str, Any]:
+        return copy.deepcopy(self.legacy_payload)
+
+
+def _normalize_request(request: RequestV3) -> RequestV3:
+    if request.capability is not Capability.SEARCH:
+        return request
+    normalized_query = unicodedata.normalize("NFC", request.input["query"]).strip()
+    if normalized_query == request.input["query"]:
+        return request
+    return replace(request, input={**request.input, "query": normalized_query})
+
+
+def execute_v3_request(
+    request: RequestV3,
+    adapter: CapabilityAdapter,
+    config: Dict[str, Any] | None = None,
+) -> ExecutedV3:
+    """Execute one RequestV3 through the canonical orchestration entrance."""
+    request = _normalize_request(request)
+    if request.capability is not adapter.capability:
+        raise ValueError("request and adapter capability differ")
+    runtime_config: Dict[str, Any] = config or {}
+    plan = adapter.plan(request, runtime_config)
+    legacy_payload = adapter.execute(request, plan, runtime_config)
+    response = adapter.normalize(request, plan, legacy_payload)
+    if response.capability is not request.capability:
+        raise ValueError("adapter returned response for another capability")
+    if tuple(response.routing_receipt["candidate_order"]) != plan.candidate_order:
+        raise ValueError("response candidate_order drifted from authoritative plan")
+    return ExecutedV3(
+        response=response,
+        plan=plan,
+        legacy_payload=copy.deepcopy(legacy_payload),
+        stage_trace=PIPELINE_STAGES,
+    )

--- a/runtime_v3.py
+++ b/runtime_v3.py
@@ -1,0 +1,307 @@
+"""Normalize legacy provider-core payloads into the frozen ResponseV3 DTO."""
+
+from __future__ import annotations
+
+import hashlib
+import unicodedata
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Mapping
+from urllib.parse import urlsplit, urlunsplit
+
+from contract_v3 import (
+    AttemptOutcome,
+    Capability,
+    CircuitState,
+    DegradedReason,
+    ErrorClass,
+    ErrorV3,
+    FallbackReason,
+    ProviderAttemptV3,
+    RequestV3,
+    ResponseStatus,
+    ResponseV3,
+)
+from orchestrator_v3 import ProviderPlan
+
+
+def _canonical_url(value: str) -> str:
+    parsed = urlsplit(value)
+    host = (parsed.hostname or "").lower()
+    port = parsed.port
+    netloc = host
+    if port and not (
+        (parsed.scheme == "http" and port == 80)
+        or (parsed.scheme == "https" and port == 443)
+    ):
+        netloc = f"{host}:{port}"
+    path = parsed.path or "/"
+    return urlunsplit((parsed.scheme.lower(), netloc, path, parsed.query, ""))
+
+
+def _stable_id(prefix: str, *parts: object) -> str:
+    raw = "\x1f".join(str(part) for part in parts)
+    return f"{prefix}_{hashlib.sha256(raw.encode()).hexdigest()[:16]}"
+
+
+def _valid_rfc3339(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return value
+
+
+def _error(message: str, provider: str | None = None) -> ErrorV3:
+    lowered = message.lower()
+    if "missing" in lowered and ("key" in lowered or "credential" in lowered):
+        error_class = ErrorClass.CONFIG
+        code = "wsp.config.missing_credentials"
+    elif "timeout" in lowered or "timed out" in lowered:
+        error_class = ErrorClass.TIMEOUT
+        code = "wsp.provider.timeout"
+    elif "rate" in lowered or "429" in lowered:
+        error_class = ErrorClass.RATE_LIMIT
+        code = "wsp.provider.rate_limit"
+    elif "security" in lowered or "blocked" in lowered:
+        error_class = ErrorClass.SECURITY
+        code = "wsp.security.request_blocked"
+    else:
+        error_class = ErrorClass.TRANSIENT
+        code = "wsp.provider.failed"
+    return ErrorV3(
+        error_class=error_class,
+        code=code,
+        message=message or "Provider execution failed",
+        retryable=error_class
+        in {ErrorClass.TIMEOUT, ErrorClass.RATE_LIMIT, ErrorClass.TRANSIENT},
+        provider=provider,
+    )
+
+
+def _error_items(payload: Mapping[str, Any]) -> List[Dict[str, Any]]:
+    values: List[Dict[str, Any]] = []
+    for candidate in (
+        payload.get("provider_errors"),
+        payload.get("fallback_errors"),
+        (payload.get("routing") or {}).get("fallback_errors"),
+    ):
+        if isinstance(candidate, list):
+            for item in candidate:
+                if isinstance(item, dict) and item not in values:
+                    values.append(dict(item))
+    return values
+
+
+def _attempts(
+    request: RequestV3,
+    plan: ProviderPlan,
+    payload: Mapping[str, Any],
+    selected: str | None,
+    result_count: int,
+) -> List[ProviderAttemptV3]:
+    attempts: List[ProviderAttemptV3] = []
+    for index, item in enumerate(_error_items(payload), 1):
+        provider = str(
+            item.get("provider")
+            or plan.candidate_order[min(index - 1, len(plan.candidate_order) - 1)]
+        )
+        error = _error(str(item.get("error") or "Provider execution failed"), provider)
+        attempts.append(
+            ProviderAttemptV3(
+                attempt_id=f"attempt-{index}",
+                provider=provider,
+                capability=request.capability,
+                outcome=AttemptOutcome.FAILED,
+                result_count=0,
+                error=error,
+                circuit_state_before=CircuitState.UNKNOWN,
+                circuit_state_after=CircuitState.UNKNOWN,
+            )
+        )
+    if selected and (result_count or not payload.get("error")):
+        attempts.append(
+            ProviderAttemptV3(
+                attempt_id=f"attempt-{len(attempts) + 1}",
+                provider=selected,
+                capability=request.capability,
+                outcome=AttemptOutcome.SUCCESS,
+                result_count=result_count,
+                circuit_state_before=CircuitState.UNKNOWN,
+                circuit_state_after=CircuitState.CLOSED,
+            )
+        )
+    return attempts
+
+
+def _provenance(
+    provider: str, url: str, rank: int, retrieved_at: str
+) -> List[Dict[str, Any]]:
+    return [
+        {
+            "provider": provider,
+            "source_url": url,
+            "retrieved_at": retrieved_at,
+            "provider_rank": rank,
+        }
+    ]
+
+
+def _search_results(
+    payload: Mapping[str, Any], provider: str, retrieved_at: str
+) -> List[Dict[str, Any]]:
+    normalized = []
+    for rank, item in enumerate(payload.get("results") or [], 1):
+        url = str(item.get("url") or "")
+        if not url:
+            continue
+        canonical = _canonical_url(url)
+        result = {
+            "result_id": _stable_id("search", canonical, rank),
+            "status": "ok",
+            "title": str(item.get("title") or ""),
+            "url": url,
+            "canonical_url": canonical,
+            "provenance": _provenance(provider, url, rank, retrieved_at),
+        }
+        if item.get("snippet") is not None:
+            result["snippet"] = str(item["snippet"])
+        published_at = _valid_rfc3339(item.get("published_at"))
+        if published_at:
+            result["published_at"] = published_at
+        normalized.append(result)
+    return normalized
+
+
+def _extract_results(
+    payload: Mapping[str, Any], provider: str, retrieved_at: str
+) -> List[Dict[str, Any]]:
+    normalized = []
+    for rank, item in enumerate(payload.get("results") or [], 1):
+        url = str(item.get("url") or "")
+        if not url:
+            continue
+        canonical = _canonical_url(url)
+        base = {
+            "result_id": _stable_id("extract", canonical, rank),
+            "title": str(item.get("title") or ""),
+            "url": url,
+            "canonical_url": canonical,
+            "provenance": _provenance(provider, url, rank, retrieved_at),
+        }
+        if item.get("error"):
+            base.update(
+                {
+                    "status": "failed",
+                    "error": _error(str(item["error"]), provider).to_dict(),
+                }
+            )
+        else:
+            text = unicodedata.normalize(
+                "NFC", str(item.get("content") or item.get("raw_content") or "")
+            )
+            base.update(
+                {
+                    "status": "ok",
+                    "text": text,
+                    "offset_unit": "unicode_codepoint",
+                    "text_normalization": "NFC",
+                    "segments": (
+                        [{"segment_id": "segment-1", "start": 0, "end": len(text)}]
+                        if text
+                        else []
+                    ),
+                }
+            )
+        normalized.append(base)
+    return normalized
+
+
+def response_from_legacy(
+    request: RequestV3,
+    plan: ProviderPlan,
+    payload: Dict[str, Any],
+) -> ResponseV3:
+    """Build a contract-valid ResponseV3 without modifying the legacy payload."""
+    request_id = request.request_id or str(uuid.uuid4())
+    routing = payload.get("routing") or {}
+    selected = (
+        routing.get("provider") or payload.get("provider") or plan.selected_provider
+    )
+    retrieved_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    if request.capability is Capability.SEARCH:
+        results = _search_results(payload, str(selected), retrieved_at)
+    else:
+        results = _extract_results(payload, str(selected), retrieved_at)
+
+    failed_items = [item for item in results if item.get("status") == "failed"]
+    top_error = payload.get("error")
+    warnings: List[Dict[str, Any]] = []
+    error = None
+    if top_error and not results:
+        status = ResponseStatus.FAILED
+        error = _error(str(top_error), str(selected) if selected else None)
+    elif failed_items:
+        status = ResponseStatus.DEGRADED
+        warnings.append(
+            {
+                "code": DegradedReason.PARTIAL_EXTRACTION.value,
+                "message": "One or more extraction results failed.",
+                "details": {"failed_count": len(failed_items)},
+            }
+        )
+    else:
+        status = ResponseStatus.OK
+
+    fallback_used = bool(routing.get("fallback_used") or _error_items(payload))
+    fallback_reason = (
+        FallbackReason.SELECTED_FAILED.value
+        if fallback_used
+        else FallbackReason.NONE.value
+    )
+    cached = bool(payload.get("cached"))
+    if request.cache.get("mode") == "bypass":
+        cache_status = {"disposition": "bypassed"}
+    elif cached:
+        cache_status = {
+            "disposition": "fresh_hit",
+            "age_seconds": max(0, int(payload.get("cache_age_seconds", 0))),
+            "source_contract_version": "2.x",
+        }
+    else:
+        cache_status = {"disposition": "miss"}
+
+    clusters = [
+        {
+            "cluster_id": _stable_id("cluster", item["canonical_url"]),
+            "member_result_ids": [item["result_id"]],
+            "canonical_url": item["canonical_url"],
+        }
+        for item in results
+    ]
+    return ResponseV3(
+        request_id=request_id,
+        capability=request.capability,
+        status=status,
+        results=results,
+        provider_attempts=_attempts(request, plan, payload, selected, len(results)),
+        routing_receipt={
+            "policy_id": "classic",
+            "policy_revision": str(routing.get("routing_policy") or "v2.9.1"),
+            "mode": plan.mode,
+            "candidate_order": list(plan.candidate_order),
+            "selected_provider": selected if results else None,
+            "fallback_reason": fallback_reason,
+        },
+        cache_status=cache_status,
+        limits_applied={"max_results": request.options.get("max_results")}
+        if request.capability is Capability.SEARCH
+        else {},
+        dedup_clusters=clusters,
+        warnings=warnings,
+        error=error,
+    )

--- a/schemas/v3/request.schema.json
+++ b/schemas/v3/request.schema.json
@@ -158,6 +158,29 @@
             "news"
           ]
         },
+        "depth": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "deep",
+            "deep-reasoning"
+          ]
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "normal",
+            "research"
+          ]
+        },
+        "quality_report": {
+          "type": "boolean"
+        },
+        "research_time_budget": {
+          "type": "number",
+          "minimum": 1,
+          "maximum": 75
+        },
         "include_domains": {
           "type": "array",
           "items": {

--- a/scripts/gen_contract_v3_schemas.py
+++ b/scripts/gen_contract_v3_schemas.py
@@ -118,6 +118,17 @@ request_defs = {
             "freshness": {"type": "string", "enum": ["day", "week", "month", "year"]},
             "time_range": {"type": "string", "enum": ["day", "week", "month", "year"]},
             "search_type": {"type": "string", "enum": ["search", "news"]},
+            "depth": {
+                "type": "string",
+                "enum": ["normal", "deep", "deep-reasoning"],
+            },
+            "mode": {"type": "string", "enum": ["normal", "research"]},
+            "quality_report": {"type": "boolean"},
+            "research_time_budget": {
+                "type": "number",
+                "minimum": 1,
+                "maximum": 75,
+            },
             "include_domains": {
                 "type": "array",
                 "items": {"type": "string", "minLength": 1},

--- a/search.py
+++ b/search.py
@@ -87,6 +87,10 @@ from request_gate_v3 import validate_provider_mode
 from search_locale import provider_supports_locale, resolve_locale
 from env_loader import load_env_files
 from research import run_research_mode
+from compat_v3 import legacy_request_to_v3, v3_response_to_legacy_search
+from contract_v3 import Capability, RequestV3, ResponseV3
+from orchestrator_v3 import CapabilityAdapter, ProviderPlan, execute_v3_request
+from runtime_v3 import response_from_legacy
 import providers as _providers
 import routing as _routing
 import extract as _extract
@@ -1065,7 +1069,7 @@ def main():
         print(json.dumps(explanation, indent=indent, ensure_ascii=False))
         return
 
-    payload, exit_code = execute_search_request(args, config)
+    payload, exit_code = _execute_search_request_core(args, config)
     if exit_code == 0:
         indent = None if args.compact else 2
         print(json.dumps(payload, indent=indent, ensure_ascii=False))
@@ -1122,7 +1126,7 @@ def _apply_result_quality_pipeline(
             result.setdefault("metadata", {})["domain_diversity_demoted"] = demoted
 
 
-def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
+def _execute_search_request_core(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
     """Run the search/research pipeline for parsed args.
 
     Returns ``(payload, exit_code)`` where exit_code 0 means a success payload bound
@@ -1452,7 +1456,12 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
             )
             result.setdefault("metadata", {})["locale"] = locale_meta
 
-        if not cache_hit and not args.no_cache and args.query:
+        if (
+            not cache_hit
+            and not args.no_cache
+            and args.query
+            and not getattr(args, "_v3_no_legacy_cache_write", False)
+        ):
             cache_put(
                 query=args.query,
                 provider=successful_provider or provider,
@@ -1491,6 +1500,98 @@ def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any]
         return error_result, 1
 
 
+def execute_search_request(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
+    """Backward-compatible standalone CLI seam over the unchanged provider core."""
+    return _execute_search_request_core(args, config)
+
+
+def _plan_search_v3(request: RequestV3, config: Dict[str, Any]) -> ProviderPlan:
+    routing_request = request.routing
+    requested = str(routing_request.get("provider") or "auto")
+    auto_config = config.get("auto_routing", {})
+    if requested == "auto":
+        routed = auto_route_provider(request.input["query"], config)
+        selected = str(routed["provider"])
+    else:
+        selected = requested
+    candidates = [selected]
+    if routing_request.get("allow_fallback", requested == "auto"):
+        disabled = set(auto_config.get("disabled_providers", []))
+        for provider in auto_config.get("provider_priority", list(SEARCH_PROVIDER_IDS)):
+            if (
+                provider not in candidates
+                and provider not in disabled
+                and _provider_auto_allowed(provider, auto_config)
+                and provider_configured(provider, config)
+            ):
+                candidates.append(provider)
+    return ProviderPlan(tuple(candidates), selected)
+
+
+def _search_args_from_v3(request: RequestV3, config: Dict[str, Any]):
+    options = request.options
+    routing_request = request.routing
+    argv: List[str] = [
+        "--query", request.input["query"],
+        "--provider", str(routing_request.get("provider") or "auto"),
+        "--max-results", str(options.get("max_results", 5)),
+    ]
+    if options.get("depth", "normal") != "normal":
+        argv += ["--exa-depth", str(options["depth"])]
+    if options.get("time_range"):
+        argv += ["--time-range", str(options["time_range"])]
+    if options.get("freshness"):
+        argv += ["--freshness", str(options["freshness"])]
+    if options.get("search_type"):
+        argv += ["--search-type", str(options["search_type"])]
+    if options.get("include_domains"):
+        argv += ["--include-domains", *options["include_domains"]]
+    if options.get("exclude_domains"):
+        argv += ["--exclude-domains", *options["exclude_domains"]]
+    if options.get("mode", "normal") != "normal":
+        argv += ["--mode", str(options["mode"]), "--research-time-budget", str(options.get("research_time_budget", 55.0))]
+    if options.get("quality_report"):
+        argv += ["--quality-report"]
+    locale = options.get("locale") or {}
+    if locale.get("language"):
+        argv += ["--language", str(locale["language"])]
+    if locale.get("country"):
+        argv += ["--country", str(locale["country"])]
+    if routing_request.get("allow_fallback") and routing_request.get("mode") == "fixed":
+        argv += ["--allow-fallback"]
+    if request.cache.get("mode") == "bypass":
+        argv += ["--no-cache"]
+    if "ttl_seconds" in request.cache:
+        argv += ["--cache-ttl", str(request.cache["ttl_seconds"])]
+    args = build_parser(config).parse_args(argv)
+    args._v3_no_legacy_cache_write = True
+    return args
+
+
+def _execute_search_v3(request: RequestV3, _plan: ProviderPlan, config: Dict[str, Any]) -> Dict[str, Any]:
+    payload, _exit_code = _execute_search_request_core(_search_args_from_v3(request, config), config)
+    return payload
+
+
+def _search_adapter() -> CapabilityAdapter:
+    return CapabilityAdapter(
+        capability=Capability.SEARCH,
+        plan=_plan_search_v3,
+        execute=_execute_search_v3,
+        normalize=response_from_legacy,
+    )
+
+
+def run_search_request_v3(
+    request: RequestV3,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+) -> ResponseV3:
+    """Execute a native search RequestV3 through the canonical orchestrator."""
+    runtime_config = config or load_config()
+    return execute_v3_request(request, _search_adapter(), runtime_config).response
+
+
 def run_search_request(
     *,
     query: str,
@@ -1523,36 +1624,37 @@ def run_search_request(
     except ValueError as exc:
         return {"error": str(exc), "provider": provider, "query": query, "results": []}
     config = config or load_config()
-    argv: List[str] = [
-        "--query", query or "",
-        "--provider", provider or "auto",
-        "--max-results", str(count),
-    ]
-    if exa_depth and exa_depth != "normal":
-        argv += ["--exa-depth", exa_depth]
-    if time_range and time_range != "none":
-        argv += ["--time-range", time_range]
-    if freshness:
-        argv += ["--freshness", freshness]
-    if search_type:
-        argv += ["--search-type", search_type]
-    if include_domains:
-        argv += ["--include-domains", *include_domains]
-    if exclude_domains:
-        argv += ["--exclude-domains", *exclude_domains]
-    if mode and mode != "normal":
-        argv += ["--mode", mode, "--research-time-budget", str(research_time_budget)]
-    if quality_report:
-        argv += ["--quality-report"]
-    if language and language != "auto":
-        argv += ["--language", language]
-    if country and country != "auto":
-        argv += ["--country", country]
+    request = legacy_request_to_v3(
+        Capability.SEARCH,
+        {
+            "query": query,
+            "provider": provider or "auto",
+            "count": count,
+            "depth": exa_depth,
+            "time_range": time_range,
+            "freshness": freshness,
+            "search_type": search_type,
+            "include_domains": include_domains,
+            "exclude_domains": exclude_domains,
+            "mode": mode,
+            "quality_report": quality_report,
+            "research_time_budget": research_time_budget,
+            "language": language,
+            "country": country,
+        },
+    )
+    execution = execute_v3_request(request, _search_adapter(), config)
+    return v3_response_to_legacy_search(execution)
 
-    parser = build_parser(config)
-    args = parser.parse_args(argv)
-    payload, _exit_code = execute_search_request(args, config)
-    return payload
+
+def run_extract_request_v3(
+    request: RequestV3,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+) -> ResponseV3:
+    """Execute a native extract RequestV3 through the canonical orchestrator."""
+    _sync_extract_dependencies()
+    return _extract.run_extract_request_v3(request, config=config or load_config())
 
 
 def run_extract_request(

--- a/tests/test_orchestrator_v3.py
+++ b/tests/test_orchestrator_v3.py
@@ -1,0 +1,239 @@
+import json
+
+import pytest
+
+from compat_v3 import (
+    legacy_request_to_v3,
+    v3_response_to_legacy_extract,
+    v3_response_to_legacy_search,
+)
+from contract_v3 import Capability, RequestV3, ResponseStatus, ResponseV3
+from orchestrator_v3 import (
+    CapabilityAdapter,
+    ExecutedV3,
+    ProviderPlan,
+    execute_v3_request,
+)
+
+
+def _response(request: RequestV3, plan: ProviderPlan, legacy: dict) -> ResponseV3:
+    return ResponseV3(
+        request_id=request.request_id or "generated",
+        capability=request.capability,
+        status=ResponseStatus.OK,
+        results=[],
+        provider_attempts=[],
+        routing_receipt={
+            "policy_id": "classic",
+            "policy_revision": "v2.9.1",
+            "mode": "classic",
+            "candidate_order": list(plan.candidate_order),
+            "selected_provider": plan.selected_provider,
+            "fallback_reason": "none",
+        },
+        cache_status={"disposition": "miss"},
+    )
+
+
+def test_m1_search_projection_validates_against_request_schema():
+    jsonschema = pytest.importorskip("jsonschema")
+    request = legacy_request_to_v3(
+        "search",
+        {
+            "query": "models",
+            "depth": "deep-reasoning",
+            "mode": "research",
+            "quality_report": True,
+            "research_time_budget": 40,
+        },
+    )
+    schema = json.loads(
+        __import__("pathlib").Path("schemas/v3/request.schema.json").read_text()
+    )
+    jsonschema.validate(request.to_dict(), schema)
+
+
+def test_legacy_search_request_projects_all_public_execution_inputs():
+    request = legacy_request_to_v3(
+        Capability.SEARCH,
+        {
+            "query": "  Cafe\u0301 models  ",
+            "provider": "auto",
+            "count": 7,
+            "depth": "deep",
+            "time_range": "month",
+            "freshness": "week",
+            "search_type": "news",
+            "include_domains": ["example.com"],
+            "exclude_domains": ["spam.test"],
+            "mode": "research",
+            "quality_report": True,
+            "research_time_budget": 42.5,
+            "country": "at",
+            "language": "de",
+        },
+        request_id="req-search",
+    )
+
+    assert request.input == {"query": "Café models"}
+    assert request.options == {
+        "max_results": 7,
+        "depth": "deep",
+        "time_range": "month",
+        "freshness": "week",
+        "search_type": "news",
+        "include_domains": ["example.com"],
+        "exclude_domains": ["spam.test"],
+        "mode": "research",
+        "quality_report": True,
+        "research_time_budget": 42.5,
+        "locale": {"country": "at", "language": "de"},
+    }
+    assert request.routing == {
+        "mode": "auto",
+        "provider": "auto",
+        "allow_fallback": True,
+        "policy_mode": "classic",
+    }
+
+
+def test_legacy_extract_request_projects_without_hidden_context():
+    request = legacy_request_to_v3(
+        "extract",
+        {
+            "urls": ["https://example.com/a"],
+            "provider": "linkup",
+            "format": "html",
+            "include_images": True,
+            "include_raw_html": True,
+            "render_js": False,
+        },
+        request_id="req-extract",
+    )
+
+    assert request == RequestV3(
+        capability=Capability.EXTRACT,
+        input={"urls": ["https://example.com/a"]},
+        request_id="req-extract",
+        options={
+            "output_format": "html",
+            "include_images": True,
+            "include_raw_html": True,
+            "render_js": False,
+        },
+        cache={"mode": "prefer", "ttl_seconds": 3600},
+        routing={
+            "mode": "fixed",
+            "provider": "linkup",
+            "allow_fallback": True,
+            "policy_mode": "classic",
+        },
+        client={"accept_contract_versions": ["3.0", "2.x"]},
+    )
+
+
+def test_legacy_projection_is_byte_compatible_and_side_effect_free():
+    legacy = {
+        "provider": "serper",
+        "query": "q",
+        "results": [{"title": "A", "url": "https://example.com", "snippet": "S"}],
+        "routing": {"provider": "serper", "fallback_used": False},
+        "cached": False,
+    }
+    before = json.dumps(legacy, ensure_ascii=False, separators=(",", ":")).encode()
+    request = legacy_request_to_v3("search", {"query": "q", "provider": "serper"})
+    plan = ProviderPlan(("serper",), "serper")
+    execution = ExecutedV3(_response(request, plan, legacy), plan, legacy, ())
+
+    first = v3_response_to_legacy_search(execution)
+    first["results"][0]["title"] = "mutated"
+    second = v3_response_to_legacy_search(execution)
+
+    assert (
+        json.dumps(second, ensure_ascii=False, separators=(",", ":")).encode() == before
+    )
+    assert legacy["results"][0]["title"] == "A"
+
+
+def test_projection_rejects_wrong_capability():
+    request = legacy_request_to_v3("search", {"query": "q"})
+    plan = ProviderPlan(("serper",), "serper")
+    execution = ExecutedV3(_response(request, plan, {}), plan, {}, ())
+
+    with pytest.raises(ValueError):
+        v3_response_to_legacy_extract(execution)
+
+
+def test_b6_same_request_has_same_plan_and_one_execution_path():
+    calls = {"plan": 0, "execute": 0, "normalize": 0}
+
+    def plan(request, _config):
+        calls["plan"] += 1
+        provider = request.routing.get("provider", "auto")
+        return ProviderPlan((provider, "serper"), provider)
+
+    def execute(request, provider_plan, _config):
+        calls["execute"] += 1
+        return {"provider": provider_plan.selected_provider, "results": []}
+
+    def normalize(request, provider_plan, legacy):
+        calls["normalize"] += 1
+        return _response(request, provider_plan, legacy)
+
+    adapter = CapabilityAdapter(
+        capability=Capability.SEARCH,
+        plan=plan,
+        execute=execute,
+        normalize=normalize,
+    )
+    legacy_request = legacy_request_to_v3(
+        "search", {"query": "same", "provider": "auto"}, request_id="same-id"
+    )
+    native_request = RequestV3.from_dict(legacy_request.to_dict())
+
+    legacy_execution = execute_v3_request(legacy_request, adapter, {})
+    native_execution = execute_v3_request(native_request, adapter, {})
+
+    assert legacy_execution.plan == native_execution.plan
+    assert (
+        legacy_execution.response.routing_receipt
+        == native_execution.response.routing_receipt
+    )
+    assert calls == {"plan": 2, "execute": 2, "normalize": 2}
+    assert legacy_execution.stage_trace == native_execution.stage_trace
+    assert legacy_execution.stage_trace == (
+        "normalize",
+        "validate",
+        "cache_lookup",
+        "candidate_plan",
+        "admission",
+        "provider_attempt",
+        "error_classification",
+        "retry_circuit_update",
+        "fallback",
+        "result_normalization",
+        "dedup_fingerprint",
+        "cache_write",
+        "response_v3",
+    )
+
+
+def test_orchestrator_rejects_adapter_for_other_capability_before_execution():
+    called = False
+
+    def execute(*_args):
+        nonlocal called
+        called = True
+        return {}
+
+    adapter = CapabilityAdapter(
+        capability=Capability.EXTRACT,
+        plan=lambda *_: ProviderPlan(("linkup",), "linkup"),
+        execute=execute,
+        normalize=_response,
+    )
+    request = legacy_request_to_v3("search", {"query": "q"})
+
+    with pytest.raises(ValueError, match="capability"):
+        execute_v3_request(request, adapter, {})
+    assert called is False

--- a/tests/test_v3_entrypoints.py
+++ b/tests/test_v3_entrypoints.py
@@ -1,0 +1,184 @@
+import json
+from pathlib import Path
+from unittest import mock
+
+import jsonschema
+import search
+from compat_v3 import legacy_request_to_v3
+from contract_v3 import Capability, ResponseV3
+
+
+CONFIG = {
+    "version": 1,
+    "auto_routing": {
+        "enabled": True,
+        "provider_priority": ["serper"],
+        "disabled_providers": [],
+    },
+}
+RESPONSE_SCHEMA = json.loads(Path("schemas/v3/response.schema.json").read_text())
+
+
+def _search_payload():
+    return {
+        "provider": "serper",
+        "query": "q",
+        "results": [
+            {
+                "title": "A",
+                "url": "https://example.com/a",
+                "snippet": "S",
+                "published_at": "Yesterday",
+            }
+        ],
+        "routing": {
+            "auto_routed": False,
+            "provider": "serper",
+            "routing_policy": "classic-v2",
+        },
+        "metadata": {"dedup_count": 0},
+        "cached": False,
+        "deduplicated": False,
+    }
+
+
+def _extract_payload():
+    return {
+        "provider": "linkup",
+        "results": [
+            {
+                "title": "A",
+                "url": "https://example.com/a",
+                "content": "Café",
+            }
+        ],
+        "routing": {
+            "provider": "linkup",
+            "requested_provider": "linkup",
+            "fallback_used": False,
+            "fallback_errors": [],
+        },
+    }
+
+
+def test_v3_execution_can_read_but_never_writes_legacy_cache(monkeypatch):
+    dummy_key = "test-key-123456789012345678901234"
+    monkeypatch.setenv("YOU_API_KEY", dummy_key)
+    monkeypatch.setattr(search, "cache_get", lambda **_kwargs: None)
+    cache_put = mock.Mock()
+    monkeypatch.setattr(search, "cache_put", cache_put)
+    monkeypatch.setattr(search, "provider_in_cooldown", lambda _provider: (False, 0))
+    monkeypatch.setattr(
+        search, "execute_provider_with_retry", lambda _provider, fn: fn()
+    )
+    monkeypatch.setattr(
+        search,
+        "search_you",
+        lambda **_kwargs: _search_payload(),
+    )
+
+    runtime_config = {
+        **CONFIG,
+        "you": {"api_key": dummy_key},
+    }
+    result = search.run_search_request(
+        query="q", provider="you", count=1, config=runtime_config
+    )
+
+    assert result["results"]
+    cache_put.assert_not_called()
+
+
+def test_b6_engine_adapter_plan_is_identical_for_legacy_and_native(monkeypatch):
+    calls = []
+
+    def fake_core(args, config):
+        calls.append((args.query, args.provider))
+        return _search_payload(), 0
+
+    monkeypatch.setattr(search, "_execute_search_request_core", fake_core)
+    legacy_request = legacy_request_to_v3(
+        "search",
+        {"query": "same", "provider": "serper", "count": 1},
+        request_id="b6",
+    )
+    native_request = type(legacy_request).from_dict(legacy_request.to_dict())
+
+    legacy_execution = search.execute_v3_request(
+        legacy_request, search._search_adapter(), CONFIG
+    )
+    native_execution = search.execute_v3_request(
+        native_request, search._search_adapter(), CONFIG
+    )
+
+    assert legacy_execution.plan == native_execution.plan
+    assert (
+        legacy_execution.response.routing_receipt
+        == native_execution.response.routing_receipt
+    )
+    assert calls == [("same", "serper"), ("same", "serper")]
+
+
+def test_search_legacy_and_native_use_same_v3_entry_and_one_core_call(monkeypatch):
+    calls = []
+
+    def fake_core(args, config):
+        calls.append((args.query, args.provider, config))
+        return _search_payload(), 0
+
+    monkeypatch.setattr(search, "_execute_search_request_core", fake_core)
+    legacy = search.run_search_request(
+        query="q", provider="serper", count=1, config=CONFIG
+    )
+    assert legacy == _search_payload()
+    assert len(calls) == 1
+
+    request = legacy_request_to_v3(
+        Capability.SEARCH,
+        {"query": "q", "provider": "serper", "count": 1},
+        request_id="native-search",
+    )
+    native = search.run_search_request_v3(request, config=CONFIG)
+
+    assert isinstance(native, ResponseV3)
+    assert native.request_id == "native-search"
+    assert native.routing_receipt["candidate_order"] == ["serper"]
+    assert native.routing_receipt["selected_provider"] == "serper"
+    assert native.results[0]["url"] == "https://example.com/a"
+    assert "published_at" not in native.results[0]
+    jsonschema.validate(
+        native.to_dict(), RESPONSE_SCHEMA, format_checker=jsonschema.FormatChecker()
+    )
+    assert len(calls) == 2
+
+
+def test_extract_legacy_and_native_use_same_v3_entry_and_one_core_call(monkeypatch):
+    calls = []
+
+    def fake_core(**kwargs):
+        calls.append(kwargs)
+        return _extract_payload()
+
+    monkeypatch.setattr(search._extract, "_extract_plus_core", fake_core)
+    legacy = search.run_extract_request(
+        ["https://example.com/a"], provider="linkup", config=CONFIG
+    )
+    assert legacy == _extract_payload()
+    assert len(calls) == 1
+
+    request = legacy_request_to_v3(
+        Capability.EXTRACT,
+        {"urls": ["https://example.com/a"], "provider": "linkup"},
+        request_id="native-extract",
+    )
+    native = search.run_extract_request_v3(request, config=CONFIG)
+
+    assert isinstance(native, ResponseV3)
+    assert native.request_id == "native-extract"
+    assert native.routing_receipt["candidate_order"][0] == "linkup"
+    assert native.results[0]["text"] == "Café"
+    assert native.results[0]["text_normalization"] == "NFC"
+    jsonschema.validate(
+        native.to_dict(), RESPONSE_SCHEMA, format_checker=jsonschema.FormatChecker()
+    )
+    assert len(calls) == 2


### PR DESCRIPTION
## Summary

- Add the canonical Web Search Plus 3.0 runtime for `search.v3` and `extract.v3`.
- Keep v2 compatibility as explicit projections over the canonical v3 response rather than a second execution path.
- Add deterministic orchestration, contract-bound entrypoints, and search-parity fixtures/tests.

## Runtime guarantees

- The canonical path returns typed v3 responses and preserves source observations.
- v2 output is projected from v3 without re-running provider execution.
- Search and extract entrypoints validate against the frozen contract.
- Compatibility behavior is isolated in `compat_v3.py`.
- Contract/schema amendments remain generated and drift-checked.

## Review boundary

This is **slice 3 of the Web Search Plus 3.0 release train** and targets `release/v3.0.0` after the contract-freeze slice.

Included:

- canonical runtime and orchestrator;
- v3 search/extract entrypoints;
- v2 compatibility projections;
- M1 search-parity contract amendment and tests.

Deferred:

- attempt/state/cache ownership;
- bounded extraction context;
- receipt journal and Operator Console;
- migration and release hardening.

## Validation

- Python 3.8: `509 passed`
- Python 3.11: `509 passed, 6 subtests passed`
- Ruff and compileall: passed
- Contract, provider, and routing drift checks: passed
- `git diff --check`: passed
- Public privacy/credential scan: passed

## Merge plan

This slice will be squash-merged into `release/v3.0.0`. Later slices extend the canonical runtime; they do not introduce parallel execution paths.
