### PR TITLE
docs: simplify README and clarify Web Search Plus 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
 - The Operator Console default state path now matches the engine's `v3/state.sqlite3` layout.
 - Brave Search is promoted to the default Routing v2 auto-pool for independent-index source diversity; its free-tier quota and rate limits use the same existing provider cooldown and fallback handling as the other free-tier auto providers.
 
+### 🎯 What 3.0 improves in practice
+- Every result is easier to audit: typed provenance connects it to the underlying source observation, while provider attempts, retries, skips, and cache origin remain visible.
+- Long pages no longer need to flood agent context: extraction returns a bounded preview and keeps the full cleaned text available on demand.
+- Provider failures become legible: missing credentials, rate limits, timeouts, empty results, and unapplied filters are represented explicitly instead of disappearing into silent gaps.
+- Upgrades are safer to try: state migration starts with a dry run, backs up existing state before writing, and supports digest-verified rollback.
+- Routing gains independent-index diversity without a surprise policy switch: Classic Routing v2 remains authoritative while Brave joins the default auto-pool.
+- Operators gain local, read-only visibility into routing receipts, provider readiness, cache state, and applied limits without triggering provider calls or configuration writes.
+
 ### ✨ Added before 3.0, carried forward
 - Added independent `auto_routing.extract_provider_priority` configuration for `web_extract_plus(provider="auto")`, with `setup.py config set-extract-priority ...`. The existing Tavily-first registry order remains the public default; partial lists append missing extract-capable providers, and search `provider_priority` remains independent.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# web-search-plus — Hermes Plugin
-
+# Web Search Plus — Hermes Plugin
 
 <p align="center">
   <img src="docs/assets/web-search-plus-v3-hero.jpg" alt="Web Search Plus: source-only web intelligence for agents with provider-independent search, extraction, routing, and evidence receipts" width="100%">
@@ -11,103 +10,61 @@
   <img alt="Hermes Plugin" src="https://img.shields.io/badge/Hermes-plugin-a78bfa.svg">
 </p>
 
-**Web Search Plus is the operator-grade, source-only web layer for Hermes: one search tool, one extraction tool, 12 search providers, 8 extraction providers, conservative routing, provenance receipts, safe large-page handling, and provider benchmarking without locking you into a single API.** `web_extract_plus(provider="auto")` defaults to Tavily-first extraction, while the v3 evidence spine records provider attempts, source observations, cache origin, policy actions, and applied limits without adding an answer-synthesis layer.
+**Web Search Plus is the source-only web layer for Hermes: one search tool, one extraction tool, and a provider mesh with conservative routing and honest execution metadata.** It searches and extracts across the providers you configure, without locking you into a single API or adding an answer-synthesis layer. Web Search Plus gathers and structures sources; it does not synthesize or verify truth.
 
-`web-search-plus` adds two Hermes tools:
+It adds two Hermes tools:
 
-- `web_search_plus` — routed multi-provider web search with quality diagnostics
-- `web_extract_plus` — clean URL extraction via provider backends
+- `web_search_plus` — routed multi-provider search with quality diagnostics
+- `web_extract_plus` — clean URL extraction through provider backends
 
 > Ported from [web-search-plus-plugin](https://github.com/robbyczgw-cla/web-search-plus-plugin) for the [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin API.
 
 ---
 
-## Why this exists
+## What 3.0 improves
 
-Most web-search tools fail in one of two boring ways: they hard-code a single provider, or they pretend every user has every API key. Web Search Plus is capability-based instead: it lets Hermes search, extract, compare, and recover across the providers you actually configured.
+3.0 keeps the same two public tools and call style, but makes the evidence underneath them far more transparent and robust.
 
-- **No global required key.** Configure one search-capable provider and search works; extraction providers are additive.
-- **Routing v2 is conservative.** You.com, Serper, Exa, Firecrawl, Tavily, Linkup, and Brave form the default auto-search pool; everything else stays explicit/guarded until you opt in.
-- **Large pages stay usable.** Long extracts return a compact head/tail preview plus a `read_file` footer for the full cleaned text, instead of dumping token bombs into the agent context.
-- **Freshness, verticals, and locale are explicit.** `day`/`week`/`month`/`year` recency, `search_type="news"`, and `country`/`language` defaults with query-language auto-detection — providers that cannot apply a filter report that in metadata instead of silently dropping it.
-- **Provider quality is measurable.** The built-in bench compares configured search providers on success rate, latency, result volume, and snippet coverage, then suggests a search-provider priority order without writing config automatically.
-- **Costs and safety stay bounded.** Research mode caps provider work and keeps partial results, failed providers go on cooldown, and extraction rejects private/internal target URLs before provider dispatch.
+- **Source-only by construction.** Search and extraction stay separate from answer synthesis, claim generation, and truth verification. Provider endpoints without a verified source-only mode are rejected rather than quietly reshaped.
+- **Traceable provenance.** Results point back to source observations, with typed records of providers tried, retried, skipped, failed, or served from cache.
+- **Bounded extraction context.** Long pages return a useful preview while keeping the full cleaned text available on demand instead of flooding the agent context.
+- **Conservative, explainable routing.** Classic Routing v2 remains authoritative, tie-breaking stays deterministic, and Brave joins the default auto-pool for independent-index diversity.
+- **Honest failures.** Typed errors and response metadata expose missing credentials, rate limits, timeouts, empty results, and filters a provider could not apply.
+- **Reversible upgrades.** State migration starts with a dry run, creates verified backups before writing, and supports rollback.
+- **Local operational visibility.** The read-only Operator Console shows routing receipts, provider readiness, cache state, and applied bounds without calling providers or changing configuration.
+
+Read the full [3.0 Release Notes](docs/RELEASE_NOTES_V3.md) for compatibility details and deliberate 3.1 deferrals.
 
 ---
 
 ## Quick Start
 
 ```bash
-# 1) Install and enable the Hermes plugin
+# 1) Install and enable the plugin
 hermes plugins install robbyczgw-cla/hermes-web-search-plus --enable
 
-# 2) Configure provider keys with the standalone setup wizard
+# 2) Inspect provider readiness and configure the providers you use
 python ~/.hermes/plugins/web-search-plus/setup.py status
-python ~/.hermes/plugins/web-search-plus/setup.py setup
+python ~/.hermes/plugins/web-search-plus/setup.py setup --preset starter
 
-# Bare setup prompts every supported provider; press Enter to skip what you do not have.
-# Fast starter preset if you want the short path:
-# python ~/.hermes/plugins/web-search-plus/setup.py setup --preset starter
-# YOU_API_KEY=...      # fast Routing v2 core provider
-# SERPER_API_KEY=...   # reliable Google-like fallback
-# LINKUP_API_KEY=...   # clean extraction
-
-# 3) Restart/reload Hermes so plugin tools are registered
+# 3) Reload Hermes so the tools are registered
 # CLI: exit and start `hermes` again, or use /reset in-session
-# Gateway/Telegram: /restart, then /reset
+# Gateway: /restart, then /reset
 
 # 4) Optional shell smoke test
 cd ~/.hermes/plugins/web-search-plus
 python3 search.py --query "Hermes Agent latest release" --provider auto --quality-report
 ```
 
-Notes:
+Add at least one search-capable provider for `web_search_plus`; add an extraction-capable provider for `web_extract_plus`. The setup helper stores keys in the active Hermes environment file — never commit them to the repository.
 
-- Plugin install clones into `~/.hermes/plugins/web-search-plus`; update later with `hermes plugins update web-search-plus`, then restart/`/reset`.
-- Keys are written to the active Hermes environment file by the setup helper; they should never be committed to the repo.
-- Python 3.10+ is required; runtime code is stdlib-only.
-- To make Web Search Plus the preferred web layer, disable the built-in web toolset (`agent.disabled_toolsets: [web]`) and verify with `setup.py fastpath` — details in the [User Guide](docs/USER_GUIDE.md#installation-and-first-run-checks).
+Update later with:
 
----
+```bash
+hermes plugins update web-search-plus
+```
 
-## Documentation
-
-### Upgrading to 3.0
-
-- [3.0 Release Notes](docs/RELEASE_NOTES_V3.md) — start here for highlights, compatibility changes, and 3.1 deferrals.
-- [3.0 Migration](docs/V3_MIGRATION.md) — dry-run, apply, smoke tests, and verified rollback.
-- [3.0 Compatibility](docs/V3_COMPATIBILITY.md) — stable surfaces, intentional removals, cache/state behavior, and routing controls.
-- [Backup and Restore](docs/V3_BACKUP_RESTORE.md) — migration backup ownership and exact restore behavior.
-
-### Operating
-
-- [Operator Console](docs/V3_OPERATOR_CONSOLE.md) — local read-only startup, security boundary, and troubleshooting.
-- [Provider Benchmarks](docs/V3_BENCHMARKS.md) — live quota use, extraction history, privacy, and applying recommendations.
-
-<p align="center">
-  <a href="docs/V3_OPERATOR_CONSOLE.md"><img src="docs/assets/operator-console-overview.png" alt="Web Search Plus local read-only Operator Console overview" width="100%"></a>
-</p>
-
-<p align="center"><sub>Local, read-only operational visibility — no provider calls, config writes, or cache mutation.</sub></p>
-
-### Reference
-
-- [User Guide](docs/USER_GUIDE.md) — detailed setup, provider tuning, tool parameters, extraction, reliability, and cost controls.
-- [Provider Reference](docs/PROVIDERS.md) — generated capabilities, environment variables, routing defaults, free tiers, and signup links.
-- [Routing v2 Reference](docs/ROUTING.md) — generated class-by-class routing preferences and demotions.
-- [3.0 Wire Contract](docs/V3_WIRE_CONTRACT.md) — normative request/response surface, with search-parity, source-evidence, and bounded-context amendments.
-- [FAQ](docs/FAQ.md) — common setup, provider selection, cache, quota, and troubleshooting questions.
-- [Architecture](docs/ARCHITECTURE.md) — plugin boundary, routing engine, cache/state flow, and provider-extension notes.
-
----
-
-## Capability model
-
-| Capability | Unlocks | Configure at least one of |
-|---|---|---|
-| Search | `web_search_plus` | Brave, Serper, Tavily, Exa, Linkup, Firecrawl, Parallel, You.com, SearXNG, SerpBase, Querit, or Keenable |
-| Extraction | `web_extract_plus` | Linkup, Firecrawl, Tavily, Exa, Parallel, You.com, Serper, or Keenable |
-| Best starter | Search + extraction + reliable fallback | You.com + Serper + Linkup |
+Python 3.10+ is required. Runtime code is standard-library only.
 
 ---
 
@@ -115,95 +72,48 @@ Notes:
 
 ### `web_search_plus`
 
-Use this when the agent needs search results and routing metadata.
+Use it for current information, source discovery, or opt-in multi-provider research.
 
 ```python
-web_search_plus(query="Graz weather today")
-# → auto-routed current-info search
-
-web_search_plus(query="alternatives to Notion", provider="exa")
-# → semantic discovery via a forced provider
-
-web_search_plus(query="compare recent reviews of turntables under 1000", mode="research", research_time_budget=45)
-# → opt-in multi-provider research; keeps partial results if extraction hits errors/budget
-
-web_search_plus(query="best bookshelf speakers under 1000", quality_report=True)
-# → normal search plus routing/result-quality diagnostics
+web_search_plus(query="Hermes Agent latest release")
+web_search_plus(query="compare recent open-source agent frameworks", mode="research", quality_report=True)
 ```
 
 ### `web_extract_plus`
 
-Use this when you already have URLs and want clean content.
+Use it when you already have URLs and want clean page content.
 
 ```python
-web_extract_plus(urls=["https://example.com"], provider="firecrawl")
-# → extract clean markdown from a URL
-
-web_extract_plus(urls=["https://docs.linkup.so"], provider="linkup", render_js=False)
-# → Linkup fetch endpoint
+web_extract_plus(urls=["https://example.com"])
+web_extract_plus(urls=["https://docs.example.com"], provider="linkup", render_js=False)
 ```
 
-Auto extraction defaults to Tavily → Exa → Linkup → Parallel → Firecrawl → You.com → Keenable → Serper for configured providers. Operators can change only the extraction order with `setup.py config set-extract-priority serper,parallel,...`; omitted extraction providers are appended in the default registry order. This is separate from search `provider_priority`. Large pages use truncate-and-store output handling: a bounded head/tail preview inline, the full cleaned text stored under `cache/web/`, and a ready-to-run `read_file` call in the footer for paging into the omitted middle.
-
-Full parameter tables for both tools, freshness/vertical/locale semantics, and cache management live in the [User Guide](docs/USER_GUIDE.md#using-web_search_plus).
+Full parameters, freshness and locale behavior, provider selection, extraction controls, and cache management live in the [User Guide](docs/USER_GUIDE.md).
 
 ---
 
-## Providers
+## Documentation
 
-| Provider | Search | Extract | Best for |
-|---|---:|---:|---|
-| You.com | ✅ | ✅ | Fast Routing v2 core for current, multilingual, LLM-ready search |
-| Serper | ✅ | ✅ | Reliable Google-like fallback for facts, shopping, local, and news; webpage scraper as last-resort extraction |
-| Exa | ✅ | ✅ | Semantic discovery, docs, GitHub, academic/arXiv |
-| Firecrawl | ✅ | ✅ | Source-first web search with scrape-ready result content |
-| Tavily | ✅ | ✅ | Long-form research and content-heavy queries |
-| Linkup | ✅ | ✅ | Source-backed grounding, citations, RAG-ready retrieval |
-| Brave | ✅ | — | Independent web index; default auto-pool priority 7 |
-| SearXNG | ✅ | — | Privacy-focused self-hosted metasearch |
-| Keenable | ✅ | ✅ | Independent web index; key or opt-in keyless public tier (off by default); lowest-priority fallback |
-| SerpBase | ✅ | — | Cheap Google-like SERP fallback; guarded by default (`auto_allow=false`) |
-| Parallel | ✅ | ✅ | LLM-ready search and fast extract with long source excerpts; guarded by default (`auto_allow=false`) |
-| Querit | ✅ | — | Multilingual and real-time queries; guarded by default (`auto_allow=false`) |
+### Start & upgrade
 
-Routing v2 is benchmarked and class-aware: it detects language/script hints and query classes (news, shopping/local, docs/API, GitHub, academic, community, CVE/security, finance, weather, and more — see the [Routing Reference](docs/ROUTING.md)). Guarded providers are available for explicit `provider=` calls once their key is set; opt them into automatic routing with `setup.py config set-auto-allow <provider> on`.
+- [User Guide](docs/USER_GUIDE.md) — installation, first-run checks, tool usage, and troubleshooting
+- [3.0 Release Notes](docs/RELEASE_NOTES_V3.md) — highlights, provider changes, compatibility, and 3.1 deferrals
+- [3.0 Migration](docs/V3_MIGRATION.md) — dry run, apply, smoke tests, and rollback
+- [3.0 Compatibility](docs/V3_COMPATIBILITY.md) and [Backup & Restore](docs/V3_BACKUP_RESTORE.md) — stable surfaces and recovery behavior
 
----
+### Configure & operate
 
-## API keys
+- [Provider Reference](docs/PROVIDERS.md) — generated capabilities, environment variables, defaults, and signup links
+- [Routing v2 Reference](docs/ROUTING.md) — generated routing classes, preferences, and demotions
+- [Operator Console](docs/V3_OPERATOR_CONSOLE.md) — local read-only visibility and troubleshooting
+- [Provider Benchmarks](docs/V3_BENCHMARKS.md) — search and extraction comparison with privacy and quota guidance
+- [FAQ](docs/FAQ.md) — provider selection, cache, cost, and common setup problems
 
-All provider keys are optional at install time. Configure only what you use:
+### Deep reference
 
-```bash
-# Search-capable providers
-SERPER_API_KEY=***        # https://serper.dev — search + extraction (webpage scraper)
-BRAVE_API_KEY=***         # https://brave.com/search/api/
-TAVILY_API_KEY=***        # https://tavily.com — search + extraction
-EXA_API_KEY=***           # https://exa.ai — search + extraction
-LINKUP_API_KEY=***        # https://linkup.so — search + cheap/citation-friendly extraction
-FIRECRAWL_API_KEY=***     # https://firecrawl.dev — search + extraction
-YOU_API_KEY=***           # https://api.you.com — search + extraction
-SEARXNG_INSTANCE_URL=https://your-instance.example.com
-KEENABLE_API_KEY=***      # https://keenable.ai — search + extraction
-SERPBASE_API_KEY=***      # https://www.serpbase.dev — explicit/fallback-only Google-like SERP search
-PARALLEL_API_KEY=***      # https://platform.parallel.ai — explicit/guarded LLM-ready search + extraction
-QUERIT_API_KEY=***        # https://querit.ai — explicit/fallback-only by default
-
-```
-
-Keenable also has an opt-in keyless public tier (off by default, per-IP limits, no SLA) — see [User Guide → Provider setup](docs/USER_GUIDE.md#provider-setup).
-
----
-
-## Quality, reliability, and safety
-
-- **Adaptive routing:** recent provider latency/error/empty-result outcomes nudge close routing calls within a bounded adjustment; strong query-class signals are never overridden.
-- **Result hygiene:** known SEO mirrors/scrapers are filtered, domain diversity is enforced, and explicit `site:`/`include_domains` intent bypasses both.
-- **Safe extraction targets:** `web_extract_plus` rejects loopback, RFC1918, link-local, cloud-metadata, and other private/internal target URLs before provider dispatch.
-- **Cooldowns and budgets:** failing providers go on escalating cooldown; research mode enforces a best-effort wall-clock budget and keeps partial results.
-- **Truthful metadata:** missing keys, quota failures, empty results, unapplied filters, and budget exhaustion are reported in response metadata instead of being hidden.
-
-Details and tuning knobs (spam-filter overrides, diversity limits, `allow_private_urls`, cache management) are in the [User Guide](docs/USER_GUIDE.md#result-quality).
+- [Architecture](docs/ARCHITECTURE.md) — plugin boundaries, routing, cache/state flow, and provider extensions
+- [3.0 Wire Contract](docs/V3_WIRE_CONTRACT.md) — normative request and response surface
+- [Source Evidence](docs/V3_SOURCE_EVIDENCE_CONTRACT.md), [Bounded Context](docs/V3_BOUNDED_CONTEXT_CONTRACT.md), and [Search Parity](docs/V3_SEARCH_PARITY_CONTRACT.md) — detailed v3 contract amendments
 
 ---
 
@@ -214,12 +124,9 @@ cd ~/.hermes/plugins/web-search-plus
 python3 -m pip install -r requirements.txt
 python3 -m pytest -q
 python3 -m compileall -q __init__.py search.py setup.py scripts tests
-
-# Offline golden snapshot quality checks (CI-safe, no live provider calls)
-python3 scripts/golden_eval.py --snapshot-fixtures tests/fixtures/golden_snapshots.json --out /tmp/golden-quality.jsonl
 ```
 
-Module layout, routing engine internals, compatibility-shim policy, and provider-extension notes are documented in [Architecture](docs/ARCHITECTURE.md).
+Generated provider and routing references are checked in CI. Development architecture and extension notes are in [Architecture](docs/ARCHITECTURE.md).
 
 ---
 


### PR DESCRIPTION
## Summary

- simplify the main README from a combined landing page/reference manual into a concise product overview
- explain the practical improvements in Web Search Plus 3.0 without implying answer synthesis or truth verification
- move readers to the existing generated provider, routing, migration, operator, and contract documentation for technical detail
- add a practical 3.0 benefits section to the detailed changelog

The approved README hero remains unchanged.

## Verification

- `763 passed, 6 subtests passed`
- `ruff check .`
- `python3 -m compileall -q .`
- generated provider and routing documentation drift checks
- local README link validation
- public-path, session-metadata, credential-value, and private-workflow hygiene scan
- unchanged hero SHA-256: `883cbfc19b725eaf24b41b69fc7573cac476d07123e41657f96da1c577364388`
