### PR TITLE
feat(v3): add fail-closed state and cache ownership

### DIFF
--- a/attempt_engine_v3.py
+++ b/attempt_engine_v3.py
@@ -29,6 +29,11 @@ class AttemptContext:
     budget_scope: str
     budget_window: str
     budget_units: int = 1
+    budget_limit_units: int = 3
+
+    def __post_init__(self) -> None:
+        if self.budget_units < 0 or self.budget_limit_units < 0:
+            raise ValueError("budget units must be non-negative")
 
     @property
     def circuit_key(self) -> CircuitKey:
@@ -68,6 +73,7 @@ class AttemptEngine:
                 context.capability.value,
                 context.endpoint,
                 context.credential_fingerprint,
+                context.budget_scope,
                 str(started),
             )
         )
@@ -117,10 +123,18 @@ class AttemptEngine:
         last_error = None
         encountered: set[ErrorClass] = set()
 
+        self.store.configure_budget(
+            context.budget_scope,
+            context.budget_window,
+            limit_units=context.budget_limit_units,
+        )
+
         for index in range(self.max_attempts):
             decision = self.store.admit(context.circuit_key, now=int(now()))
             if index == 0:
                 before = decision.circuit_state
+            if decision.allowed and decision.blocking_error_class is not None:
+                encountered.add(decision.blocking_error_class)
             if not decision.allowed:
                 return self._skipped(
                     context,
@@ -181,7 +195,7 @@ class AttemptEngine:
                             0, int((time.monotonic() - call_started) * 1000)
                         ),
                         error=classified,
-                        budget_decision="committed",
+                        budget_decision="reserved",
                         circuit_state_before=before,
                         circuit_state_after=after_record.state,
                     ),
@@ -210,7 +224,7 @@ class AttemptEngine:
                     duration_ms=max(
                         0, int((time.monotonic() - call_started) * 1000)
                     ),
-                    budget_decision="committed",
+                    budget_decision="reserved",
                     circuit_state_before=before,
                     circuit_state_after=CircuitState.CLOSED,
                 ),

--- a/attempt_engine_v3.py
+++ b/attempt_engine_v3.py
@@ -1,0 +1,219 @@
+"""Engine-owned admission, retry, circuit and budget handling for v3 attempts."""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Dict, Optional
+
+from contract_v3 import (
+    AttemptOutcome,
+    Capability,
+    CircuitState,
+    ErrorClass,
+    ProviderAttemptV3,
+    SkipReason,
+)
+from errors_v3 import classify_provider_error
+from state_store_v3 import CircuitKey, SQLiteStateStore
+
+
+@dataclass(frozen=True)
+class AttemptContext:
+    provider: str
+    capability: Capability
+    endpoint: str
+    credential_fingerprint: str
+    budget_scope: str
+    budget_window: str
+    budget_units: int = 1
+
+    @property
+    def circuit_key(self) -> CircuitKey:
+        return CircuitKey(
+            self.provider,
+            self.capability,
+            self.endpoint,
+            self.credential_fingerprint,
+        )
+
+
+@dataclass(frozen=True)
+class AttemptExecution:
+    payload: Optional[Dict]
+    receipt: ProviderAttemptV3
+
+
+class AttemptEngine:
+    def __init__(
+        self,
+        store: SQLiteStateStore,
+        *,
+        max_attempts: int = 3,
+        sleep: Callable[[float], None] = time.sleep,
+    ):
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be at least one")
+        self.store = store
+        self.max_attempts = max_attempts
+        self.sleep = sleep
+
+    @staticmethod
+    def _attempt_id(context: AttemptContext, started: int) -> str:
+        material = "\x1f".join(
+            (
+                context.provider,
+                context.capability.value,
+                context.endpoint,
+                context.credential_fingerprint,
+                str(started),
+            )
+        )
+        return "attempt_" + hashlib.sha256(material.encode()).hexdigest()[:16]
+
+    @staticmethod
+    def _started_at(timestamp: int) -> str:
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc).isoformat().replace(
+            "+00:00", "Z"
+        )
+
+    def _skipped(
+        self,
+        context: AttemptContext,
+        *,
+        started: int,
+        retry_count: int,
+        state: CircuitState,
+        reason: SkipReason,
+        budget_decision: str,
+    ) -> AttemptExecution:
+        return AttemptExecution(
+            None,
+            ProviderAttemptV3(
+                attempt_id=self._attempt_id(context, started),
+                provider=context.provider,
+                capability=context.capability,
+                outcome=AttemptOutcome.SKIPPED,
+                retry_count=retry_count,
+                started_at=self._started_at(started),
+                skip_reason=reason,
+                budget_decision=budget_decision,
+                circuit_state_before=state,
+                circuit_state_after=state,
+            ),
+        )
+
+    def execute(
+        self,
+        context: AttemptContext,
+        operation: Callable[[], Dict],
+        *,
+        now: Callable[[], int] = lambda: int(time.time()),
+    ) -> AttemptExecution:
+        started = int(now())
+        before = CircuitState.CLOSED
+        last_error = None
+        encountered: set[ErrorClass] = set()
+
+        for index in range(self.max_attempts):
+            decision = self.store.admit(context.circuit_key, now=int(now()))
+            if index == 0:
+                before = decision.circuit_state
+            if not decision.allowed:
+                return self._skipped(
+                    context,
+                    started=started,
+                    retry_count=index,
+                    state=decision.circuit_state,
+                    reason=decision.skip_reason or SkipReason.CIRCUIT_OPEN,
+                    budget_decision="not_reserved",
+                )
+
+            if not self.store.reserve_budget(
+                context.budget_scope,
+                context.budget_window,
+                units=context.budget_units,
+            ):
+                return self._skipped(
+                    context,
+                    started=started,
+                    retry_count=index,
+                    state=decision.circuit_state,
+                    reason=SkipReason.BUDGET_BLOCKED,
+                    budget_decision="blocked",
+                )
+
+            call_started = time.monotonic()
+            try:
+                payload = operation()
+            except BaseException as exc:
+                self.store.commit_budget(
+                    context.budget_scope,
+                    context.budget_window,
+                    units=context.budget_units,
+                )
+                classified = classify_provider_error(exc, provider=context.provider)
+                last_error = classified
+                encountered.add(classified.error_class)
+                should_retry = classified.retryable and index < self.max_attempts - 1
+                if should_retry:
+                    self.sleep(classified.retry_after_seconds or 0.0)
+                    continue
+                after_record = self.store.record_failure(
+                    context.circuit_key,
+                    classified.error_class,
+                    now=int(now()),
+                    retry_after_seconds=classified.retry_after_seconds,
+                )
+                return AttemptExecution(
+                    None,
+                    ProviderAttemptV3(
+                        attempt_id=self._attempt_id(context, started),
+                        provider=context.provider,
+                        capability=context.capability,
+                        outcome=AttemptOutcome.FAILED,
+                        retry_count=index,
+                        result_count=0,
+                        started_at=self._started_at(started),
+                        duration_ms=max(
+                            0, int((time.monotonic() - call_started) * 1000)
+                        ),
+                        error=classified,
+                        budget_decision="committed",
+                        circuit_state_before=before,
+                        circuit_state_after=after_record.state,
+                    ),
+                )
+
+            self.store.commit_budget(
+                context.budget_scope,
+                context.budget_window,
+                units=context.budget_units,
+            )
+            for error_class in encountered:
+                self.store.record_success(
+                    context.circuit_key, error_class, now=int(now())
+                )
+            result_count = len(payload.get("results") or [])
+            return AttemptExecution(
+                payload,
+                ProviderAttemptV3(
+                    attempt_id=self._attempt_id(context, started),
+                    provider=context.provider,
+                    capability=context.capability,
+                    outcome=AttemptOutcome.SUCCESS,
+                    retry_count=index,
+                    result_count=result_count,
+                    started_at=self._started_at(started),
+                    duration_ms=max(
+                        0, int((time.monotonic() - call_started) * 1000)
+                    ),
+                    budget_decision="committed",
+                    circuit_state_before=before,
+                    circuit_state_after=CircuitState.CLOSED,
+                ),
+            )
+
+        raise RuntimeError(last_error or "attempt loop exhausted")

--- a/cache_v3.py
+++ b/cache_v3.py
@@ -1,0 +1,241 @@
+"""Namespaced, ownership-safe response cache for the frozen v3 contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from contract_v3 import RequestV3
+
+
+CACHE_SCHEMA_VERSION = 1
+CACHE_OWNER = "web-search-plus:v3"
+
+
+@dataclass(frozen=True)
+class CacheLookupV3:
+    disposition: str
+    payload: Optional[Dict[str, Any]] = None
+    entry_id: Optional[str] = None
+    age_seconds: Optional[int] = None
+    source_contract_version: Optional[str] = None
+    legacy_payload: Optional[Dict[str, Any]] = None
+
+
+def derive_cache_key(request: RequestV3) -> str:
+    """Hash execution semantics, deliberately excluding request/cache policy IDs."""
+    material = {
+        "contract_version": request.contract_version,
+        "capability": request.capability.value,
+        "input": request.input,
+        "options": request.options,
+        "routing": request.routing,
+    }
+    encoded = json.dumps(
+        material,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    digest = hashlib.sha256(encoded).hexdigest()[:32]
+    return f"{request.capability.value}_{digest}"
+
+
+class ResponseCacheV3:
+    def __init__(self, root: str | Path):
+        self.root = Path(root)
+        self.response_root = self.root / "v3" / "response"
+
+    def path_for(self, request: RequestV3) -> Path:
+        entry_id = derive_cache_key(request)
+        return self.response_root / request.capability.value / f"{entry_id}.json"
+
+    @staticmethod
+    def _owned_envelope(value: object) -> bool:
+        return (
+            isinstance(value, dict)
+            and value.get("owner") == CACHE_OWNER
+            and value.get("cache_schema_version") == CACHE_SCHEMA_VERSION
+            and value.get("contract_version") == "3.0"
+            and isinstance(value.get("payload"), dict)
+        )
+
+    @staticmethod
+    def _read(path: Path) -> Optional[Dict[str, Any]]:
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        return value if ResponseCacheV3._owned_envelope(value) else None
+
+    @staticmethod
+    def _atomic_write(path: Path, value: Dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        fd, temporary = tempfile.mkstemp(
+            prefix=f"{path.name}.", suffix=".tmp", dir=str(path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(value, handle, ensure_ascii=False, sort_keys=True)
+                handle.write("\n")
+            os.replace(temporary, path)
+        except BaseException:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+            raise
+
+    def put(
+        self,
+        request: RequestV3,
+        payload: Dict[str, Any],
+        *,
+        now: int,
+        legacy_payload: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        entry_id = derive_cache_key(request)
+        envelope = {
+            "owner": CACHE_OWNER,
+            "cache_schema_version": CACHE_SCHEMA_VERSION,
+            "contract_version": "3.0",
+            "entry_id": entry_id,
+            "created_at": int(now),
+            "payload": payload,
+            "legacy_payload": legacy_payload,
+        }
+        self._atomic_write(self.path_for(request), envelope)
+        return entry_id
+
+    def get(
+        self,
+        request: RequestV3,
+        *,
+        ttl_seconds: int,
+        allow_stale_seconds: int,
+        now: int,
+    ) -> CacheLookupV3:
+        path = self.path_for(request)
+        envelope = self._read(path)
+        if envelope is None:
+            return CacheLookupV3("miss")
+        created_at = envelope.get("created_at")
+        if not isinstance(created_at, int):
+            return CacheLookupV3("miss")
+        age = max(0, int(now) - created_at)
+        entry_id = str(envelope.get("entry_id") or derive_cache_key(request))
+        if age <= max(0, int(ttl_seconds)):
+            return CacheLookupV3(
+                "fresh_hit",
+                dict(envelope["payload"]),
+                entry_id,
+                age,
+                "3.0",
+                dict(envelope["legacy_payload"])
+                if isinstance(envelope.get("legacy_payload"), dict)
+                else None,
+            )
+        if age <= max(0, int(ttl_seconds)) + max(0, int(allow_stale_seconds)):
+            return CacheLookupV3(
+                "stale_hit",
+                dict(envelope["payload"]),
+                entry_id,
+                age,
+                "3.0",
+                dict(envelope["legacy_payload"])
+                if isinstance(envelope.get("legacy_payload"), dict)
+                else None,
+            )
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        return CacheLookupV3("miss")
+
+    def stats(self) -> Dict[str, int]:
+        entries = 0
+        size_bytes = 0
+        if self.response_root.exists():
+            for path in self.response_root.rglob("*.json"):
+                if self._read(path) is None:
+                    continue
+                entries += 1
+                try:
+                    size_bytes += path.stat().st_size
+                except OSError:
+                    pass
+        return {"entries": entries, "size_bytes": size_bytes}
+
+    def clear(self) -> int:
+        cleared = 0
+        if not self.response_root.exists():
+            return cleared
+        for path in self.response_root.rglob("*.json"):
+            if self._read(path) is None:
+                continue
+            try:
+                path.unlink()
+                cleared += 1
+            except OSError:
+                pass
+        return cleared
+
+
+def peek_legacy_search(
+    root: str | Path,
+    *,
+    query: str,
+    provider: str,
+    max_results: int,
+    params: Optional[Dict[str, Any]],
+    ttl_seconds: int,
+    now: int,
+) -> CacheLookupV3:
+    """Read a v2 search entry without modifying, deleting, or refreshing it."""
+    material: Dict[str, Any] = {
+        "query": query,
+        "provider": provider,
+        "max_results": max_results,
+    }
+    if params:
+        material.update(params)
+    encoded = json.dumps(
+        material, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    entry_id = hashlib.sha256(encoded).hexdigest()[:32]
+    path = Path(root) / f"{entry_id}.json"
+    try:
+        cached = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return CacheLookupV3("miss")
+    marker_fields = {
+        "_cache_timestamp",
+        "_cache_key",
+        "_cache_query",
+        "_cache_provider",
+    }
+    if not isinstance(cached, dict) or not marker_fields.issubset(cached):
+        return CacheLookupV3("miss")
+    timestamp = cached.get("_cache_timestamp")
+    if not isinstance(timestamp, (int, float)):
+        return CacheLookupV3("miss")
+    age = max(0, int(now - timestamp))
+    if age > max(0, int(ttl_seconds)):
+        return CacheLookupV3("miss")
+    legacy_payload = {
+        key: value for key, value in cached.items() if not key.startswith("_cache_")
+    }
+    legacy_payload["cached"] = True
+    legacy_payload["cache_age_seconds"] = age
+    return CacheLookupV3(
+        "fresh_hit",
+        entry_id=entry_id,
+        age_seconds=age,
+        source_contract_version="2.x",
+        legacy_payload=legacy_payload,
+    )

--- a/errors_v3.py
+++ b/errors_v3.py
@@ -29,6 +29,11 @@ _CODES = {
 }
 
 
+class ProviderContractFailure(Exception):
+    """Provider returned a structurally unusable result without a transport error."""
+
+
+
 def classify_provider_error(error: BaseException, *, provider: str) -> ErrorV3:
     """Map an arbitrary provider exception to the frozen ErrorV3 taxonomy.
 
@@ -55,6 +60,8 @@ def classify_provider_error(error: BaseException, *, provider: str) -> ErrorV3:
         or (isinstance(status, int) and status >= 500)
     ):
         error_class = ErrorClass.TRANSIENT
+    elif isinstance(error, ProviderContractFailure):
+        error_class = ErrorClass.PROVIDER_CONTRACT
     elif isinstance(error, (TypeError, KeyError)):
         error_class = ErrorClass.PROVIDER_CONTRACT
     else:

--- a/errors_v3.py
+++ b/errors_v3.py
@@ -1,0 +1,78 @@
+"""Typed, privacy-safe provider error classification for the v3 engine."""
+
+from __future__ import annotations
+
+from contract_v3 import ErrorClass, ErrorV3
+from http_client import ProviderRequestError
+
+
+_MESSAGES = {
+    ErrorClass.CONFIG: "Provider configuration is invalid",
+    ErrorClass.AUTH: "Provider authentication failed",
+    ErrorClass.QUOTA: "Provider quota is exhausted",
+    ErrorClass.RATE_LIMIT: "Provider rate limit was reached",
+    ErrorClass.TRANSIENT: "Provider is temporarily unavailable",
+    ErrorClass.TIMEOUT: "Provider request timed out",
+    ErrorClass.PROVIDER_CONTRACT: "Provider returned an invalid response",
+    ErrorClass.INTERNAL: "Provider execution failed",
+}
+
+_CODES = {
+    ErrorClass.CONFIG: "wsp.config.provider_invalid",
+    ErrorClass.AUTH: "wsp.provider.auth",
+    ErrorClass.QUOTA: "wsp.provider.quota",
+    ErrorClass.RATE_LIMIT: "wsp.provider.rate_limit",
+    ErrorClass.TRANSIENT: "wsp.provider.transient",
+    ErrorClass.TIMEOUT: "wsp.provider.timeout",
+    ErrorClass.PROVIDER_CONTRACT: "wsp.provider.contract",
+    ErrorClass.INTERNAL: "wsp.provider.internal",
+}
+
+
+def classify_provider_error(error: BaseException, *, provider: str) -> ErrorV3:
+    """Map an arbitrary provider exception to the frozen ErrorV3 taxonomy.
+
+    Exception messages are deliberately not copied: upstream messages routinely
+    contain request URLs, credentials, query text, or response fragments.
+    """
+
+    status = getattr(error, "status_code", None)
+    retry_after = getattr(error, "retry_after", None)
+    class_name = type(error).__name__
+
+    if class_name == "ProviderConfigError":
+        error_class = ErrorClass.CONFIG
+    elif isinstance(error, (TimeoutError,)):
+        error_class = ErrorClass.TIMEOUT
+    elif status in {401, 403}:
+        error_class = ErrorClass.AUTH
+    elif status == 402:
+        error_class = ErrorClass.QUOTA
+    elif status == 429:
+        error_class = ErrorClass.RATE_LIMIT
+    elif isinstance(error, ProviderRequestError) and (
+        bool(getattr(error, "transient", False))
+        or (isinstance(status, int) and status >= 500)
+    ):
+        error_class = ErrorClass.TRANSIENT
+    elif isinstance(error, (TypeError, KeyError)):
+        error_class = ErrorClass.PROVIDER_CONTRACT
+    else:
+        error_class = ErrorClass.INTERNAL
+
+    retryable = error_class in {
+        ErrorClass.RATE_LIMIT,
+        ErrorClass.TRANSIENT,
+        ErrorClass.TIMEOUT,
+    }
+    return ErrorV3(
+        error_class=error_class,
+        code=_CODES[error_class],
+        message=_MESSAGES[error_class],
+        retryable=retryable,
+        provider=provider,
+        http_status=status if isinstance(status, int) else None,
+        retry_after_seconds=(
+            float(retry_after) if isinstance(retry_after, (int, float)) else None
+        ),
+    )

--- a/extract.py
+++ b/extract.py
@@ -1,11 +1,16 @@
 """Extraction orchestrator for Web Search Plus."""
 
 import ipaddress
+import os
 import socket
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
-from config import get_api_key, keyless_public_allowed, load_config
+from config import ProviderConfigError, get_api_key, keyless_public_allowed, load_config
+from cache import CACHE_DIR
+from attempt_engine_v3 import AttemptContext, AttemptEngine
+from errors_v3 import ProviderContractFailure
+from http_client import ProviderRequestError
 from provider_health import (
     execute_provider_with_retry,
     mark_provider_failure,
@@ -29,8 +34,14 @@ from provider_dispatch import EXTRACT_DISPATCH
 from provider_registry import EXTRACT_PROVIDER_IDS
 from compat_v3 import legacy_request_to_v3, v3_response_to_legacy_extract
 from contract_v3 import Capability, RequestV3, ResponseV3
-from orchestrator_v3 import CapabilityAdapter, ProviderPlan, execute_v3_request
+from orchestrator_v3 import (
+    CapabilityAdapter,
+    CapabilityExecution,
+    ProviderPlan,
+    execute_v3_request,
+)
 from runtime_v3 import response_from_legacy
+from state_store_v3 import SQLiteStateStore, credential_fingerprint
 
 
 EXTRACT_PROVIDER_PRIORITY = list(EXTRACT_PROVIDER_IDS)
@@ -144,6 +155,7 @@ def _extract_plus_core(
     include_raw_html: bool = False,
     render_js: bool = False,
     config: Optional[Dict[str, Any]] = None,
+    engine_owned_attempt: bool = False,
 ) -> dict:
     """Extract URL content with provider fallback."""
     config = config or load_config()
@@ -161,7 +173,13 @@ def _extract_plus_core(
         }
     auto_config = config.get("auto_routing", {})
     disabled_providers = set(auto_config.get("disabled_providers", []))
-    base_providers = resolve_extract_provider_priority(config) if selected == "auto" else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
+    base_providers = (
+        [selected]
+        if engine_owned_attempt
+        else resolve_extract_provider_priority(config)
+        if selected == "auto"
+        else [selected] + [p for p in EXTRACT_PROVIDER_PRIORITY if p != selected]
+    )
     providers = [p for p in base_providers if p == selected or p not in disabled_providers]
     errors = []
     cooldown_skips = []
@@ -172,12 +190,15 @@ def _extract_plus_core(
         key = get_api_key(prov, config)
         keyless_allowed = keyless_public_allowed(prov, config)
         if not key and not keyless_allowed:
+            if engine_owned_attempt:
+                raise ProviderConfigError(f"missing API key for {prov}")
             errors.append({"provider": prov, "error": "missing_api_key"})
             continue
-        in_cooldown, remaining = provider_in_cooldown(prov)
-        if in_cooldown and not (selected != "auto" and prov == selected):
-            cooldown_skips.append({"provider": prov, "cooldown_remaining_seconds": remaining})
-            continue
+        if not engine_owned_attempt:
+            in_cooldown, remaining = provider_in_cooldown(prov)
+            if in_cooldown and not (selected != "auto" and prov == selected):
+                cooldown_skips.append({"provider": prov, "cooldown_remaining_seconds": remaining})
+                continue
         try:
             def execute_extract() -> Dict[str, Any]:
                 # Provider-specific kwargs-building lives in
@@ -189,22 +210,31 @@ def _extract_plus_core(
                     raise ValueError(f"Unknown extract provider: {prov}")
                 return adapter(globals(), prov, urls, key, output_format, include_images, include_raw_html, render_js, config, keyless_allowed)
 
-            result = execute_provider_with_retry(prov, execute_extract)
+            result = (
+                execute_extract()
+                if engine_owned_attempt
+                else execute_provider_with_retry(prov, execute_extract)
+            )
             res_list = result.get("results") or []
             all_failed = bool(res_list) and all(r.get("error") for r in res_list)
             if all_failed:
+                if engine_owned_attempt:
+                    raise ProviderContractFailure("all_urls_failed")
                 errors.append({
                     "provider": prov,
                     "error": "all_urls_failed",
                     "details": [r.get("error") for r in res_list],
                 })
                 continue
-            reset_provider_health(prov)
+            if not engine_owned_attempt:
+                reset_provider_health(prov)
             result["routing"] = {"provider": prov, "requested_provider": selected, "fallback_used": bool(errors) or bool(cooldown_skips), "fallback_errors": errors}
             if cooldown_skips:
                 result["routing"]["cooldown_skips"] = cooldown_skips
             return result
         except Exception as e:
+            if engine_owned_attempt:
+                raise
             error_msg = str(e)
             cooldown_info = mark_provider_failure(prov, error_msg, retry_after=getattr(e, "retry_after", None))
             errors.append({"provider": prov, "error": error_msg, "cooldown_seconds": cooldown_info.get("cooldown_seconds")})
@@ -218,27 +248,141 @@ def _extract_plus_core(
 def _plan_extract_v3(request: RequestV3, config: Dict[str, Any]) -> ProviderPlan:
     selected = str(request.routing.get("provider") or "auto")
     disabled = set((config.get("auto_routing") or {}).get("disabled_providers", []))
+    configured = [
+        provider
+        for provider in resolve_extract_provider_priority(config)
+        if provider not in disabled
+        and (get_api_key(provider, config) or keyless_public_allowed(provider, config))
+    ]
     if selected == "auto":
-        candidates = [provider for provider in resolve_extract_provider_priority(config) if provider not in disabled]
+        candidates = configured
         chosen = candidates[0] if candidates else EXTRACT_PROVIDER_PRIORITY[0]
     else:
-        candidates = [selected] + [provider for provider in EXTRACT_PROVIDER_PRIORITY if provider != selected and provider not in disabled]
+        candidates = [selected] + [
+            provider for provider in configured if provider != selected
+        ]
         chosen = selected
     if not request.routing.get("allow_fallback", True):
         candidates = [chosen]
     return ProviderPlan(tuple(candidates or [chosen]), chosen)
 
 
-def _execute_extract_v3(request: RequestV3, _plan: ProviderPlan, config: Dict[str, Any]) -> Dict[str, Any]:
+def _execute_extract_v3(
+    request: RequestV3, plan: ProviderPlan, config: Dict[str, Any]
+) -> CapabilityExecution:
     options = request.options
-    return _extract_plus_core(
-        urls=list(request.input["urls"]),
-        provider=str(request.routing.get("provider") or "auto"),
-        output_format=str(options.get("output_format", "markdown")),
-        include_images=bool(options.get("include_images", False)),
-        include_raw_html=bool(options.get("include_raw_html", False)),
-        render_js=bool(options.get("render_js", False)),
-        config=dict(config),
+    try:
+        urls = _validate_extract_urls(list(request.input["urls"]), config)
+    except (ValueError, ExtractUrlSecurityError) as exc:
+        requested = str(request.routing.get("provider") or "auto")
+        return CapabilityExecution(
+            payload={
+                "provider": requested,
+                "results": [],
+                "error": str(exc),
+                "requested_provider": requested,
+            },
+            stages=(),
+        )
+    v3_config = config.get("v3") or {}
+    state_path = v3_config.get("state_path") or os.path.join(
+        str(CACHE_DIR), "v3", "state.sqlite3"
+    )
+    engine = AttemptEngine(
+        SQLiteStateStore(state_path),
+        max_attempts=int(v3_config.get("max_attempts_per_provider", 2)),
+    )
+    budget_limit = int(
+        request.budget.get(
+            "max_provider_attempts",
+            v3_config.get("default_max_provider_attempts", 3),
+        )
+    )
+    scope = request.request_id or plan.execution_id
+    receipts = []
+    fallback_errors = []
+    payload = None
+    successful_provider = None
+
+    for provider in plan.candidate_order:
+        provider_config = config.get(provider) or {}
+        endpoint = str(
+            provider_config.get("endpoint")
+            or provider_config.get("base_url")
+            or provider_config.get("url")
+            or f"provider://{provider}/extract"
+        )
+        credential = get_api_key(provider, config) or f"keyless:{provider}"
+        context = AttemptContext(
+            provider=provider,
+            capability=Capability.EXTRACT,
+            endpoint=endpoint,
+            credential_fingerprint=credential_fingerprint(credential),
+            budget_scope=scope,
+            budget_window="request",
+            budget_limit_units=budget_limit,
+        )
+
+        def operation(current_provider=provider):
+            result = _extract_plus_core(
+                urls=urls,
+                provider=current_provider,
+                output_format=str(options.get("output_format", "markdown")),
+                include_images=bool(options.get("include_images", False)),
+                include_raw_html=bool(options.get("include_raw_html", False)),
+                render_js=bool(options.get("render_js", False)),
+                config=dict(config),
+                engine_owned_attempt=True,
+            )
+            if result.get("error"):
+                raise ProviderRequestError(str(result["error"]), transient=False)
+            return result
+
+        attempted = engine.execute(context, operation)
+        receipts.append(attempted.receipt)
+        if attempted.payload is not None:
+            payload = attempted.payload
+            successful_provider = provider
+            break
+        error_code = (
+            "all_urls_failed"
+            if attempted.receipt.error is not None
+            and attempted.receipt.error.error_class.value == "provider_contract"
+            else attempted.receipt.error.error_class.value
+            if attempted.receipt.error is not None
+            else attempted.receipt.skip_reason.value
+            if attempted.receipt.skip_reason is not None
+            else "provider_failed"
+        )
+        fallback_errors.append({"provider": provider, "error": error_code})
+
+    if payload is None:
+        payload = {
+            "provider": plan.selected_provider,
+            "results": [],
+            "error": "All extraction providers failed",
+            "fallback_errors": fallback_errors,
+        }
+    else:
+        routing = payload.setdefault("routing", {})
+        routing["requested_provider"] = str(
+            request.routing.get("provider") or "auto"
+        )
+        routing["provider"] = successful_provider
+        routing["fallback_used"] = successful_provider != plan.selected_provider
+        routing["fallback_errors"] = fallback_errors
+
+    stages = ["admission", "provider_attempt"]
+    if any(receipt.error is not None for receipt in receipts):
+        stages.append("error_classification")
+    stages.append("retry_circuit_update")
+    if len(receipts) > 1:
+        stages.append("fallback")
+    stages.append("dedup_fingerprint")
+    return CapabilityExecution(
+        payload=payload,
+        provider_attempts=tuple(receipts),
+        stages=tuple(stages),
     )
 
 

--- a/independence_v3.py
+++ b/independence_v3.py
@@ -104,7 +104,8 @@ def _providers(result: Dict[str, Any]) -> List[str]:
 
 
 def _source_family(url: str) -> str:
-    return (urlsplit(url).hostname or "").lower().removeprefix("www.")
+    hostname = (urlsplit(url).hostname or "").lower()
+    return hostname[4:] if hostname.startswith("www.") else hostname
 
 
 def analyze_source_independence(

--- a/independence_v3.py
+++ b/independence_v3.py
@@ -1,0 +1,196 @@
+"""Deterministic local deduplication and source-independence estimation."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+_TRACKING_KEYS = {"fbclid", "gclid", "dclid", "msclkid"}
+_TOKEN_RE = re.compile(r"[\w]+", re.UNICODE)
+_MINHASH_PERMUTATIONS = 32
+_MINHASH_THRESHOLD = 0.65
+
+
+def canonicalize_url(value: str) -> str:
+    parsed = urlsplit(value)
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    port = parsed.port
+    netloc = host
+    if port and not (
+        (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    ):
+        netloc = f"{host}:{port}"
+    path = parsed.path or "/"
+    if path != "/":
+        path = path.rstrip("/") or "/"
+    query_items = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if not key.lower().startswith("utm_") and key.lower() not in _TRACKING_KEYS
+    ]
+    query = urlencode(sorted(query_items))
+    return urlunsplit((scheme, netloc, path, query, ""))
+
+
+def _tokens(result: Dict[str, Any]) -> List[str]:
+    text = " ".join(
+        str(result.get(field) or "") for field in ("title", "snippet", "text")
+    )
+    normalized = unicodedata.normalize("NFKC", text).casefold()
+    return _TOKEN_RE.findall(normalized)
+
+
+def _shingles(result: Dict[str, Any]) -> set[str]:
+    tokens = _tokens(result)
+    if len(tokens) < 5:
+        return set()
+    return {" ".join(tokens[index : index + 3]) for index in range(len(tokens) - 2)}
+
+
+def _minhash(shingles: Iterable[str]) -> Optional[Tuple[int, ...]]:
+    values = tuple(sorted(set(shingles)))
+    if not values:
+        return None
+    signature = []
+    for seed in range(_MINHASH_PERMUTATIONS):
+        prefix = seed.to_bytes(2, "big")
+        signature.append(
+            min(
+                int.from_bytes(
+                    hashlib.sha256(prefix + value.encode("utf-8")).digest()[:8],
+                    "big",
+                )
+                for value in values
+            )
+        )
+    return tuple(signature)
+
+
+def _similarity(left: Tuple[int, ...], right: Tuple[int, ...]) -> float:
+    return sum(a == b for a, b in zip(left, right)) / len(left)
+
+
+class _UnionFind:
+    def __init__(self, identifiers: Sequence[str]):
+        self.parent = {identifier: identifier for identifier in identifiers}
+
+    def find(self, identifier: str) -> str:
+        parent = self.parent[identifier]
+        if parent != identifier:
+            self.parent[identifier] = self.find(parent)
+        return self.parent[identifier]
+
+    def union(self, left: str, right: str) -> None:
+        left_root = self.find(left)
+        right_root = self.find(right)
+        if left_root == right_root:
+            return
+        first, second = sorted((left_root, right_root))
+        self.parent[second] = first
+
+
+def _providers(result: Dict[str, Any]) -> List[str]:
+    providers = {
+        str(item.get("provider"))
+        for item in result.get("provenance") or []
+        if isinstance(item, dict) and item.get("provider")
+    }
+    return sorted(providers)
+
+
+def _source_family(url: str) -> str:
+    return (urlsplit(url).hostname or "").lower().removeprefix("www.")
+
+
+def analyze_source_independence(
+    results: Sequence[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Cluster returned results and estimate independence without network access."""
+    if not results:
+        return [], None
+    ordered = sorted((dict(item) for item in results), key=lambda item: item["result_id"])
+    identifiers = [str(item["result_id"]) for item in ordered]
+    union = _UnionFind(identifiers)
+    canonical = {
+        str(item["result_id"]): canonicalize_url(
+            str(item.get("canonical_url") or item.get("url") or "")
+        )
+        for item in ordered
+    }
+    signatures = {
+        str(item["result_id"]): _minhash(_shingles(item)) for item in ordered
+    }
+    for index, left in enumerate(ordered):
+        left_id = str(left["result_id"])
+        for right in ordered[index + 1 :]:
+            right_id = str(right["result_id"])
+            if canonical[left_id] and canonical[left_id] == canonical[right_id]:
+                union.union(left_id, right_id)
+                continue
+            left_signature = signatures[left_id]
+            right_signature = signatures[right_id]
+            if (
+                left_signature is not None
+                and right_signature is not None
+                and _similarity(left_signature, right_signature) >= _MINHASH_THRESHOLD
+            ):
+                union.union(left_id, right_id)
+
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for item in ordered:
+        grouped.setdefault(union.find(str(item["result_id"])), []).append(item)
+
+    clusters = []
+    for members in grouped.values():
+        member_ids = sorted(str(item["result_id"]) for item in members)
+        canonical_id = member_ids[0]
+        providers = sorted(
+            {provider for item in members for provider in _providers(item)}
+        )
+        digest = hashlib.sha256("\x1f".join(member_ids).encode("utf-8")).hexdigest()[:16]
+        clusters.append(
+            {
+                "cluster_id": f"cluster_{digest}",
+                "canonical_result_id": canonical_id,
+                "member_result_ids": member_ids,
+                "canonical_url": canonical[canonical_id],
+                "providers": providers,
+            }
+        )
+    clusters.sort(key=lambda item: item["cluster_id"])
+
+    result_count = len(ordered)
+    cluster_count = len(clusters)
+    source_families = {
+        _source_family(canonical[identifier])
+        for identifier in identifiers
+        if _source_family(canonical[identifier])
+    }
+    providers = {
+        provider for item in ordered for provider in _providers(item)
+    }
+    text_capable = sum(signature is not None for signature in signatures.values()) >= 2
+    score = round(
+        0.7 * (cluster_count / result_count)
+        + 0.3 * (len(source_families) / result_count),
+        3,
+    )
+    estimate = {
+        "score": min(1.0, max(0.0, score)),
+        "unique_cluster_count": cluster_count,
+        "result_count": result_count,
+        "source_family_count": len(source_families),
+        "provider_count": len(providers),
+        "method": "url+snippet-minhash-v1" if text_capable else "url-v1",
+        "confidence": "medium" if text_capable and result_count > 1 else "low",
+        "method_degraded": not text_capable,
+        "limitations": [
+            "shared upstream indexes and syndication without textual overlap may be undetectable"
+        ],
+    }
+    return clusters, estimate

--- a/orchestrator_v3.py
+++ b/orchestrator_v3.py
@@ -12,7 +12,7 @@ import time
 import unicodedata
 import uuid
 from dataclasses import dataclass, field, replace
-from typing import Any, Callable, Dict, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import cache as legacy_cache
 from cache_v3 import ResponseCacheV3
@@ -87,7 +87,7 @@ ExecuteFn = Callable[
 ]
 NormalizeFn = Callable[[RequestV3, ProviderPlan, Dict[str, Any]], ResponseV3]
 LegacyCacheLookupFn = Callable[
-    [RequestV3, ProviderPlan, Dict[str, Any]], CapabilityExecution | None
+    [RequestV3, ProviderPlan, Dict[str, Any]], Optional[CapabilityExecution]
 ]
 
 

--- a/orchestrator_v3.py
+++ b/orchestrator_v3.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import copy
 import unicodedata
-from dataclasses import dataclass, replace
-from typing import Any, Callable, Dict, Tuple
+import uuid
+from dataclasses import dataclass, field, replace
+from typing import Any, Callable, Dict, Tuple, Union
 
 from contract_v3 import Capability, RequestV3, ResponseV3
 
@@ -36,7 +37,11 @@ PIPELINE_STAGES: Tuple[str, ...] = (
 class ProviderPlan:
     candidate_order: Tuple[str, ...]
     selected_provider: str
+    routing_metadata: Dict[str, Any] = field(default_factory=dict)
     mode: str = "classic"
+    execution_id: str = field(
+        default_factory=lambda: str(uuid.uuid4()), compare=False
+    )
 
     def __post_init__(self) -> None:
         if self.mode not in {"classic", "shadow"}:
@@ -48,7 +53,27 @@ class ProviderPlan:
 
 
 PlanFn = Callable[[RequestV3, Dict[str, Any]], ProviderPlan]
-ExecuteFn = Callable[[RequestV3, ProviderPlan, Dict[str, Any]], Dict[str, Any]]
+@dataclass(frozen=True)
+class CapabilityExecution:
+    payload: Dict[str, Any]
+    provider_attempts: Tuple[Any, ...] = ()
+    stages: Tuple[str, ...] = ("provider_attempt",)
+
+    def __post_init__(self) -> None:
+        if len(set(self.stages)) != len(self.stages):
+            raise ValueError("execution stages must be unique")
+        unknown = set(self.stages) - set(PIPELINE_STAGES)
+        if unknown:
+            raise ValueError(f"unknown execution stages: {sorted(unknown)}")
+        positions = [PIPELINE_STAGES.index(stage) for stage in self.stages]
+        if positions != sorted(positions):
+            raise ValueError("execution stages must follow canonical order")
+
+
+ExecuteFn = Callable[
+    [RequestV3, ProviderPlan, Dict[str, Any]],
+    Union[Dict[str, Any], CapabilityExecution],
+]
 NormalizeFn = Callable[[RequestV3, ProviderPlan, Dict[str, Any]], ResponseV3]
 
 
@@ -91,15 +116,36 @@ def execute_v3_request(
         raise ValueError("request and adapter capability differ")
     runtime_config: Dict[str, Any] = config or {}
     plan = adapter.plan(request, runtime_config)
-    legacy_payload = adapter.execute(request, plan, runtime_config)
+    raw_execution = adapter.execute(request, plan, runtime_config)
+    if isinstance(raw_execution, CapabilityExecution):
+        legacy_payload = raw_execution.payload
+        execution_stages = raw_execution.stages
+        provider_attempts = raw_execution.provider_attempts
+    else:
+        legacy_payload = raw_execution
+        execution_stages = ("provider_attempt",)
+        provider_attempts = ()
     response = adapter.normalize(request, plan, legacy_payload)
+    if provider_attempts:
+        response = replace(response, provider_attempts=list(provider_attempts))
     if response.capability is not request.capability:
         raise ValueError("adapter returned response for another capability")
     if tuple(response.routing_receipt["candidate_order"]) != plan.candidate_order:
         raise ValueError("response candidate_order drifted from authoritative plan")
+    executed_stage_set = {
+        "normalize",
+        "validate",
+        "candidate_plan",
+        *execution_stages,
+        "result_normalization",
+        "response_v3",
+    }
+    stage_trace = tuple(
+        stage for stage in PIPELINE_STAGES if stage in executed_stage_set
+    )
     return ExecutedV3(
         response=response,
         plan=plan,
         legacy_payload=copy.deepcopy(legacy_payload),
-        stage_trace=PIPELINE_STAGES,
+        stage_trace=stage_trace,
     )

--- a/orchestrator_v3.py
+++ b/orchestrator_v3.py
@@ -8,12 +8,23 @@ RequestV3 before they can reach this function.
 from __future__ import annotations
 
 import copy
+import time
 import unicodedata
 import uuid
 from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Dict, Tuple, Union
 
-from contract_v3 import Capability, RequestV3, ResponseV3
+import cache as legacy_cache
+from cache_v3 import ResponseCacheV3
+from contract_v3 import (
+    Capability,
+    DegradedReason,
+    ErrorClass,
+    ErrorV3,
+    RequestV3,
+    ResponseStatus,
+    ResponseV3,
+)
 
 
 PIPELINE_STAGES: Tuple[str, ...] = (
@@ -75,6 +86,9 @@ ExecuteFn = Callable[
     Union[Dict[str, Any], CapabilityExecution],
 ]
 NormalizeFn = Callable[[RequestV3, ProviderPlan, Dict[str, Any]], ResponseV3]
+LegacyCacheLookupFn = Callable[
+    [RequestV3, ProviderPlan, Dict[str, Any]], CapabilityExecution | None
+]
 
 
 @dataclass(frozen=True)
@@ -83,6 +97,7 @@ class CapabilityAdapter:
     plan: PlanFn
     execute: ExecuteFn
     normalize: NormalizeFn
+    legacy_cache_lookup: LegacyCacheLookupFn | None = None
 
 
 @dataclass(frozen=True)
@@ -116,18 +131,132 @@ def execute_v3_request(
         raise ValueError("request and adapter capability differ")
     runtime_config: Dict[str, Any] = config or {}
     plan = adapter.plan(request, runtime_config)
-    raw_execution = adapter.execute(request, plan, runtime_config)
+    cache_mode = str(request.cache.get("mode") or "prefer")
+    cache_enabled = cache_mode != "bypass"
+    v3_config = runtime_config.get("v3") or {}
+    response_cache = ResponseCacheV3(
+        v3_config.get("cache_dir") or legacy_cache.CACHE_DIR
+    )
+    if cache_enabled:
+        lookup = response_cache.get(
+            request,
+            ttl_seconds=int(request.cache.get("ttl_seconds", 3600)),
+            allow_stale_seconds=int(request.cache.get("allow_stale_seconds", 0)),
+            now=int(time.time()),
+        )
+        if lookup.payload is not None:
+            cached_response = ResponseV3.from_dict(lookup.payload)
+            cached_order = tuple(
+                cached_response.routing_receipt.get("candidate_order") or ()
+            )
+            if cached_order == plan.candidate_order:
+                cache_status = {
+                    "disposition": lookup.disposition,
+                    "entry_id": lookup.entry_id,
+                    "age_seconds": lookup.age_seconds,
+                    "ttl_seconds": int(request.cache.get("ttl_seconds", 3600)),
+                    "served_stale": lookup.disposition == "stale_hit",
+                    "source_contract_version": "3.0",
+                }
+                warnings = list(cached_response.warnings)
+                status = cached_response.status
+                if lookup.disposition == "stale_hit":
+                    status = ResponseStatus.DEGRADED
+                    warnings.append(
+                        {
+                            "code": DegradedReason.SERVED_STALE.value,
+                            "message": "Served stale cached response.",
+                        }
+                    )
+                cached_response = replace(
+                    cached_response,
+                    request_id=request.request_id or plan.execution_id,
+                    status=status,
+                    provider_attempts=[],
+                    cache_status=cache_status,
+                    warnings=warnings,
+                )
+                legacy_payload = copy.deepcopy(lookup.legacy_payload or {})
+                legacy_payload["cached"] = True
+                legacy_payload["cache_age_seconds"] = lookup.age_seconds or 0
+                stage_set = {
+                    "normalize",
+                    "validate",
+                    "cache_lookup",
+                    "candidate_plan",
+                    "response_v3",
+                }
+                return ExecutedV3(
+                    response=cached_response,
+                    plan=plan,
+                    legacy_payload=legacy_payload,
+                    stage_trace=tuple(
+                        stage for stage in PIPELINE_STAGES if stage in stage_set
+                    ),
+                )
+    legacy_execution = (
+        adapter.legacy_cache_lookup(request, plan, runtime_config)
+        if cache_enabled and adapter.legacy_cache_lookup is not None
+        else None
+    )
+    if cache_mode == "only" and legacy_execution is None:
+        response = ResponseV3(
+            request_id=request.request_id or plan.execution_id,
+            capability=request.capability,
+            status=ResponseStatus.FAILED,
+            results=[],
+            provider_attempts=[],
+            routing_receipt={
+                "policy_id": "classic",
+                "policy_revision": "v2.9.1",
+                "mode": plan.mode,
+                "candidate_order": list(plan.candidate_order),
+                "selected_provider": None,
+                "fallback_reason": "none",
+            },
+            cache_status={"disposition": "miss"},
+            error=ErrorV3(
+                error_class=ErrorClass.CONFIG,
+                code="wsp.cache.miss",
+                message="Cache-only request missed.",
+                retryable=False,
+            ),
+        )
+        stage_set = {
+            "normalize",
+            "validate",
+            "cache_lookup",
+            "candidate_plan",
+            "response_v3",
+        }
+        return ExecutedV3(
+            response=response,
+            plan=plan,
+            legacy_payload={
+                "error": "Cache-only request missed",
+                "provider": plan.selected_provider,
+                "results": [],
+            },
+            stage_trace=tuple(
+                stage for stage in PIPELINE_STAGES if stage in stage_set
+            ),
+        )
+    raw_execution = legacy_execution or adapter.execute(request, plan, runtime_config)
     if isinstance(raw_execution, CapabilityExecution):
         legacy_payload = raw_execution.payload
         execution_stages = raw_execution.stages
         provider_attempts = raw_execution.provider_attempts
+        attempts_authoritative = True
     else:
         legacy_payload = raw_execution
         execution_stages = ("provider_attempt",)
         provider_attempts = ()
+        attempts_authoritative = False
     response = adapter.normalize(request, plan, legacy_payload)
-    if provider_attempts:
+    if attempts_authoritative:
         response = replace(response, provider_attempts=list(provider_attempts))
+    if cache_mode == "bypass":
+        response = replace(response, cache_status={"disposition": "bypassed"})
     if response.capability is not request.capability:
         raise ValueError("adapter returned response for another capability")
     if tuple(response.routing_receipt["candidate_order"]) != plan.candidate_order:
@@ -140,6 +269,25 @@ def execute_v3_request(
         "result_normalization",
         "response_v3",
     }
+    if cache_enabled:
+        executed_stage_set.add("cache_lookup")
+        if response.status is not ResponseStatus.FAILED:
+            try:
+                response_cache.put(
+                    request,
+                    response.to_dict(),
+                    now=int(time.time()),
+                    legacy_payload=legacy_payload,
+                )
+                executed_stage_set.add("cache_write")
+            except OSError:
+                response = replace(
+                    response,
+                    cache_status={
+                        **response.cache_status,
+                        "write_error": "write_failed",
+                    },
+                )
     stage_trace = tuple(
         stage for stage in PIPELINE_STAGES if stage in executed_stage_set
     )

--- a/runtime_v3.py
+++ b/runtime_v3.py
@@ -22,6 +22,7 @@ from contract_v3 import (
     ResponseV3,
 )
 from orchestrator_v3 import ProviderPlan
+from independence_v3 import analyze_source_independence
 
 
 def _canonical_url(value: str) -> str:
@@ -274,14 +275,7 @@ def response_from_legacy(
     else:
         cache_status = {"disposition": "miss"}
 
-    clusters = [
-        {
-            "cluster_id": _stable_id("cluster", item["canonical_url"]),
-            "member_result_ids": [item["result_id"]],
-            "canonical_url": item["canonical_url"],
-        }
-        for item in results
-    ]
+    clusters, independence_estimate = analyze_source_independence(results)
     return ResponseV3(
         request_id=request_id,
         capability=request.capability,
@@ -301,6 +295,7 @@ def response_from_legacy(
         if request.capability is Capability.SEARCH
         else {},
         dedup_clusters=clusters,
+        source_independence_estimate=independence_estimate,
         warnings=warnings,
         error=error,
     )

--- a/runtime_v3.py
+++ b/runtime_v3.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import unicodedata
-import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Mapping
 from urllib.parse import urlsplit, urlunsplit
@@ -227,7 +226,7 @@ def response_from_legacy(
     payload: Dict[str, Any],
 ) -> ResponseV3:
     """Build a contract-valid ResponseV3 without modifying the legacy payload."""
-    request_id = request.request_id or str(uuid.uuid4())
+    request_id = request.request_id or plan.execution_id
     routing = payload.get("routing") or {}
     selected = (
         routing.get("provider") or payload.get("provider") or plan.selected_provider

--- a/search.py
+++ b/search.py
@@ -88,6 +88,7 @@ from search_locale import provider_supports_locale, resolve_locale
 from env_loader import load_env_files
 from research import run_research_mode
 from attempt_engine_v3 import AttemptContext, AttemptEngine
+from cache_v3 import peek_legacy_search
 from compat_v3 import legacy_request_to_v3, v3_response_to_legacy_search
 from contract_v3 import Capability, RequestV3, ResponseV3
 from orchestrator_v3 import (
@@ -1133,6 +1134,40 @@ def _apply_result_quality_pipeline(
             result.setdefault("metadata", {})["domain_diversity_demoted"] = demoted
 
 
+def _legacy_search_cache_context(
+    args, provider: str, config: Dict[str, Any]
+) -> Dict[str, Any]:
+    locale_country, locale_language, _locale_meta = resolve_locale(
+        provider,
+        config,
+        args.query,
+        cli_country=args.country,
+        cli_language=args.language,
+    )
+    return {
+        "locale": f"{locale_country}:{locale_language}",
+        "freshness": args.freshness,
+        "time_range": args.time_range,
+        "include_domains": sorted(args.include_domains)
+        if args.include_domains
+        else None,
+        "exclude_domains": sorted(args.exclude_domains)
+        if args.exclude_domains
+        else None,
+        "topic": args.topic,
+        "search_engines": sorted(args.engines) if args.engines else None,
+        "include_news": not args.no_news,
+        "search_type": args.search_type,
+        "exa_type": args.exa_type,
+        "exa_depth": args.exa_depth,
+        "exa_verbosity": args.exa_verbosity,
+        "category": args.category,
+        "similar_url": args.similar_url,
+        "mode": args.mode,
+        "quality_report": args.quality_report,
+    }
+
+
 def _execute_search_request_core(args, config: Dict[str, Any]) -> Tuple[Dict[str, Any], int]:
     """Run the search/research pipeline for parsed args.
 
@@ -1246,31 +1281,7 @@ def _execute_search_request_core(args, config: Dict[str, Any]) -> Tuple[Dict[str
         )
         return provider_result
 
-    # Resolved locale for the selected provider: config-first country,
-    # query-aware language (see search_locale.resolve_locale). Defaults stay
-    # us/en, so cache keys are unchanged for unconfigured setups.
-    locale_country, locale_language, _locale_meta = resolve_locale(
-        provider or "", config, args.query, cli_country=args.country, cli_language=args.language
-    )
-
-    cache_context = {
-        "locale": f"{locale_country}:{locale_language}",
-        "freshness": args.freshness,
-        "time_range": args.time_range,
-        "include_domains": sorted(args.include_domains) if args.include_domains else None,
-        "exclude_domains": sorted(args.exclude_domains) if args.exclude_domains else None,
-        "topic": args.topic,
-        "search_engines": sorted(args.engines) if args.engines else None,
-        "include_news": not args.no_news,
-        "search_type": args.search_type,
-        "exa_type": args.exa_type,
-        "exa_depth": args.exa_depth,
-        "exa_verbosity": args.exa_verbosity,
-        "category": args.category,
-        "similar_url": args.similar_url,
-        "mode": args.mode,
-        "quality_report": args.quality_report,
-    }
+    cache_context = _legacy_search_cache_context(args, provider or "", config)
 
     providers_considered = providers_to_try.copy()
 
@@ -1588,6 +1599,33 @@ def _search_args_from_v3(request: RequestV3, config: Dict[str, Any]):
     return args
 
 
+def _lookup_legacy_search_v3(
+    request: RequestV3, plan: ProviderPlan, config: Dict[str, Any]
+) -> CapabilityExecution | None:
+    legacy_args = _search_args_from_v3(request, config)
+    legacy_args.provider = plan.selected_provider
+    if legacy_args.mode == "research":
+        return None
+    legacy_lookup = peek_legacy_search(
+        CACHE_DIR,
+        query=legacy_args.query,
+        provider=plan.selected_provider,
+        max_results=legacy_args.max_results,
+        params=_legacy_search_cache_context(
+            legacy_args, plan.selected_provider, config
+        ),
+        ttl_seconds=int(request.cache.get("ttl_seconds", 3600)),
+        now=int(time.time()),
+    )
+    if legacy_lookup.legacy_payload is None:
+        return None
+    return CapabilityExecution(
+        payload=legacy_lookup.legacy_payload,
+        provider_attempts=(),
+        stages=("dedup_fingerprint",),
+    )
+
+
 def _execute_search_v3(
     request: RequestV3, plan: ProviderPlan, config: Dict[str, Any]
 ) -> CapabilityExecution:
@@ -1708,6 +1746,7 @@ def _search_adapter() -> CapabilityAdapter:
         plan=_plan_search_v3,
         execute=_execute_search_v3,
         normalize=response_from_legacy,
+        legacy_cache_lookup=_lookup_legacy_search_v3,
     )
 
 

--- a/search.py
+++ b/search.py
@@ -24,6 +24,8 @@ Examples:
     python3 search.py -q "latest OpenSSH CVE mitigation"    # → Serper (security/current)
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import os

--- a/search.py
+++ b/search.py
@@ -87,10 +87,17 @@ from request_gate_v3 import validate_provider_mode
 from search_locale import provider_supports_locale, resolve_locale
 from env_loader import load_env_files
 from research import run_research_mode
+from attempt_engine_v3 import AttemptContext, AttemptEngine
 from compat_v3 import legacy_request_to_v3, v3_response_to_legacy_search
 from contract_v3 import Capability, RequestV3, ResponseV3
-from orchestrator_v3 import CapabilityAdapter, ProviderPlan, execute_v3_request
+from orchestrator_v3 import (
+    CapabilityAdapter,
+    CapabilityExecution,
+    ProviderPlan,
+    execute_v3_request,
+)
 from runtime_v3 import response_from_legacy
+from state_store_v3 import SQLiteStateStore, credential_fingerprint
 import providers as _providers
 import routing as _routing
 import extract as _extract
@@ -1190,15 +1197,20 @@ def _execute_search_request_core(args, config: Dict[str, Any]) -> Tuple[Dict[str
             if p not in providers_to_try and p not in disabled_providers and _provider_auto_allowed(p, auto_config) and provider_configured(p, config):
                 providers_to_try.append(p)
 
-    # Skip providers currently in cooldown
+    # The v3 AttemptEngine owns admission/circuit state. Its single-provider
+    # adapter must not consult or mutate the legacy provider-health system.
+    engine_owned_attempt = bool(getattr(args, "_v3_engine_owned_attempt", False))
     eligible_providers = []
     cooldown_skips = []
-    for p in providers_to_try:
-        in_cd, remaining = provider_in_cooldown(p)
-        if in_cd:
-            cooldown_skips.append({"provider": p, "cooldown_remaining_seconds": remaining})
-        else:
-            eligible_providers.append(p)
+    if engine_owned_attempt:
+        eligible_providers = list(providers_to_try)
+    else:
+        for p in providers_to_try:
+            in_cd, remaining = provider_in_cooldown(p)
+            if in_cd:
+                cooldown_skips.append({"provider": p, "cooldown_remaining_seconds": remaining})
+            else:
+                eligible_providers.append(p)
 
     if not eligible_providers:
         eligible_providers = providers_to_try[:1]
@@ -1216,6 +1228,8 @@ def _execute_search_request_core(args, config: Dict[str, Any]) -> Tuple[Dict[str
         return adapter(globals(), prov, args, key, config, routing_info)
 
     def execute_with_retry(prov: str) -> Dict[str, Any]:
+        if engine_owned_attempt:
+            return execute_search(prov)
         started = time.monotonic()
         try:
             provider_result = execute_provider_with_retry(prov, lambda: execute_search(prov))
@@ -1362,7 +1376,8 @@ def _execute_search_request_core(args, config: Dict[str, Any]) -> Tuple[Dict[str
             break
         try:
             provider_result = execute_with_retry(current_provider)
-            reset_provider_health(current_provider)
+            if not engine_owned_attempt:
+                reset_provider_health(current_provider)
             successful_results.append((current_provider, provider_result))
             successful_provider = current_provider
 
@@ -1374,6 +1389,8 @@ def _execute_search_request_core(args, config: Dict[str, Any]) -> Tuple[Dict[str
             if not errors:
                 break
         except ProviderConfigError as e:
+            if engine_owned_attempt:
+                raise
             # Missing/invalid local credentials are configuration errors, not
             # provider health failures. Do not poison shared cooldown state for
             # a provider the runtime never actually contacted.
@@ -1383,6 +1400,8 @@ def _execute_search_request_core(args, config: Dict[str, Any]) -> Tuple[Dict[str
             })
             continue
         except Exception as e:
+            if engine_owned_attempt:
+                raise
             error_msg = str(e)
             cooldown_info = mark_provider_failure(current_provider, error_msg, retry_after=getattr(e, "retry_after", None))
             errors.append({
@@ -1514,6 +1533,7 @@ def _plan_search_v3(request: RequestV3, config: Dict[str, Any]) -> ProviderPlan:
         selected = str(routed["provider"])
     else:
         selected = requested
+        routed = {}
     candidates = [selected]
     if routing_request.get("allow_fallback", requested == "auto"):
         disabled = set(auto_config.get("disabled_providers", []))
@@ -1525,7 +1545,7 @@ def _plan_search_v3(request: RequestV3, config: Dict[str, Any]) -> ProviderPlan:
                 and provider_configured(provider, config)
             ):
                 candidates.append(provider)
-    return ProviderPlan(tuple(candidates), selected)
+    return ProviderPlan(tuple(candidates), selected, routing_metadata=dict(routed))
 
 
 def _search_args_from_v3(request: RequestV3, config: Dict[str, Any]):
@@ -1568,9 +1588,118 @@ def _search_args_from_v3(request: RequestV3, config: Dict[str, Any]):
     return args
 
 
-def _execute_search_v3(request: RequestV3, _plan: ProviderPlan, config: Dict[str, Any]) -> Dict[str, Any]:
-    payload, _exit_code = _execute_search_request_core(_search_args_from_v3(request, config), config)
-    return payload
+def _execute_search_v3(
+    request: RequestV3, plan: ProviderPlan, config: Dict[str, Any]
+) -> CapabilityExecution:
+    v3_config = config.get("v3") or {}
+    state_path = v3_config.get("state_path") or os.path.join(
+        str(CACHE_DIR), "v3", "state.sqlite3"
+    )
+    store = SQLiteStateStore(state_path)
+    budget_limit = int(
+        request.budget.get(
+            "max_provider_attempts",
+            v3_config.get("default_max_provider_attempts", 3),
+        )
+    )
+    engine = AttemptEngine(
+        store,
+        max_attempts=int(v3_config.get("max_attempts_per_provider", 2)),
+    )
+    receipts = []
+    payload = None
+    successful_provider = None
+    scope = request.request_id or plan.execution_id
+
+    for provider in plan.candidate_order:
+        provider_config = config.get(provider) or {}
+        endpoint = str(
+            provider_config.get("endpoint")
+            or provider_config.get("base_url")
+            or provider_config.get("url")
+            or f"provider://{provider}/search"
+        )
+        credential = get_api_key(provider, config) or f"keyless:{provider}"
+        context = AttemptContext(
+            provider=provider,
+            capability=Capability.SEARCH,
+            endpoint=endpoint,
+            credential_fingerprint=credential_fingerprint(credential),
+            budget_scope=scope,
+            budget_window="request",
+            budget_limit_units=budget_limit,
+        )
+
+        def operation(current_provider=provider):
+            args = _search_args_from_v3(request, config)
+            args.provider = current_provider
+            args.allow_fallback = False
+            args.no_cache = True
+            args._v3_engine_owned_attempt = True
+            provider_payload, exit_code = _execute_search_request_core(args, config)
+            if exit_code:
+                raise ProviderRequestError(
+                    str(provider_payload.get("error") or "provider failed"),
+                    transient=False,
+                )
+            return provider_payload
+
+        attempted = engine.execute(context, operation)
+        receipts.append(attempted.receipt)
+        if attempted.payload is not None:
+            payload = attempted.payload
+            successful_provider = provider
+            break
+
+    if payload is None:
+        payload = {
+            "error": "All providers failed",
+            "provider": plan.selected_provider,
+            "query": request.input["query"],
+            "results": [],
+            "routing": {
+                "provider": plan.selected_provider,
+                "fallback_used": False,
+            },
+            "provider_errors": [
+                {
+                    "provider": receipt.provider,
+                    "error": (
+                        receipt.error.message
+                        if receipt.error is not None
+                        else receipt.skip_reason.value
+                        if receipt.skip_reason is not None
+                        else "provider attempt failed"
+                    ),
+                }
+                for receipt in receipts
+            ],
+        }
+    else:
+        routing = payload.setdefault("routing", {})
+        requested = str(request.routing.get("provider") or "auto")
+        if requested == "auto":
+            routing.update(plan.routing_metadata)
+            routing["auto_routed"] = True
+            routing["provider"] = successful_provider
+            payload["provider"] = successful_provider
+        if successful_provider != plan.selected_provider:
+            routing["fallback_used"] = True
+            routing["original_provider"] = plan.selected_provider
+            routing["provider"] = successful_provider
+
+    stages = ["admission", "provider_attempt"]
+    if any(receipt.error is not None for receipt in receipts):
+        stages.append("error_classification")
+    stages.append("retry_circuit_update")
+    if len(receipts) > 1:
+        stages.append("fallback")
+    stages.append("dedup_fingerprint")
+    return CapabilityExecution(
+        payload=payload,
+        provider_attempts=tuple(receipts),
+        stages=tuple(stages),
+    )
 
 
 def _search_adapter() -> CapabilityAdapter:

--- a/state_store_v3.py
+++ b/state_store_v3.py
@@ -1,0 +1,395 @@
+"""Fail-closed SQLite operational state for the Web Search Plus v3 engine."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from contract_v3 import Capability, CircuitState, ErrorClass, SkipReason
+
+
+SCHEMA_VERSION = 1
+DEFAULT_OPEN_SECONDS = {
+    ErrorClass.QUOTA: 3600,
+    ErrorClass.RATE_LIMIT: 60,
+    ErrorClass.TRANSIENT: 60,
+    ErrorClass.TIMEOUT: 60,
+}
+
+
+def credential_fingerprint(secret: str | None) -> str:
+    """Return a non-reversible identity for one configured provider credential."""
+    material = secret if secret else "<anonymous>"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()[:24]
+
+
+@dataclass(frozen=True)
+class CircuitKey:
+    provider: str
+    capability: Capability
+    endpoint: str
+    credential_fingerprint: str
+
+    def values(self) -> tuple[str, str, str, str]:
+        return (
+            self.provider,
+            self.capability.value,
+            self.endpoint,
+            self.credential_fingerprint,
+        )
+
+
+@dataclass(frozen=True)
+class CircuitRecord:
+    state: CircuitState = CircuitState.CLOSED
+    failure_count: int = 0
+    open_until: Optional[int] = None
+    updated_at: int = 0
+
+
+@dataclass(frozen=True)
+class AdmissionDecision:
+    allowed: bool
+    circuit_state: CircuitState
+    skip_reason: Optional[SkipReason] = None
+    store_available: bool = True
+    blocking_error_class: Optional[ErrorClass] = None
+
+
+@dataclass(frozen=True)
+class BudgetRecord:
+    scope: str
+    window_key: str
+    limit_units: int
+    used_units: int
+    reserved_units: int
+
+
+class SQLiteStateStore:
+    """Durable state store whose admission path fails closed on SQLite errors."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+        self._available = False
+        self._initialize()
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path, timeout=5, isolation_level=None)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA busy_timeout=5000")
+        return connection
+
+    def _initialize(self) -> None:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            connection = self._connect()
+            try:
+                connection.execute("PRAGMA journal_mode=WAL")
+                connection.execute("PRAGMA foreign_keys=ON")
+                connection.executescript(
+                    """
+                    CREATE TABLE IF NOT EXISTS circuit_state (
+                        provider TEXT NOT NULL,
+                        capability TEXT NOT NULL,
+                        endpoint TEXT NOT NULL,
+                        credential_fingerprint TEXT NOT NULL,
+                        error_class TEXT NOT NULL,
+                        state TEXT NOT NULL,
+                        failure_count INTEGER NOT NULL DEFAULT 0,
+                        open_until INTEGER,
+                        updated_at INTEGER NOT NULL,
+                        PRIMARY KEY (
+                            provider, capability, endpoint,
+                            credential_fingerprint, error_class
+                        )
+                    );
+                    CREATE TABLE IF NOT EXISTS budget_ledger (
+                        scope TEXT NOT NULL,
+                        window_key TEXT NOT NULL,
+                        limit_units INTEGER NOT NULL,
+                        used_units INTEGER NOT NULL DEFAULT 0,
+                        reserved_units INTEGER NOT NULL DEFAULT 0,
+                        PRIMARY KEY (scope, window_key)
+                    );
+                    PRAGMA user_version=1;
+                    """
+                )
+            finally:
+                connection.close()
+            self._available = True
+        except (OSError, sqlite3.Error):
+            self._available = False
+
+    @staticmethod
+    def _state_for(error_class: ErrorClass) -> CircuitState:
+        if error_class is ErrorClass.AUTH:
+            return CircuitState.BLOCKED_AUTH
+        if error_class is ErrorClass.QUOTA:
+            return CircuitState.BLOCKED_QUOTA
+        return CircuitState.OPEN
+
+    def record_failure(
+        self,
+        key: CircuitKey,
+        error_class: ErrorClass,
+        *,
+        now: int,
+        retry_after_seconds: float | None = None,
+    ) -> CircuitRecord:
+        if not self._available:
+            return CircuitRecord(CircuitState.UNKNOWN)
+        state = self._state_for(error_class)
+        if error_class is ErrorClass.AUTH:
+            open_until = None
+        else:
+            seconds = int(
+                retry_after_seconds
+                if retry_after_seconds is not None
+                else DEFAULT_OPEN_SECONDS.get(error_class, 60)
+            )
+            open_until = now + max(1, seconds)
+        try:
+            connection = self._connect()
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                connection.execute(
+                    """
+                    INSERT INTO circuit_state (
+                        provider, capability, endpoint, credential_fingerprint,
+                        error_class, state, failure_count, open_until, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
+                    ON CONFLICT (
+                        provider, capability, endpoint,
+                        credential_fingerprint, error_class
+                    ) DO UPDATE SET
+                        state=excluded.state,
+                        failure_count=circuit_state.failure_count + 1,
+                        open_until=excluded.open_until,
+                        updated_at=excluded.updated_at
+                    """,
+                    (*key.values(), error_class.value, state.value, open_until, now),
+                )
+                connection.commit()
+            finally:
+                connection.close()
+        except sqlite3.Error:
+            self._available = False
+            return CircuitRecord(CircuitState.UNKNOWN)
+        return self.get_circuit(key, error_class)
+
+    def record_success(
+        self, key: CircuitKey, error_class: ErrorClass, *, now: int
+    ) -> None:
+        del now
+        if not self._available:
+            return
+        try:
+            connection = self._connect()
+            try:
+                connection.execute(
+                    """
+                    DELETE FROM circuit_state
+                    WHERE provider=? AND capability=? AND endpoint=?
+                      AND credential_fingerprint=? AND error_class=?
+                    """,
+                    (*key.values(), error_class.value),
+                )
+            finally:
+                connection.close()
+        except sqlite3.Error:
+            self._available = False
+
+    def get_circuit(
+        self, key: CircuitKey, error_class: ErrorClass
+    ) -> CircuitRecord:
+        if not self._available:
+            return CircuitRecord(CircuitState.UNKNOWN)
+        try:
+            connection = self._connect()
+            try:
+                row = connection.execute(
+                    """
+                    SELECT state, failure_count, open_until, updated_at
+                    FROM circuit_state
+                    WHERE provider=? AND capability=? AND endpoint=?
+                      AND credential_fingerprint=? AND error_class=?
+                    """,
+                    (*key.values(), error_class.value),
+                ).fetchone()
+            finally:
+                connection.close()
+        except sqlite3.Error:
+            self._available = False
+            return CircuitRecord(CircuitState.UNKNOWN)
+        if row is None:
+            return CircuitRecord()
+        return CircuitRecord(
+            state=CircuitState(row["state"]),
+            failure_count=int(row["failure_count"]),
+            open_until=(int(row["open_until"]) if row["open_until"] is not None else None),
+            updated_at=int(row["updated_at"]),
+        )
+
+    def admit(self, key: CircuitKey, *, now: int) -> AdmissionDecision:
+        if not self._available:
+            return AdmissionDecision(
+                False,
+                CircuitState.UNKNOWN,
+                SkipReason.CIRCUIT_OPEN,
+                store_available=False,
+            )
+        checks = (
+            (ErrorClass.AUTH, SkipReason.AUTH_BLOCKED),
+            (ErrorClass.QUOTA, SkipReason.QUOTA_BLOCKED),
+            (ErrorClass.RATE_LIMIT, SkipReason.RATE_LIMITED),
+            (ErrorClass.TRANSIENT, SkipReason.CIRCUIT_OPEN),
+            (ErrorClass.TIMEOUT, SkipReason.CIRCUIT_OPEN),
+        )
+        for error_class, skip_reason in checks:
+            record = self.get_circuit(key, error_class)
+            if not self._available:
+                return AdmissionDecision(
+                    False,
+                    CircuitState.UNKNOWN,
+                    SkipReason.CIRCUIT_OPEN,
+                    store_available=False,
+                )
+            active = record.state is CircuitState.BLOCKED_AUTH or (
+                record.state in {
+                    CircuitState.BLOCKED_QUOTA,
+                    CircuitState.OPEN,
+                    CircuitState.HALF_OPEN,
+                }
+                and (record.open_until is None or record.open_until > now)
+            )
+            if active:
+                return AdmissionDecision(
+                    False,
+                    record.state,
+                    skip_reason,
+                    blocking_error_class=error_class,
+                )
+        return AdmissionDecision(True, CircuitState.CLOSED)
+
+    def configure_budget(
+        self, scope: str, window_key: str, *, limit_units: int
+    ) -> None:
+        if limit_units < 0:
+            raise ValueError("budget limit_units must be non-negative")
+        if not self._available:
+            return
+        try:
+            connection = self._connect()
+            try:
+                connection.execute(
+                    """
+                    INSERT INTO budget_ledger (
+                        scope, window_key, limit_units, used_units, reserved_units
+                    ) VALUES (?, ?, ?, 0, 0)
+                    ON CONFLICT(scope, window_key)
+                    DO UPDATE SET limit_units=excluded.limit_units
+                    """,
+                    (scope, window_key, limit_units),
+                )
+            finally:
+                connection.close()
+        except sqlite3.Error:
+            self._available = False
+
+    def reserve_budget(self, scope: str, window_key: str, *, units: int) -> bool:
+        if units < 0:
+            raise ValueError("budget units must be non-negative")
+        if not self._available:
+            return False
+        try:
+            connection = self._connect()
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                cursor = connection.execute(
+                    """
+                    UPDATE budget_ledger
+                    SET reserved_units=reserved_units + ?
+                    WHERE scope=? AND window_key=?
+                      AND used_units + reserved_units + ? <= limit_units
+                    """,
+                    (units, scope, window_key, units),
+                )
+                allowed = cursor.rowcount == 1
+                connection.commit()
+                return allowed
+            finally:
+                connection.close()
+        except sqlite3.Error:
+            self._available = False
+            return False
+
+    def release_budget(self, scope: str, window_key: str, *, units: int) -> None:
+        self._move_budget(scope, window_key, units=units, commit=False)
+
+    def commit_budget(self, scope: str, window_key: str, *, units: int) -> None:
+        self._move_budget(scope, window_key, units=units, commit=True)
+
+    def _move_budget(
+        self, scope: str, window_key: str, *, units: int, commit: bool
+    ) -> None:
+        if units < 0:
+            raise ValueError("budget units must be non-negative")
+        if not self._available:
+            return
+        used_expression = "used_units + ?" if commit else "used_units"
+        parameters = (
+            (units, units, scope, window_key)
+            if commit
+            else (units, scope, window_key)
+        )
+        try:
+            connection = self._connect()
+            try:
+                connection.execute(
+                    f"""
+                    UPDATE budget_ledger
+                    SET used_units={used_expression},
+                        reserved_units=MAX(0, reserved_units - ?)
+                    WHERE scope=? AND window_key=?
+                    """,
+                    parameters,
+                )
+            finally:
+                connection.close()
+        except sqlite3.Error:
+            self._available = False
+
+    def get_budget(self, scope: str, window_key: str) -> BudgetRecord:
+        if not self._available:
+            raise RuntimeError("state store unavailable")
+        try:
+            connection = self._connect()
+            try:
+                row = connection.execute(
+                    """
+                    SELECT limit_units, used_units, reserved_units
+                    FROM budget_ledger WHERE scope=? AND window_key=?
+                    """,
+                    (scope, window_key),
+                ).fetchone()
+            finally:
+                connection.close()
+        except sqlite3.Error as exc:
+            self._available = False
+            raise RuntimeError("state store unavailable") from exc
+        if row is None:
+            raise KeyError((scope, window_key))
+        return BudgetRecord(
+            scope,
+            window_key,
+            int(row["limit_units"]),
+            int(row["used_units"]),
+            int(row["reserved_units"]),
+        )

--- a/state_store_v3.py
+++ b/state_store_v3.py
@@ -13,6 +13,7 @@ from contract_v3 import Capability, CircuitState, ErrorClass, SkipReason
 
 SCHEMA_VERSION = 1
 DEFAULT_OPEN_SECONDS = {
+    ErrorClass.AUTH: 300,
     ErrorClass.QUOTA: 3600,
     ErrorClass.RATE_LIMIT: 60,
     ErrorClass.TRANSIENT: 60,
@@ -146,15 +147,12 @@ class SQLiteStateStore:
         if not self._available:
             return CircuitRecord(CircuitState.UNKNOWN)
         state = self._state_for(error_class)
-        if error_class is ErrorClass.AUTH:
-            open_until = None
-        else:
-            seconds = int(
-                retry_after_seconds
-                if retry_after_seconds is not None
-                else DEFAULT_OPEN_SECONDS.get(error_class, 60)
-            )
-            open_until = now + max(1, seconds)
+        seconds = int(
+            retry_after_seconds
+            if retry_after_seconds is not None
+            else DEFAULT_OPEN_SECONDS.get(error_class, 60)
+        )
+        open_until = now + max(1, seconds)
         try:
             connection = self._connect()
             try:
@@ -237,6 +235,46 @@ class SQLiteStateStore:
             updated_at=int(row["updated_at"]),
         )
 
+    def _claim_half_open(
+        self, key: CircuitKey, error_class: ErrorClass, *, now: int
+    ) -> bool:
+        """Atomically lease one probe for an expired circuit bucket."""
+        if not self._available:
+            return False
+        try:
+            connection = self._connect()
+            try:
+                connection.execute("BEGIN IMMEDIATE")
+                cursor = connection.execute(
+                    """
+                    UPDATE circuit_state
+                    SET state=?, open_until=?, updated_at=?
+                    WHERE provider=? AND capability=? AND endpoint=?
+                      AND credential_fingerprint=? AND error_class=?
+                      AND state IN (?, ?, ?, ?)
+                      AND open_until IS NOT NULL AND open_until <= ?
+                    """,
+                    (
+                        CircuitState.HALF_OPEN.value,
+                        now + 60,
+                        now,
+                        *key.values(),
+                        error_class.value,
+                        CircuitState.BLOCKED_AUTH.value,
+                        CircuitState.BLOCKED_QUOTA.value,
+                        CircuitState.OPEN.value,
+                        CircuitState.HALF_OPEN.value,
+                        now,
+                    ),
+                )
+                connection.commit()
+                return cursor.rowcount == 1
+            finally:
+                connection.close()
+        except sqlite3.Error:
+            self._available = False
+            return False
+
     def admit(self, key: CircuitKey, *, now: int) -> AdmissionDecision:
         if not self._available:
             return AdmissionDecision(
@@ -252,6 +290,7 @@ class SQLiteStateStore:
             (ErrorClass.TRANSIENT, SkipReason.CIRCUIT_OPEN),
             (ErrorClass.TIMEOUT, SkipReason.CIRCUIT_OPEN),
         )
+        expired = []
         for error_class, skip_reason in checks:
             record = self.get_circuit(key, error_class)
             if not self._available:
@@ -261,14 +300,9 @@ class SQLiteStateStore:
                     SkipReason.CIRCUIT_OPEN,
                     store_available=False,
                 )
-            active = record.state is CircuitState.BLOCKED_AUTH or (
-                record.state in {
-                    CircuitState.BLOCKED_QUOTA,
-                    CircuitState.OPEN,
-                    CircuitState.HALF_OPEN,
-                }
-                and (record.open_until is None or record.open_until > now)
-            )
+            if record.state is CircuitState.CLOSED:
+                continue
+            active = record.open_until is None or record.open_until > now
             if active:
                 return AdmissionDecision(
                     False,
@@ -276,6 +310,29 @@ class SQLiteStateStore:
                     skip_reason,
                     blocking_error_class=error_class,
                 )
+            expired.append((error_class, skip_reason))
+
+        for error_class, skip_reason in expired:
+            if self._claim_half_open(key, error_class, now=now):
+                return AdmissionDecision(
+                    True,
+                    CircuitState.HALF_OPEN,
+                    blocking_error_class=error_class,
+                )
+            if not self._available:
+                return AdmissionDecision(
+                    False,
+                    CircuitState.UNKNOWN,
+                    SkipReason.CIRCUIT_OPEN,
+                    store_available=False,
+                )
+            current = self.get_circuit(key, error_class)
+            return AdmissionDecision(
+                False,
+                current.state,
+                skip_reason,
+                blocking_error_class=error_class,
+            )
         return AdmissionDecision(True, CircuitState.CLOSED)
 
     def configure_budget(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,20 @@
 import pytest
 
+import cache
+import extract
 import provider_stats
+import search
 
 
 @pytest.fixture(autouse=True)
-def _isolate_provider_stats(tmp_path, monkeypatch):
-    """Keep adaptive-routing stats out of the real cache dir during tests.
+def _isolate_runtime_state(tmp_path, monkeypatch):
+    """Keep mutable runtime state out of real paths and isolate every test.
 
     Search tests record outcomes for mocked providers; without isolation those
     samples would pollute the operator's provider_stats.json and, worse, feed
     back into routing decisions and make routing tests order-dependent.
     """
     monkeypatch.setattr(provider_stats, "PROVIDER_STATS_FILE", tmp_path / "provider_stats.json")
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(search, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(extract, "CACHE_DIR", tmp_path)

--- a/tests/test_extract_plus.py
+++ b/tests/test_extract_plus.py
@@ -340,20 +340,12 @@ class ExtractPlusCoreTests(unittest.TestCase):
                 "search.extract_firecrawl",
                 side_effect=[transient, {"provider": "firecrawl", "results": [{"url": "https://example.com", "content": "ok"}]}],
             ) as mock_firecrawl:
-                with mock.patch("search.time.sleep") as mock_sleep:
-                    result = search.extract_plus(["https://example.com"], provider="firecrawl")
+                result = search.extract_plus(["https://example.com"], provider="firecrawl")
 
         self.assertEqual(result["provider"], "firecrawl")
         self.assertEqual(mock_firecrawl.call_count, 2)
-        # Retry backoff now carries jitter to de-synchronize retries: the delay is
-        # the base step plus up to RETRY_JITTER_FRACTION of it.
-        mock_sleep.assert_called_once()
-        (slept,) = mock_sleep.call_args[0]
-        base = search.RETRY_BACKOFF_SECONDS[0]
-        self.assertGreaterEqual(slept, base)
-        self.assertLessEqual(slept, base * (1 + search.RETRY_JITTER_FRACTION))
 
-    def test_extract_plus_marks_failed_provider_and_resets_successful_fallback(self):
+    def test_extract_plus_does_not_write_legacy_health_on_fallback(self):
         transient = search.ProviderRequestError("temporary outage", status_code=503, transient=True)
         with mock.patch.dict(os.environ, {"FIRECRAWL_API_KEY": "fc-test", "LINKUP_API_KEY": "linkup-test"}, clear=True):
             with mock.patch("search.extract_firecrawl", side_effect=[transient, transient, transient]):
@@ -364,24 +356,20 @@ class ExtractPlusCoreTests(unittest.TestCase):
                                 result = search.extract_plus(["https://example.com"], provider="firecrawl")
 
         self.assertEqual(result["provider"], "linkup")
-        mock_mark.assert_called_once()
-        self.assertEqual(mock_mark.call_args.args[0], "firecrawl")
-        mock_reset.assert_called_once_with("linkup")
-        self.assertEqual(result["routing"]["fallback_errors"][0]["cooldown_seconds"], 60)
+        mock_mark.assert_not_called()
+        mock_reset.assert_not_called()
+        self.assertEqual(result["routing"]["fallback_errors"][0]["error"], "transient")
 
-    def test_extract_plus_skips_provider_in_cooldown(self):
-        def fake_cooldown(provider):
-            return (provider == "tavily", 42 if provider == "tavily" else 0)
-
+    def test_extract_plus_ignores_legacy_cooldown_state(self):
         with mock.patch.dict(os.environ, {"TAVILY_API_KEY": "tvly-test", "LINKUP_API_KEY": "linkup-test"}, clear=True):
-            with mock.patch("search.provider_in_cooldown", side_effect=fake_cooldown):
-                with mock.patch("search.extract_tavily") as mock_tavily:
+            with mock.patch("search.provider_in_cooldown") as legacy_cooldown:
+                with mock.patch("search.extract_tavily", return_value={"provider": "tavily", "results": []}) as mock_tavily:
                     with mock.patch("search.extract_linkup", return_value={"provider": "linkup", "results": [{"url": "https://example.com", "content": "fallback"}]}):
                         result = search.extract_plus(["https://example.com"], provider="auto")
 
-        self.assertEqual(result["provider"], "linkup")
-        mock_tavily.assert_not_called()
-        self.assertEqual(result["routing"]["cooldown_skips"], [{"provider": "tavily", "cooldown_remaining_seconds": 42}])
+        self.assertEqual(result["provider"], "tavily")
+        mock_tavily.assert_called_once()
+        legacy_cooldown.assert_not_called()
 
 
 class ExtractPlusPluginTests(unittest.TestCase):

--- a/tests/test_m2_attempt_engine_v3.py
+++ b/tests/test_m2_attempt_engine_v3.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from contract_v3 import (
+    AttemptOutcome,
+    Capability,
+    CircuitState,
+    ErrorClass,
+    SkipReason,
+)
+from attempt_engine_v3 import AttemptContext, AttemptEngine
+from http_client import ProviderRequestError
+from state_store_v3 import SQLiteStateStore, credential_fingerprint
+
+
+def _context(*, budget_units: int = 1) -> AttemptContext:
+    return AttemptContext(
+        provider="serper",
+        capability=Capability.SEARCH,
+        endpoint="https://google.serper.dev/search",
+        credential_fingerprint=credential_fingerprint("credential"),
+        budget_scope="request-1",
+        budget_window="request",
+        budget_units=budget_units,
+    )
+
+
+def test_attempt_engine_retries_transient_and_records_one_provider_receipt(tmp_path):
+    store = SQLiteStateStore(tmp_path / "state.sqlite3")
+    store.configure_budget("request-1", "request", limit_units=3)
+    engine = AttemptEngine(store, max_attempts=3, sleep=lambda _seconds: None)
+    calls = []
+
+    def operation():
+        calls.append("call")
+        if len(calls) == 1:
+            raise ProviderRequestError("upstream", status_code=503, transient=True)
+        return {"results": [{"url": "https://example.com"}]}
+
+    execution = engine.execute(_context(), operation, now=lambda: 100)
+
+    assert len(calls) == 2
+    assert execution.payload is not None
+    assert execution.receipt.outcome is AttemptOutcome.SUCCESS
+    assert execution.receipt.retry_count == 1
+    assert execution.receipt.result_count == 1
+    assert execution.receipt.circuit_state_before is CircuitState.CLOSED
+    assert execution.receipt.circuit_state_after is CircuitState.CLOSED
+    assert store.get_budget("request-1", "request").used_units == 2
+
+
+def test_auth_failure_is_not_retried_and_blocks_same_credential(tmp_path):
+    store = SQLiteStateStore(tmp_path / "state.sqlite3")
+    store.configure_budget("request-1", "request", limit_units=3)
+    engine = AttemptEngine(store, max_attempts=3, sleep=lambda _seconds: None)
+    calls = []
+
+    def operation():
+        calls.append("call")
+        raise ProviderRequestError("bad key", status_code=401)
+
+    failed = engine.execute(_context(), operation, now=lambda: 100)
+    blocked = engine.execute(_context(), operation, now=lambda: 101)
+
+    assert len(calls) == 1
+    assert failed.receipt.outcome is AttemptOutcome.FAILED
+    assert failed.receipt.error.error_class is ErrorClass.AUTH
+    assert failed.receipt.retry_count == 0
+    assert blocked.receipt.outcome is AttemptOutcome.SKIPPED
+    assert blocked.receipt.skip_reason is SkipReason.AUTH_BLOCKED
+
+
+def test_fail_closed_state_store_skips_before_provider_call(tmp_path):
+    path = tmp_path / "state.sqlite3"
+    path.write_bytes(b"corrupt")
+    engine = AttemptEngine(SQLiteStateStore(path))
+    calls = []
+
+    execution = engine.execute(
+        _context(), lambda: calls.append("called") or {"results": []}, now=lambda: 100
+    )
+
+    assert calls == []
+    assert execution.receipt.outcome is AttemptOutcome.SKIPPED
+    assert execution.receipt.skip_reason is SkipReason.CIRCUIT_OPEN
+    assert execution.receipt.circuit_state_before is CircuitState.UNKNOWN
+
+
+def test_budget_is_admitted_before_provider_call(tmp_path):
+    store = SQLiteStateStore(tmp_path / "state.sqlite3")
+    store.configure_budget("request-1", "request", limit_units=0)
+    engine = AttemptEngine(store)
+    calls = []
+
+    execution = engine.execute(
+        _context(), lambda: calls.append("called") or {"results": []}, now=lambda: 100
+    )
+
+    assert calls == []
+    assert execution.receipt.outcome is AttemptOutcome.SKIPPED
+    assert execution.receipt.skip_reason is SkipReason.BUDGET_BLOCKED
+    assert execution.receipt.budget_decision == "blocked"
+
+
+def test_admission_runs_before_each_retry(tmp_path):
+    class CountingStore(SQLiteStateStore):
+        def __init__(self, path):
+            self.admissions = 0
+            super().__init__(path)
+
+        def admit(self, key, *, now):
+            self.admissions += 1
+            return super().admit(key, now=now)
+
+    store = CountingStore(tmp_path / "state.sqlite3")
+    store.configure_budget("request-1", "request", limit_units=3)
+    engine = AttemptEngine(store, max_attempts=3, sleep=lambda _seconds: None)
+    calls = []
+
+    def operation():
+        calls.append("call")
+        if len(calls) < 3:
+            raise ProviderRequestError("upstream", status_code=503, transient=True)
+        return {"results": []}
+
+    engine.execute(_context(), operation, now=lambda: 100)
+
+    assert len(calls) == 3
+    assert store.admissions == 3

--- a/tests/test_m2_attempt_engine_v3.py
+++ b/tests/test_m2_attempt_engine_v3.py
@@ -12,7 +12,7 @@ from http_client import ProviderRequestError
 from state_store_v3 import SQLiteStateStore, credential_fingerprint
 
 
-def _context(*, budget_units: int = 1) -> AttemptContext:
+def _context(*, budget_units: int = 1, budget_limit_units: int = 3) -> AttemptContext:
     return AttemptContext(
         provider="serper",
         capability=Capability.SEARCH,
@@ -21,12 +21,12 @@ def _context(*, budget_units: int = 1) -> AttemptContext:
         budget_scope="request-1",
         budget_window="request",
         budget_units=budget_units,
+        budget_limit_units=budget_limit_units,
     )
 
 
 def test_attempt_engine_retries_transient_and_records_one_provider_receipt(tmp_path):
     store = SQLiteStateStore(tmp_path / "state.sqlite3")
-    store.configure_budget("request-1", "request", limit_units=3)
     engine = AttemptEngine(store, max_attempts=3, sleep=lambda _seconds: None)
     calls = []
 
@@ -50,7 +50,6 @@ def test_attempt_engine_retries_transient_and_records_one_provider_receipt(tmp_p
 
 def test_auth_failure_is_not_retried_and_blocks_same_credential(tmp_path):
     store = SQLiteStateStore(tmp_path / "state.sqlite3")
-    store.configure_budget("request-1", "request", limit_units=3)
     engine = AttemptEngine(store, max_attempts=3, sleep=lambda _seconds: None)
     calls = []
 
@@ -87,18 +86,36 @@ def test_fail_closed_state_store_skips_before_provider_call(tmp_path):
 
 def test_budget_is_admitted_before_provider_call(tmp_path):
     store = SQLiteStateStore(tmp_path / "state.sqlite3")
-    store.configure_budget("request-1", "request", limit_units=0)
     engine = AttemptEngine(store)
     calls = []
 
     execution = engine.execute(
-        _context(), lambda: calls.append("called") or {"results": []}, now=lambda: 100
+        _context(budget_limit_units=0),
+        lambda: calls.append("called") or {"results": []},
+        now=lambda: 100,
     )
 
     assert calls == []
     assert execution.receipt.outcome is AttemptOutcome.SKIPPED
     assert execution.receipt.skip_reason is SkipReason.BUDGET_BLOCKED
     assert execution.receipt.budget_decision == "blocked"
+
+
+def test_successful_half_open_probe_clears_auth_bucket(tmp_path):
+    store = SQLiteStateStore(tmp_path / "state.sqlite3")
+    context = _context()
+    store.record_failure(context.circuit_key, ErrorClass.AUTH, now=100)
+    engine = AttemptEngine(store, max_attempts=1)
+
+    execution = engine.execute(
+        context,
+        lambda: {"results": []},
+        now=lambda: 400,
+    )
+
+    assert execution.receipt.outcome is AttemptOutcome.SUCCESS
+    assert execution.receipt.circuit_state_before is CircuitState.HALF_OPEN
+    assert store.get_circuit(context.circuit_key, ErrorClass.AUTH).state is CircuitState.CLOSED
 
 
 def test_admission_runs_before_each_retry(tmp_path):
@@ -112,7 +129,6 @@ def test_admission_runs_before_each_retry(tmp_path):
             return super().admit(key, now=now)
 
     store = CountingStore(tmp_path / "state.sqlite3")
-    store.configure_budget("request-1", "request", limit_units=3)
     engine = AttemptEngine(store, max_attempts=3, sleep=lambda _seconds: None)
     calls = []
 

--- a/tests/test_m2_state_store_v3.py
+++ b/tests/test_m2_state_store_v3.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import sqlite3
+
+from contract_v3 import Capability, CircuitState, ErrorClass, SkipReason
+from errors_v3 import classify_provider_error
+from http_client import ProviderRequestError
+from state_store_v3 import CircuitKey, SQLiteStateStore, credential_fingerprint
+
+
+def _key(secret: str = "credential-a") -> CircuitKey:
+    return CircuitKey(
+        provider="serper",
+        capability=Capability.SEARCH,
+        endpoint="https://google.serper.dev/search",
+        credential_fingerprint=credential_fingerprint(secret),
+    )
+
+
+def test_error_classifier_keeps_auth_quota_rate_and_transient_distinct():
+    cases = [
+        (ProviderRequestError("unauthorized", status_code=401), ErrorClass.AUTH),
+        (ProviderRequestError("payment required", status_code=402), ErrorClass.QUOTA),
+        (
+            ProviderRequestError("rate limited", status_code=429, transient=True, retry_after=7),
+            ErrorClass.RATE_LIMIT,
+        ),
+        (ProviderRequestError("upstream", status_code=503, transient=True), ErrorClass.TRANSIENT),
+        (TimeoutError("timed out"), ErrorClass.TIMEOUT),
+    ]
+
+    for error, expected in cases:
+        classified = classify_provider_error(error, provider="serper")
+        assert classified.error_class is expected
+        assert classified.provider == "serper"
+
+
+def test_error_classifier_does_not_leak_exception_secret():
+    error = ProviderRequestError("request failed with key super-secret-value", status_code=401)
+
+    classified = classify_provider_error(error, provider="serper")
+
+    assert "super-secret-value" not in classified.message
+    assert classified.message == "Provider authentication failed"
+
+
+def test_credential_fingerprint_is_stable_and_never_contains_secret():
+    first = credential_fingerprint("super-secret-value")
+    second = credential_fingerprint("super-secret-value")
+
+    assert first == second
+    assert "super-secret-value" not in first
+    assert len(first) == 24
+
+
+def test_state_store_admission_is_fail_closed_when_database_is_corrupt(tmp_path):
+    path = tmp_path / "state.sqlite3"
+    path.write_bytes(b"not sqlite")
+    store = SQLiteStateStore(path)
+
+    decision = store.admit(_key(), now=100)
+
+    assert decision.allowed is False
+    assert decision.circuit_state is CircuitState.UNKNOWN
+    assert decision.skip_reason is SkipReason.CIRCUIT_OPEN
+    assert decision.store_available is False
+
+
+def test_circuit_rows_are_isolated_by_error_class(tmp_path):
+    store = SQLiteStateStore(tmp_path / "state.sqlite3")
+    key = _key()
+
+    store.record_failure(key, ErrorClass.AUTH, now=100)
+    store.record_failure(key, ErrorClass.RATE_LIMIT, now=101, retry_after_seconds=30)
+
+    auth = store.get_circuit(key, ErrorClass.AUTH)
+    rate = store.get_circuit(key, ErrorClass.RATE_LIMIT)
+    transient = store.get_circuit(key, ErrorClass.TRANSIENT)
+
+    assert auth.state is CircuitState.BLOCKED_AUTH
+    assert rate.state is CircuitState.OPEN
+    assert rate.open_until == 131
+    assert transient.state is CircuitState.CLOSED
+    assert transient.failure_count == 0
+
+
+def test_circuit_key_isolated_by_capability_endpoint_and_credential(tmp_path):
+    store = SQLiteStateStore(tmp_path / "state.sqlite3")
+    blocked = _key("credential-a")
+    store.record_failure(blocked, ErrorClass.AUTH, now=100)
+
+    variants = [
+        CircuitKey("serper", Capability.EXTRACT, blocked.endpoint, blocked.credential_fingerprint),
+        CircuitKey("serper", Capability.SEARCH, "https://scrape.serper.dev", blocked.credential_fingerprint),
+        _key("credential-b"),
+    ]
+
+    assert store.admit(blocked, now=101).allowed is False
+    assert all(store.admit(key, now=101).allowed for key in variants)
+
+
+def test_admission_maps_independent_open_buckets_to_specific_skip_reasons(tmp_path):
+    store = SQLiteStateStore(tmp_path / "state.sqlite3")
+    key = _key()
+
+    store.record_failure(key, ErrorClass.RATE_LIMIT, now=100, retry_after_seconds=20)
+    decision = store.admit(key, now=101)
+    assert decision.allowed is False
+    assert decision.skip_reason is SkipReason.RATE_LIMITED
+
+    store.record_success(key, ErrorClass.RATE_LIMIT, now=102)
+    store.record_failure(key, ErrorClass.QUOTA, now=103, retry_after_seconds=40)
+    decision = store.admit(key, now=104)
+    assert decision.allowed is False
+    assert decision.skip_reason is SkipReason.QUOTA_BLOCKED
+
+
+def test_budget_ledger_reserve_commit_release_uses_abstract_units(tmp_path):
+    store = SQLiteStateStore(tmp_path / "state.sqlite3")
+    store.configure_budget("request-1", "2026-07-12", limit_units=5)
+
+    assert store.reserve_budget("request-1", "2026-07-12", units=3) is True
+    assert store.reserve_budget("request-1", "2026-07-12", units=3) is False
+    store.release_budget("request-1", "2026-07-12", units=1)
+    assert store.reserve_budget("request-1", "2026-07-12", units=3) is True
+    store.commit_budget("request-1", "2026-07-12", units=5)
+
+    ledger = store.get_budget("request-1", "2026-07-12")
+    assert ledger.limit_units == 5
+    assert ledger.used_units == 5
+    assert ledger.reserved_units == 0
+
+
+def test_schema_initialization_is_idempotent_and_uses_wal(tmp_path):
+    path = tmp_path / "state.sqlite3"
+    SQLiteStateStore(path)
+    SQLiteStateStore(path)
+
+    connection = sqlite3.connect(path)
+    try:
+        mode = connection.execute("PRAGMA journal_mode").fetchone()[0]
+        version = connection.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        connection.close()
+
+    assert mode.lower() == "wal"
+    assert version == 1

--- a/tests/test_m2_state_store_v3.py
+++ b/tests/test_m2_state_store_v3.py
@@ -99,6 +99,28 @@ def test_circuit_key_isolated_by_capability_endpoint_and_credential(tmp_path):
     assert all(store.admit(key, now=101).allowed for key in variants)
 
 
+def test_auth_circuit_allows_exactly_one_half_open_probe_after_cooldown(tmp_path):
+    store = SQLiteStateStore(tmp_path / "state.sqlite3")
+    key = _key()
+
+    record = store.record_failure(key, ErrorClass.AUTH, now=100)
+
+    assert record.open_until == 400
+    assert store.admit(key, now=399).allowed is False
+    probe = store.admit(key, now=400)
+    competing = store.admit(key, now=400)
+    assert probe.allowed is True
+    assert probe.circuit_state is CircuitState.HALF_OPEN
+    assert probe.blocking_error_class is ErrorClass.AUTH
+    assert competing.allowed is False
+    assert competing.circuit_state is CircuitState.HALF_OPEN
+
+    store.record_success(key, ErrorClass.AUTH, now=401)
+    recovered = store.admit(key, now=401)
+    assert recovered.allowed is True
+    assert recovered.circuit_state is CircuitState.CLOSED
+
+
 def test_admission_maps_independent_open_buckets_to_specific_skip_reasons(tmp_path):
     store = SQLiteStateStore(tmp_path / "state.sqlite3")
     key = _key()

--- a/tests/test_m3_cache_integration.py
+++ b/tests/test_m3_cache_integration.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from compat_v3 import legacy_request_to_v3
+from contract_v3 import Capability, RequestV3, ResponseStatus, ResponseV3
+from orchestrator_v3 import CapabilityAdapter, ProviderPlan, execute_v3_request
+
+
+def _response(request: RequestV3, plan: ProviderPlan, _payload: dict) -> ResponseV3:
+    return ResponseV3(
+        request_id=request.request_id or plan.execution_id,
+        capability=request.capability,
+        status=ResponseStatus.OK,
+        results=[],
+        provider_attempts=[],
+        routing_receipt={
+            "policy_id": "classic",
+            "policy_revision": "v2.9.1",
+            "mode": "classic",
+            "candidate_order": list(plan.candidate_order),
+            "selected_provider": "serper",
+            "fallback_reason": "none",
+        },
+        cache_status={"disposition": "miss"},
+    )
+
+
+def _request(request_id: str, *, bypass: bool = False) -> RequestV3:
+    request = legacy_request_to_v3(
+        Capability.SEARCH,
+        {"query": "cache me", "provider": "serper", "count": 2},
+        request_id=request_id,
+    )
+    if not bypass:
+        return request
+    return RequestV3.from_dict(
+        {**request.to_dict(), "cache": {**request.cache, "mode": "bypass"}}
+    )
+
+
+def test_orchestrator_v3_cache_hit_skips_provider_and_rebinds_request_id(tmp_path):
+    calls = []
+
+    def execute(_request, _plan, _config):
+        calls.append("provider")
+        return {"provider": "serper", "results": [], "cached": False}
+
+    adapter = CapabilityAdapter(
+        capability=Capability.SEARCH,
+        plan=lambda *_: ProviderPlan(("serper",), "serper"),
+        execute=execute,
+        normalize=_response,
+    )
+    config = {"v3": {"cache_dir": str(tmp_path)}}
+
+    first = execute_v3_request(_request("first"), adapter, config)
+    second = execute_v3_request(_request("second"), adapter, config)
+
+    assert calls == ["provider"]
+    assert first.response.cache_status["disposition"] == "miss"
+    assert "cache_lookup" in first.stage_trace
+    assert "cache_write" in first.stage_trace
+    assert second.response.request_id == "second"
+    assert second.response.cache_status["disposition"] == "fresh_hit"
+    assert second.response.cache_status["source_contract_version"] == "3.0"
+    assert second.response.provider_attempts == []
+    assert second.legacy_payload["cached"] is True
+    assert "provider_attempt" not in second.stage_trace
+    assert "cache_write" not in second.stage_trace
+
+
+def test_cache_bypass_neither_reads_nor_writes(tmp_path):
+    calls = []
+    adapter = CapabilityAdapter(
+        capability=Capability.SEARCH,
+        plan=lambda *_: ProviderPlan(("serper",), "serper"),
+        execute=lambda *_: calls.append("provider") or {"provider": "serper", "results": []},
+        normalize=_response,
+    )
+    config = {"v3": {"cache_dir": str(tmp_path)}}
+
+    first = execute_v3_request(_request("one", bypass=True), adapter, config)
+    second = execute_v3_request(_request("two", bypass=True), adapter, config)
+
+    assert calls == ["provider", "provider"]
+    assert first.response.cache_status["disposition"] == "bypassed"
+    assert second.response.cache_status["disposition"] == "bypassed"
+    assert "cache_lookup" not in first.stage_trace
+    assert "cache_write" not in first.stage_trace
+    assert not (tmp_path / "v3" / "response").exists()
+
+
+def test_cache_only_miss_never_calls_provider(tmp_path):
+    calls = []
+    adapter = CapabilityAdapter(
+        capability=Capability.SEARCH,
+        plan=lambda *_: ProviderPlan(("serper",), "serper"),
+        execute=lambda *_: calls.append("provider") or {},
+        normalize=_response,
+    )
+    base = _request("only")
+    request = RequestV3.from_dict(
+        {**base.to_dict(), "cache": {**base.cache, "mode": "only"}}
+    )
+
+    execution = execute_v3_request(
+        request, adapter, {"v3": {"cache_dir": str(tmp_path)}}
+    )
+
+    assert calls == []
+    assert execution.response.status.value == "failed"
+    assert execution.response.error is not None
+    assert execution.response.error.code == "wsp.cache.miss"
+    assert execution.response.cache_status == {"disposition": "miss"}
+    assert "provider_attempt" not in execution.stage_trace

--- a/tests/test_m3_cache_v3.py
+++ b/tests/test_m3_cache_v3.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import json
+
+from cache_v3 import ResponseCacheV3, derive_cache_key
+from compat_v3 import legacy_request_to_v3
+from contract_v3 import Capability, RequestV3
+
+
+def _request(*, request_id: str, reordered: bool = False) -> RequestV3:
+    request = legacy_request_to_v3(
+        Capability.SEARCH,
+        {
+            "query": "Café models",
+            "provider": "serper",
+            "count": 3,
+            "include_domains": ["example.com"],
+        },
+        request_id=request_id,
+    )
+    if not reordered:
+        return request
+    payload = request.to_dict()
+    payload["options"] = dict(reversed(list(payload["options"].items())))
+    payload["routing"] = dict(reversed(list(payload["routing"].items())))
+    return RequestV3.from_dict(payload)
+
+
+def _response_payload(request_id: str = "stored-id") -> dict:
+    return {
+        "contract_version": "3.0",
+        "request_id": request_id,
+        "capability": "search",
+        "status": "ok",
+        "results": [],
+        "provider_attempts": [],
+        "routing_receipt": {
+            "policy_id": "classic",
+            "policy_revision": "v2.9.1",
+            "mode": "classic",
+            "candidate_order": ["serper"],
+            "selected_provider": "serper",
+            "fallback_reason": "none",
+        },
+        "cache_status": {"disposition": "miss"},
+        "limits_applied": {"max_results": 3},
+        "dedup_clusters": [],
+        "warnings": [],
+    }
+
+
+def test_cache_key_is_deterministic_without_request_id_or_dict_order():
+    first = derive_cache_key(_request(request_id="one"))
+    second = derive_cache_key(_request(request_id="two", reordered=True))
+
+    assert first == second
+    assert first.startswith("search_")
+    assert "one" not in first
+    assert "two" not in first
+
+
+def test_v3_cache_write_and_fresh_stale_lookup_are_namespaced(tmp_path):
+    cache = ResponseCacheV3(tmp_path)
+    request = _request(request_id="current")
+
+    entry_id = cache.put(request, _response_payload(), now=100)
+    fresh = cache.get(request, ttl_seconds=20, allow_stale_seconds=40, now=110)
+    stale = cache.get(request, ttl_seconds=20, allow_stale_seconds=40, now=130)
+    expired = cache.get(request, ttl_seconds=20, allow_stale_seconds=40, now=161)
+
+    assert fresh.disposition == "fresh_hit"
+    assert fresh.payload["request_id"] == "stored-id"
+    assert fresh.age_seconds == 10
+    assert stale.disposition == "stale_hit"
+    assert stale.age_seconds == 30
+    assert expired.disposition == "miss"
+    path = tmp_path / "v3" / "response" / "search" / f"{entry_id}.json"
+    envelope = json.loads(path.read_text()) if path.exists() else None
+    # Expired owned entries may be removed; fresh/stale reads above prove the path.
+    assert envelope is None or envelope["contract_version"] == "3.0"
+
+
+def test_v3_clear_and_stats_never_touch_legacy_or_foreign_files(tmp_path):
+    cache = ResponseCacheV3(tmp_path)
+    request = _request(request_id="current")
+    cache.put(request, _response_payload(), now=100)
+    legacy = tmp_path / "legacy-v2.json"
+    legacy.write_text('{"_cache_timestamp": 100}\n')
+    foreign = tmp_path / "v3" / "response" / "foreign.json"
+    foreign.parent.mkdir(parents=True, exist_ok=True)
+    foreign.write_text('{"owner": "someone-else"}\n')
+
+    before = cache.stats()
+    cleared = cache.clear()
+    after = cache.stats()
+
+    assert before["entries"] == 1
+    assert cleared == 1
+    assert after["entries"] == 0
+    assert legacy.exists()
+    assert foreign.exists()
+
+
+def test_corrupt_or_foreign_v3_entry_is_a_miss_and_not_deleted(tmp_path):
+    cache = ResponseCacheV3(tmp_path)
+    request = _request(request_id="current")
+    path = cache.path_for(request)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"owner": "someone-else", "broken": true}\n')
+
+    lookup = cache.get(request, ttl_seconds=20, allow_stale_seconds=0, now=110)
+
+    assert lookup.disposition == "miss"
+    assert path.exists()

--- a/tests/test_m3_independence_v3.py
+++ b/tests/test_m3_independence_v3.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from independence_v3 import analyze_source_independence
+
+
+def _result(result_id, url, title, snippet=None, provider="serper"):
+    value = {
+        "result_id": result_id,
+        "url": url,
+        "canonical_url": url,
+        "title": title,
+        "status": "ok",
+        "provenance": [
+            {
+                "provider": provider,
+                "source_url": url,
+                "retrieved_at": "2026-07-12T00:00:00Z",
+            }
+        ],
+    }
+    if snippet is not None:
+        value["snippet"] = snippet
+    return value
+
+
+def _cluster_members(clusters):
+    return sorted(sorted(item["member_result_ids"]) for item in clusters)
+
+
+def test_canonical_url_variants_form_one_cluster():
+    results = [
+        _result("a", "HTTPS://Example.COM:443/story?utm_source=x#part", "Story"),
+        _result("b", "https://example.com/story", "Story copy", provider="brave"),
+    ]
+
+    clusters, estimate = analyze_source_independence(results)
+
+    assert _cluster_members(clusters) == [["a", "b"]]
+    assert clusters[0]["providers"] == ["brave", "serper"]
+    assert estimate["unique_cluster_count"] == 1
+    assert estimate["result_count"] == 2
+
+
+def test_deterministic_minhash_union_find_groups_near_duplicate_text():
+    shared = (
+        "Web Search Plus version three introduces deterministic provider routing "
+        "with durable circuit state and strict privacy safe receipts"
+    )
+    results = [
+        _result("a", "https://alpha.example/news", "Release notes", shared),
+        _result(
+            "b",
+            "https://beta.example/article",
+            "Release notes mirror",
+            shared + " today",
+            provider="brave",
+        ),
+        _result(
+            "c",
+            "https://gamma.example/other",
+            "Football scores",
+            "The home team won three nil after a late second half goal",
+        ),
+    ]
+
+    forward = analyze_source_independence(results)
+    reverse = analyze_source_independence(list(reversed(results)))
+
+    assert _cluster_members(forward[0]) == [["a", "b"], ["c"]]
+    assert forward == reverse
+    assert forward[1]["method"] == "url+snippet-minhash-v1"
+    assert forward[1]["method_degraded"] is False
+
+
+def test_url_only_estimate_is_real_but_explicitly_degraded():
+    clusters, estimate = analyze_source_independence(
+        [_result("a", "https://one.example/a", "", None)]
+    )
+
+    assert len(clusters) == 1
+    assert estimate["method"] == "url-v1"
+    assert estimate["method_degraded"] is True
+    assert estimate["confidence"] == "low"
+    assert analyze_source_independence([]) == ([], None)

--- a/tests/test_m3_legacy_cache.py
+++ b/tests/test_m3_legacy_cache.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import cache
+import search
+from compat_v3 import legacy_request_to_v3
+from contract_v3 import Capability
+
+
+def test_v2_search_cache_is_read_only_legacy_hit_and_promotes_to_v3(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setattr(cache, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(search, "CACHE_DIR", tmp_path)
+    config = {
+        "version": 1,
+        "auto_routing": {
+            "enabled": True,
+            "provider_priority": ["serper"],
+            "disabled_providers": [],
+        },
+        "v3": {
+            "cache_dir": str(tmp_path),
+            "state_path": str(tmp_path / "v3" / "state.sqlite3"),
+        },
+    }
+    request = legacy_request_to_v3(
+        Capability.SEARCH,
+        {"query": "legacy cache", "provider": "serper", "count": 2},
+        request_id="current-id",
+    )
+    request = type(request).from_dict(
+        {**request.to_dict(), "cache": {**request.cache, "mode": "only"}}
+    )
+    args = search._search_args_from_v3(request, config)
+    args.provider = "serper"
+    params = search._legacy_search_cache_context(args, "serper", config)
+    legacy_payload = {
+        "provider": "serper",
+        "query": "legacy cache",
+        "results": [
+            {
+                "title": "Cached",
+                "url": "https://example.com/cached",
+                "snippet": "from v2",
+            }
+        ],
+    }
+    cache.cache_put(
+        "legacy cache", "serper", 2, legacy_payload, params=params
+    )
+    v2_path = cache._get_cache_path(
+        cache._get_cache_key("legacy cache", "serper", 2, params)
+    )
+    before = v2_path.read_bytes()
+
+    monkeypatch.setattr(
+        search,
+        "_execute_search_request_core",
+        lambda *_: (_ for _ in ()).throw(AssertionError("provider called")),
+    )
+    execution = search.execute_v3_request(request, search._search_adapter(), config)
+
+    assert execution.response.cache_status["disposition"] == "fresh_hit"
+    assert execution.response.cache_status["source_contract_version"] == "2.x"
+    assert execution.response.provider_attempts == []
+    assert execution.legacy_payload["results"] == legacy_payload["results"]
+    assert v2_path.read_bytes() == before
+    assert list((tmp_path / "v3" / "response" / "search").glob("*.json"))

--- a/tests/test_orchestrator_v3.py
+++ b/tests/test_orchestrator_v3.py
@@ -208,14 +208,23 @@ def test_b6_same_request_has_same_plan_and_one_execution_path():
         legacy_execution.response.routing_receipt
         == native_execution.response.routing_receipt
     )
-    assert calls == {"plan": 2, "execute": 2, "normalize": 2}
-    assert legacy_execution.stage_trace == native_execution.stage_trace
+    assert calls == {"plan": 2, "execute": 1, "normalize": 1}
+    assert native_execution.response.cache_status["disposition"] == "fresh_hit"
     assert legacy_execution.stage_trace == (
         "normalize",
         "validate",
+        "cache_lookup",
         "candidate_plan",
         "provider_attempt",
         "result_normalization",
+        "cache_write",
+        "response_v3",
+    )
+    assert native_execution.stage_trace == (
+        "normalize",
+        "validate",
+        "cache_lookup",
+        "candidate_plan",
         "response_v3",
     )
 
@@ -251,11 +260,13 @@ def test_orchestrator_uses_actual_attempt_receipts_and_stages():
     assert execution.stage_trace == (
         "normalize",
         "validate",
+        "cache_lookup",
         "candidate_plan",
         "admission",
         "provider_attempt",
         "retry_circuit_update",
         "result_normalization",
+        "cache_write",
         "response_v3",
     )
 

--- a/tests/test_orchestrator_v3.py
+++ b/tests/test_orchestrator_v3.py
@@ -7,8 +7,17 @@ from compat_v3 import (
     v3_response_to_legacy_extract,
     v3_response_to_legacy_search,
 )
-from contract_v3 import Capability, RequestV3, ResponseStatus, ResponseV3
+from contract_v3 import (
+    AttemptOutcome,
+    Capability,
+    CircuitState,
+    ProviderAttemptV3,
+    RequestV3,
+    ResponseStatus,
+    ResponseV3,
+)
 from orchestrator_v3 import (
+    CapabilityExecution,
     CapabilityAdapter,
     ExecutedV3,
     ProviderPlan,
@@ -204,16 +213,49 @@ def test_b6_same_request_has_same_plan_and_one_execution_path():
     assert legacy_execution.stage_trace == (
         "normalize",
         "validate",
-        "cache_lookup",
+        "candidate_plan",
+        "provider_attempt",
+        "result_normalization",
+        "response_v3",
+    )
+
+
+def test_orchestrator_uses_actual_attempt_receipts_and_stages():
+    request = legacy_request_to_v3(
+        "search", {"query": "q", "provider": "serper"}, request_id="req-1"
+    )
+    plan = ProviderPlan(("serper",), "serper")
+    receipt = ProviderAttemptV3(
+        attempt_id="attempt-1",
+        provider="serper",
+        capability=Capability.SEARCH,
+        outcome=AttemptOutcome.SUCCESS,
+        result_count=1,
+        circuit_state_before=CircuitState.CLOSED,
+        circuit_state_after=CircuitState.CLOSED,
+    )
+    adapter = CapabilityAdapter(
+        capability=Capability.SEARCH,
+        plan=lambda *_: plan,
+        execute=lambda *_: CapabilityExecution(
+            payload={"provider": "serper", "results": []},
+            provider_attempts=(receipt,),
+            stages=("admission", "provider_attempt", "retry_circuit_update"),
+        ),
+        normalize=_response,
+    )
+
+    execution = execute_v3_request(request, adapter, {})
+
+    assert execution.response.provider_attempts == [receipt]
+    assert execution.stage_trace == (
+        "normalize",
+        "validate",
         "candidate_plan",
         "admission",
         "provider_attempt",
-        "error_classification",
         "retry_circuit_update",
-        "fallback",
         "result_normalization",
-        "dedup_fingerprint",
-        "cache_write",
         "response_v3",
     )
 

--- a/tests/test_v3_entrypoints.py
+++ b/tests/test_v3_entrypoints.py
@@ -215,12 +215,14 @@ def test_search_adapter_emits_engine_attempt_receipt(tmp_path, monkeypatch):
     assert execution.stage_trace == (
         "normalize",
         "validate",
+        "cache_lookup",
         "candidate_plan",
         "admission",
         "provider_attempt",
         "retry_circuit_update",
         "result_normalization",
         "dedup_fingerprint",
+        "cache_write",
         "response_v3",
     )
 
@@ -303,7 +305,8 @@ def test_b6_engine_adapter_plan_is_identical_for_legacy_and_native(monkeypatch):
         legacy_execution.response.routing_receipt
         == native_execution.response.routing_receipt
     )
-    assert calls == [("same", "serper"), ("same", "serper")]
+    assert calls == [("same", "serper")]
+    assert native_execution.response.cache_status["disposition"] == "fresh_hit"
 
 
 def test_search_legacy_and_native_use_same_v3_entry_and_one_core_call(monkeypatch):
@@ -336,7 +339,8 @@ def test_search_legacy_and_native_use_same_v3_entry_and_one_core_call(monkeypatc
     jsonschema.validate(
         native.to_dict(), RESPONSE_SCHEMA, format_checker=jsonschema.FormatChecker()
     )
-    assert len(calls) == 2
+    assert len(calls) == 1
+    assert native.cache_status["disposition"] == "fresh_hit"
 
 
 def test_extract_legacy_and_native_use_same_v3_entry_and_one_core_call(monkeypatch):
@@ -368,4 +372,5 @@ def test_extract_legacy_and_native_use_same_v3_entry_and_one_core_call(monkeypat
     jsonschema.validate(
         native.to_dict(), RESPONSE_SCHEMA, format_checker=jsonschema.FormatChecker()
     )
-    assert len(calls) == 2
+    assert len(calls) == 1
+    assert native.cache_status["disposition"] == "fresh_hit"

--- a/tests/test_v3_entrypoints.py
+++ b/tests/test_v3_entrypoints.py
@@ -3,9 +3,11 @@ from pathlib import Path
 from unittest import mock
 
 import jsonschema
+import pytest
 import search
 from compat_v3 import legacy_request_to_v3
 from contract_v3 import Capability, ResponseV3
+from http_client import ProviderRequestError
 
 
 CONFIG = {
@@ -87,6 +89,191 @@ def test_v3_execution_can_read_but_never_writes_legacy_cache(monkeypatch):
 
     assert result["results"]
     cache_put.assert_not_called()
+
+
+def test_engine_owned_provider_call_bypasses_all_legacy_retry_and_health(monkeypatch):
+    dummy_key = "test-key-123456789012345678901234"
+    config = {**CONFIG, "you": {"api_key": dummy_key}}
+    request = legacy_request_to_v3(
+        Capability.SEARCH,
+        {"query": "q", "provider": "you", "count": 1},
+        request_id="engine-owned",
+    )
+    args = search._search_args_from_v3(request, config)
+    args.no_cache = True
+    args._v3_engine_owned_attempt = True
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("legacy health/retry seam was called")
+
+    monkeypatch.setattr(search, "provider_in_cooldown", forbidden)
+    monkeypatch.setattr(search, "execute_provider_with_retry", forbidden)
+    monkeypatch.setattr(search, "mark_provider_failure", forbidden)
+    monkeypatch.setattr(search, "reset_provider_health", forbidden)
+    monkeypatch.setattr(search, "record_provider_outcome", forbidden)
+    monkeypatch.setattr(
+        search,
+        "search_you",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ProviderRequestError("upstream", status_code=503, transient=True)
+        ),
+    )
+
+    with pytest.raises(ProviderRequestError):
+        search._execute_search_request_core(args, config)
+
+
+def test_engine_owned_extract_call_bypasses_legacy_retry_and_health(monkeypatch):
+    config = {
+        "linkup": {"api_key": "linkup-test-key-123456789012345678"},
+        "extract": {"allow_private_urls": True},
+    }
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("legacy extract health/retry seam was called")
+
+    monkeypatch.setattr(search._extract, "provider_in_cooldown", forbidden)
+    monkeypatch.setattr(search._extract, "execute_provider_with_retry", forbidden)
+    monkeypatch.setattr(search._extract, "mark_provider_failure", forbidden)
+    monkeypatch.setattr(search._extract, "reset_provider_health", forbidden)
+    monkeypatch.setattr(
+        search._extract,
+        "extract_linkup",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            ProviderRequestError("upstream", status_code=503, transient=True)
+        ),
+    )
+
+    with pytest.raises(ProviderRequestError):
+        search._extract._extract_plus_core(
+            ["https://example.com/a"],
+            provider="linkup",
+            config=config,
+            engine_owned_attempt=True,
+        )
+
+
+def test_extract_adapter_emits_engine_attempt_receipt(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_core(**kwargs):
+        calls.append((kwargs["provider"], kwargs["engine_owned_attempt"]))
+        return _extract_payload()
+
+    monkeypatch.setattr(search._extract, "_extract_plus_core", fake_core)
+    config = {
+        "version": 1,
+        "linkup": {"api_key": "linkup-test-key-123456789012345678"},
+        "extract": {"allow_private_urls": True},
+        "v3": {"state_path": str(tmp_path / "state.sqlite3")},
+    }
+    request = legacy_request_to_v3(
+        Capability.EXTRACT,
+        {"urls": ["https://example.com/a"], "provider": "linkup"},
+        request_id="extract-attempt",
+    )
+
+    execution = search.execute_v3_request(
+        request, search._extract._extract_adapter(), config
+    )
+
+    assert calls == [("linkup", True)]
+    assert len(execution.response.provider_attempts) == 1
+    assert execution.response.provider_attempts[0].provider == "linkup"
+    assert execution.response.provider_attempts[0].outcome.value == "success"
+    assert "admission" in execution.stage_trace
+    assert "dedup_fingerprint" in execution.stage_trace
+
+
+def test_search_adapter_emits_engine_attempt_receipt(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_core(args, _config):
+        calls.append(
+            (args.provider, args.no_cache, args._v3_engine_owned_attempt)
+        )
+        return _search_payload(), 0
+
+    monkeypatch.setattr(search, "_execute_search_request_core", fake_core)
+    config = {
+        **CONFIG,
+        "serper": {"api_key": "test-key-123456789012345678901234"},
+        "v3": {"state_path": str(tmp_path / "state.sqlite3")},
+    }
+    request = legacy_request_to_v3(
+        Capability.SEARCH,
+        {"query": "q", "provider": "serper", "count": 1},
+        request_id="attempt-receipt",
+    )
+
+    execution = search.execute_v3_request(request, search._search_adapter(), config)
+
+    assert calls == [("serper", True, True)]
+    assert len(execution.response.provider_attempts) == 1
+    assert execution.response.provider_attempts[0].provider == "serper"
+    assert execution.response.provider_attempts[0].outcome.value == "success"
+    assert execution.stage_trace == (
+        "normalize",
+        "validate",
+        "candidate_plan",
+        "admission",
+        "provider_attempt",
+        "retry_circuit_update",
+        "result_normalization",
+        "dedup_fingerprint",
+        "response_v3",
+    )
+
+
+def test_search_engine_owns_typed_fallback_and_receipts(tmp_path, monkeypatch):
+    calls = []
+
+    def fake_core(args, _config):
+        calls.append(args.provider)
+        if args.provider == "serper":
+            raise ProviderRequestError("bad key", status_code=401)
+        payload = _search_payload()
+        payload["provider"] = "you"
+        return payload, 0
+
+    monkeypatch.setattr(search, "_execute_search_request_core", fake_core)
+    config = {
+        "version": 1,
+        "auto_routing": {
+            "enabled": True,
+            "provider_priority": ["serper", "you"],
+            "disabled_providers": [],
+        },
+        "serper": {"api_key": "serper-test-key-12345678901234567890"},
+        "you": {"api_key": "you-test-key-12345678901234567890123"},
+        "v3": {"state_path": str(tmp_path / "state.sqlite3")},
+    }
+    request = legacy_request_to_v3(
+        Capability.SEARCH,
+        {"query": "q", "provider": "serper", "count": 1},
+        request_id="typed-fallback",
+    )
+    request = type(request).from_dict(
+        {
+            **request.to_dict(),
+            "routing": {**request.routing, "allow_fallback": True},
+        }
+    )
+
+    execution = search.execute_v3_request(request, search._search_adapter(), config)
+
+    assert calls == ["serper", "you"]
+    assert [attempt.outcome.value for attempt in execution.response.provider_attempts] == [
+        "failed",
+        "success",
+    ]
+    assert execution.response.provider_attempts[0].error.error_class.value == "auth"
+    assert execution.legacy_payload["routing"]["fallback_used"] is True
+    assert execution.legacy_payload["routing"]["original_provider"] == "serper"
+    assert execution.legacy_payload["routing"]["provider"] == "you"
+    assert "error_classification" in execution.stage_trace
+    assert "fallback" in execution.stage_trace
+    assert "bad key" not in json.dumps(execution.response.to_dict())
 
 
 def test_b6_engine_adapter_plan_is_identical_for_legacy_and_native(monkeypatch):


### PR DESCRIPTION
## Summary

- Add the fail-closed v3 attempt/state engine and integrate it as the owner of provider attempts.
- Add the v3 response cache with explicit legacy-cache read compatibility and no legacy writes.
- Add deterministic source-independence clustering and cache/state integration tests.

## Guarantees

- Attempt lifecycle, cooldowns, circuit state, retries, and terminal outcomes are typed and persisted consistently.
- Cache keys are contract-aware; v3 execution never mutates the legacy cache.
- Legacy cache hits are projected through the canonical v3 runtime.
- Source-family and near-duplicate clustering is deterministic.
- Intermediate code remains compatible with the release branch's Python 3.8 CI floor.

## Review boundary

This is **slice 4 of the Web Search Plus 3.0 release train** and targets `release/v3.0.0`.

Included: attempt engine, state store, cache, independence analysis, canonical runtime integration, and focused tests.

Deferred: Amendment 002 evidence fields, bounded extraction context, receipts, Operator Console, migration, and release hardening.

## Validation

- Python 3.8: `542 passed`
- Python 3.11: `542 passed, 6 subtests passed`
- Ruff and compileall: passed
- Contract/provider/routing drift checks: passed
- `git diff --check`: passed
- Public privacy/credential scan: passed

## Merge plan

Squash-merge into `release/v3.0.0`; subsequent slices extend this state/cache ownership model.
