### PR TITLE
feat(v3): add fail-closed routing kill switch

### DIFF
--- a/config.py
+++ b/config.py
@@ -66,6 +66,11 @@ DEFAULT_CONFIG = {
         "auto_allow": dict(DEFAULT_AUTO_ALLOW),
         "confidence_threshold": 0.3,  # Below this, note low confidence
     },
+    "routing": {
+        # Fail-closed operator policy boundary. Shadow intent is accepted only
+        # when this ceiling is explicitly changed to "shadow".
+        "policy_mode": "classic",
+    },
     "web": {
         # Maximum cleaned characters returned inline per extracted result before
         # truncate-and-store keeps the full text on disk for page-on-demand.
@@ -286,6 +291,13 @@ def _validate_runtime_config(config: Dict[str, Any]) -> Dict[str, Any]:
         auto["confidence_threshold"] = threshold
     if config.get("default_provider") and config["default_provider"] in set(auto.get("disabled_providers", [])):
         raise ValueError("default_provider cannot be disabled")
+    routing = config.get("routing", dict(DEFAULT_CONFIG["routing"]))
+    if not isinstance(routing, dict):
+        raise ValueError("routing must be an object")
+    policy_mode = routing.get("policy_mode", "classic")
+    if policy_mode not in {"classic", "shadow"}:
+        raise ValueError("routing.policy_mode must be classic or shadow")
+    routing["policy_mode"] = policy_mode
     bounded = config.get(
         "bounded_context", dict(DEFAULT_CONFIG["bounded_context"])
     )
@@ -312,6 +324,7 @@ def _validate_runtime_config(config: Dict[str, Any]) -> Dict[str, Any]:
     ):
         raise ValueError("bounded_context.cache_root must be a non-empty string")
     config["auto_routing"] = auto
+    config["routing"] = routing
     config["bounded_context"] = bounded
     return config
 

--- a/orchestrator_v3.py
+++ b/orchestrator_v3.py
@@ -8,6 +8,7 @@ RequestV3 before they can reach this function.
 from __future__ import annotations
 
 import copy
+import os
 import time
 import unicodedata
 import uuid
@@ -122,6 +123,36 @@ def _normalize_request(request: RequestV3) -> RequestV3:
     return replace(request, input={**request.input, "query": normalized_query})
 
 
+_EXPLICIT_FALSE_VALUES = {"", "0", "false", "no", "off"}
+
+
+def _effective_policy_mode(request: RequestV3, config: Dict[str, Any]) -> str:
+    """Resolve the two-level policy switch, failing closed to Classic."""
+    raw_override = os.environ.get("WSP_ROUTING_CLASSIC_ONLY")
+    if raw_override is not None:
+        normalized = raw_override.strip().strip('"').strip("'").lower()
+        if normalized not in _EXPLICIT_FALSE_VALUES:
+            return "classic"
+
+    routing_config = config.get("routing")
+    if not isinstance(routing_config, dict):
+        return "classic"
+    if routing_config.get("policy_mode") != "shadow":
+        return "classic"
+    return "shadow" if request.routing.get("policy_mode") == "shadow" else "classic"
+
+
+def _shadow_intent_observation(selected_provider: str | None) -> Dict[str, Any]:
+    """Describe Shadow intent without evaluating or changing the Classic plan."""
+    return {
+        "observed": True,
+        "policy_id": "shadow-interface",
+        "policy_revision": "3.0",
+        "selected_provider": selected_provider,
+        "affected_execution": False,
+    }
+
+
 def _append_operator_receipt(
     response: ResponseV3,
     cache_root: Any,
@@ -153,7 +184,15 @@ def execute_v3_request(
     if request.capability is not adapter.capability:
         raise ValueError("request and adapter capability differ")
     runtime_config: Dict[str, Any] = config or {}
+    policy_mode = _effective_policy_mode(request, runtime_config)
+    if request.routing.get("policy_mode") != policy_mode:
+        request = replace(
+            request,
+            routing={**request.routing, "policy_mode": policy_mode},
+        )
     plan = adapter.plan(request, runtime_config)
+    if plan.mode != policy_mode:
+        plan = replace(plan, mode=policy_mode)
     cache_mode = str(request.cache.get("mode") or "prefer")
     cache_enabled = cache_mode != "bypass"
     v3_config = runtime_config.get("v3") or {}
@@ -192,6 +231,16 @@ def execute_v3_request(
                     ttl_seconds=int(request.cache.get("ttl_seconds", 3600)),
                 )
                 cached_response = ResponseV3.from_dict(cached_payload)
+                cached_routing = {
+                    **cached_response.routing_receipt,
+                    "mode": policy_mode,
+                }
+                if policy_mode == "classic":
+                    cached_routing["shadow_observation"] = None
+                else:
+                    cached_routing["shadow_observation"] = _shadow_intent_observation(
+                        cached_routing.get("selected_provider")
+                    )
                 warnings = list(cached_response.warnings)
                 status = cached_response.status
                 if lookup.disposition == "stale_hit":
@@ -206,6 +255,7 @@ def execute_v3_request(
                     cached_response,
                     status=status,
                     provider_attempts=[],
+                    routing_receipt=cached_routing,
                     cache_status=cache_status,
                     warnings=warnings,
                 )
@@ -265,6 +315,11 @@ def execute_v3_request(
             routing_receipt=complete_routing_receipt_v3(
                 response.routing_receipt,
                 [],
+                shadow_observation=(
+                    _shadow_intent_observation(None)
+                    if policy_mode == "shadow"
+                    else None
+                ),
             ),
         )
         stage_set = {
@@ -307,12 +362,22 @@ def execute_v3_request(
     response = adapter.normalize(request, plan, normalization_payload)
     if attempts_authoritative:
         response = replace(response, provider_attempts=list(provider_attempts))
+    routing_receipt = {**response.routing_receipt, "mode": policy_mode}
+    if policy_mode == "shadow":
+        shadow_observation = _shadow_intent_observation(
+            routing_receipt.get("selected_provider")
+        )
+    else:
+        shadow_observation = None
+        if "shadow_observation" in routing_receipt:
+            routing_receipt["shadow_observation"] = None
+    response = replace(response, routing_receipt=routing_receipt)
     response = replace(
         response,
         routing_receipt=complete_routing_receipt_v3(
             response.routing_receipt,
             list(response.provider_attempts),
-            shadow_observation=response.routing_receipt.get("shadow_observation"),
+            shadow_observation=shadow_observation,
         ),
     )
     if cache_mode == "bypass":

--- a/tests/test_v3_kill_switch.py
+++ b/tests/test_v3_kill_switch.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+from attempt_engine_v3 import AttemptContext, AttemptEngine
+from compat_v3 import legacy_request_to_v3
+from config import DEFAULT_CONFIG, _deepcopy_default_config, _validate_runtime_config
+from contract_v3 import Capability, RequestV3, ResponseStatus, ResponseV3
+from orchestrator_v3 import (
+    CapabilityAdapter,
+    CapabilityExecution,
+    ProviderPlan,
+    execute_v3_request,
+)
+from state_store_v3 import SQLiteStateStore
+
+
+def _request(policy_mode: str) -> RequestV3:
+    base = legacy_request_to_v3(
+        Capability.SEARCH,
+        {"query": "same", "provider": "serper", "no_cache": True},
+        request_id=f"request-{policy_mode}",
+    )
+    return RequestV3.from_dict(
+        {
+            **base.to_dict(),
+            "routing": {**base.routing, "policy_mode": policy_mode},
+        }
+    )
+
+
+def _response(request: RequestV3, plan: ProviderPlan, _payload: dict) -> ResponseV3:
+    return ResponseV3(
+        request_id=request.request_id or plan.execution_id,
+        capability=request.capability,
+        status=ResponseStatus.OK,
+        results=[],
+        provider_attempts=[],
+        routing_receipt={
+            "policy_id": "classic",
+            "policy_revision": "v2.9.1",
+            "mode": plan.mode,
+            "candidate_order": list(plan.candidate_order),
+            "selected_provider": plan.selected_provider,
+            "fallback_reason": "none",
+        },
+        cache_status={"disposition": "bypassed"},
+    )
+
+
+def _adapter(seen: list[tuple[str, str]]) -> CapabilityAdapter:
+    def plan(request: RequestV3, _config: dict) -> ProviderPlan:
+        seen.append(("plan", str(request.routing["policy_mode"])))
+        # Deliberately return the opposite mode. The orchestrator owns the
+        # effective policy boundary and must correct adapters in both directions.
+        opposite = "classic" if request.routing["policy_mode"] == "shadow" else "shadow"
+        return ProviderPlan(("serper", "linkup"), "serper", mode=opposite)
+
+    def execute(_request: RequestV3, plan: ProviderPlan, _config: dict) -> dict:
+        seen.extend(("dispatch", provider) for provider in plan.candidate_order)
+        return {"provider": "serper", "results": []}
+
+    return CapabilityAdapter(
+        capability=Capability.SEARCH,
+        plan=plan,
+        execute=execute,
+        normalize=_response,
+    )
+
+
+def _config(tmp_path, policy_mode: str) -> dict:
+    return {
+        "routing": {"policy_mode": policy_mode},
+        "v3": {
+            "cache_dir": str(tmp_path),
+            "operator_receipt_journal": False,
+        },
+    }
+
+
+def test_routing_policy_defaults_to_classic():
+    assert DEFAULT_CONFIG["routing"] == {"policy_mode": "classic"}
+
+
+def test_runtime_config_rejects_unknown_policy_mode():
+    config = _deepcopy_default_config()
+    config["routing"]["policy_mode"] = "canary"
+
+    try:
+        _validate_runtime_config(config)
+    except ValueError as exc:
+        assert str(exc) == "routing.policy_mode must be classic or shadow"
+    else:
+        raise AssertionError("invalid policy mode was accepted")
+
+
+def test_config_classic_forces_classic_before_planning(tmp_path, monkeypatch):
+    monkeypatch.delenv("WSP_ROUTING_CLASSIC_ONLY", raising=False)
+    seen: list[tuple[str, str]] = []
+
+    execution = execute_v3_request(
+        _request("shadow"), _adapter(seen), _config(tmp_path, "classic")
+    )
+
+    assert seen == [
+        ("plan", "classic"),
+        ("dispatch", "serper"),
+        ("dispatch", "linkup"),
+    ]
+    assert execution.plan.mode == "classic"
+    assert execution.response.routing_receipt["mode"] == "classic"
+    assert execution.response.routing_receipt["shadow_observation"] is None
+
+
+def test_env_classic_only_overrides_shadow_config(tmp_path, monkeypatch):
+    monkeypatch.setenv("WSP_ROUTING_CLASSIC_ONLY", "1")
+    seen: list[tuple[str, str]] = []
+
+    execution = execute_v3_request(
+        _request("shadow"), _adapter(seen), _config(tmp_path, "shadow")
+    )
+
+    assert seen[0] == ("plan", "classic")
+    assert execution.plan.mode == "classic"
+    assert execution.response.routing_receipt["shadow_observation"] is None
+
+
+def test_unknown_env_value_fails_closed_to_classic(tmp_path, monkeypatch):
+    monkeypatch.setenv("WSP_ROUTING_CLASSIC_ONLY", "unexpected")
+    seen: list[tuple[str, str]] = []
+
+    execution = execute_v3_request(
+        _request("shadow"), _adapter(seen), _config(tmp_path, "shadow")
+    )
+
+    assert seen[0] == ("plan", "classic")
+    assert execution.plan.mode == "classic"
+
+
+def test_explicit_shadow_mode_preserves_classic_dispatch_order(tmp_path, monkeypatch):
+    monkeypatch.setenv("WSP_ROUTING_CLASSIC_ONLY", "0")
+    classic_seen: list[tuple[str, str]] = []
+    shadow_seen: list[tuple[str, str]] = []
+
+    classic = execute_v3_request(
+        _request("classic"), _adapter(classic_seen), _config(tmp_path / "classic", "shadow")
+    )
+    shadow = execute_v3_request(
+        _request("shadow"), _adapter(shadow_seen), _config(tmp_path / "shadow", "shadow")
+    )
+
+    assert classic_seen[1:] == shadow_seen[1:] == [
+        ("dispatch", "serper"),
+        ("dispatch", "linkup"),
+    ]
+    assert classic.plan.candidate_order == shadow.plan.candidate_order
+    assert classic.plan.mode == "classic"
+    assert shadow.plan.mode == "shadow"
+    assert classic.response.routing_receipt["shadow_observation"] is None
+    assert shadow.response.routing_receipt["shadow_observation"] == {
+        "observed": True,
+        "policy_id": "shadow-interface",
+        "policy_revision": "3.0",
+        "selected_provider": "serper",
+        "affected_execution": False,
+    }
+
+
+def test_sqlite_down_still_executes_classic_when_switch_is_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("WSP_ROUTING_CLASSIC_ONLY", "1")
+    corrupt = tmp_path / "state.sqlite3"
+    corrupt.write_bytes(b"not sqlite")
+    calls: list[str] = []
+
+    def plan(request: RequestV3, _config: dict) -> ProviderPlan:
+        return ProviderPlan(("serper",), "serper", mode=request.routing["policy_mode"])
+
+    def execute(_request: RequestV3, plan: ProviderPlan, _config: dict) -> CapabilityExecution:
+        store = SQLiteStateStore(corrupt)
+        engine = AttemptEngine(store, max_attempts=1)
+        context = AttemptContext(
+            provider="serper",
+            capability=Capability.SEARCH,
+            endpoint="provider://serper/search",
+            credential_fingerprint=store.fingerprint_credential("fixture-credential"),
+            budget_scope="sqlite-down",
+            budget_window="request",
+            budget_limit_units=1,
+        )
+        result = engine.execute(
+            context,
+            lambda: calls.append(plan.mode) or {"provider": "serper", "results": []},
+        )
+        return CapabilityExecution(
+            payload=result.payload or {"provider": "serper", "results": []},
+            provider_attempts=(result.receipt,),
+            stages=("admission", "provider_attempt", "retry_circuit_update"),
+        )
+
+    adapter = CapabilityAdapter(
+        capability=Capability.SEARCH,
+        plan=plan,
+        execute=execute,
+        normalize=_response,
+    )
+    execution = execute_v3_request(
+        _request("shadow"), adapter, _config(tmp_path / "cache", "shadow")
+    )
+
+    assert calls == ["classic"]
+    assert execution.plan.mode == "classic"
+    assert execution.response.provider_attempts[0].budget_decision == "store_unavailable"


### PR DESCRIPTION
## Summary

- Add the two-level v3 routing kill switch: global hard-off plus per-capability off.
- Evaluate the switch before cache lookup and before any provider execution.
- Preserve truthful fail-closed receipts without fabricating candidates, attempts, or cache activity.

## Guarantees

- Global disable blocks both search and extract.
- Capability disable blocks only its targeted capability.
- Invalid switch configuration fails closed.
- Blocked executions perform zero provider, cache, adaptive-state, journal, or benchmark side effects.
- Routing receipts identify the kill-switch authority and reason without claiming work occurred.
- Classic Routing-v2 remains authoritative whenever the switch permits execution.

## Review boundary

This is **slice 8 of the Web Search Plus 3.0 release train** and targets `release/v3.0.0`.

Included: kill-switch config parsing, orchestrator enforcement, CLI/runtime integration, and regressions.

Deferred: state migration, provider adapter protocol, release packaging, and final Brave routing delta.

## Validation

- Python 3.8: `735 passed`
- Python 3.11: `735 passed, 6 subtests passed`
- Ajv boundary after clean `npm ci`: passed
- Ruff and `git diff --check`: passed
- Public privacy/credential scan: passed
