### PR TITLE
fix: prioritize plugin imports in Hermes gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [v3.0.1] — 2026-07-13
+
+### 🐛 Fixed
+- Fixed in-process engine loading when Hermes' host package root precedes an already-registered plugin path. The lazy loader now temporarily prioritizes Web Search Plus sibling modules and restores the exact original `sys.path`, preventing collisions with Hermes' `providers` package and avoiding a permanent subprocess fallback.
+
 ## [v3.0.0] — 2026-07-13
 
 ### 🚀 WSP 3.0 — Source-only evidence engine

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v3.0.0
+web-search-plus — Hermes Plugin v3.0.1
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 import argparse
 import getpass
@@ -1149,11 +1149,13 @@ def _load_search_module() -> Any:
             return _search_module
         if _search_import_failed:
             return None
-        plugin_dir = str(Path(__file__).parent)
-        inserted = False
-        if plugin_dir not in sys.path:
-            sys.path.insert(0, plugin_dir)
-            inserted = True
+        plugin_dir = str(_PLUGIN_DIR)
+        original_sys_path = list(sys.path)
+        # Hermes may already have this plugin path on sys.path, but behind the
+        # host package root. Move it to the front while flat sibling imports
+        # resolve, then restore the exact original order in the finally block.
+        sys.path[:] = [entry for entry in sys.path if entry != plugin_dir]
+        sys.path.insert(0, plugin_dir)
         # Stash any top-level modules whose names collide with this plugin's
         # flat sibling imports (providers, extract, routing, research, etc.).
         # If hermes-agent's `providers` package is already in sys.modules,
@@ -1200,11 +1202,7 @@ def _load_search_module() -> Any:
                 sys.modules.pop(_name, None)
             for _name, _mod in stashed.items():
                 sys.modules[_name] = _mod
-            if inserted:
-                try:
-                    sys.path.remove(plugin_dir)
-                except ValueError:  # pragma: no cover - defensive cleanup
-                    pass
+            sys.path[:] = original_sys_path
         _search_module = _search
         return _search_module
 

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/3.0.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/3.0.1"
 
 
 class ProviderRequestError(Exception):

--- a/operator_console_v3.py
+++ b/operator_console_v3.py
@@ -407,7 +407,7 @@ def build_overview(
     config: Mapping[str, Any] | None = None,
     provider_ids: Sequence[str] | None = None,
     state_path: str | Path | None = None,
-    plugin_version: str = "3.0.0",
+    plugin_version: str = "3.0.1",
     now: Callable[[], float] = time.time,
 ) -> dict[str, Any]:
     root = Path(cache_root)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "3.0.0"
+version: "3.0.1"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 3.0.0
+Version: 3.0.1
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable, Serper.

--- a/tests/test_plugin_package_import.py
+++ b/tests/test_plugin_package_import.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib
 import importlib.util
 import re
 import sys
@@ -71,3 +72,42 @@ def test_plugin_loads_from_foreign_cwd_without_package_context(tmp_path, monkeyp
         assert module._get_provider_catalog()
     finally:
         sys.modules.pop(module_name, None)
+
+
+def test_lazy_search_loader_prioritizes_plugin_over_host_modules(tmp_path):
+    """Gateway sys.path precedence must not shadow WSP's flat siblings."""
+    module_name = "wsp_gateway_precedence_import_test"
+    host_root = tmp_path / "host"
+    host_providers = host_root / "providers"
+    host_providers.mkdir(parents=True)
+    (host_providers / "__init__.py").write_text("HOST_PROVIDER = True\n", encoding="utf-8")
+
+    original_path = list(sys.path)
+    previous_providers = sys.modules.pop("providers", None)
+    sys.modules.pop(module_name, None)
+    sys.modules.pop("_wsp_search_engine", None)
+
+    try:
+        sys.path[:] = [str(host_root), *[entry for entry in original_path if entry != str(ROOT)]]
+        host_module = importlib.import_module("providers")
+
+        spec = importlib.util.spec_from_file_location(module_name, ROOT / "__init__.py")
+        assert spec is not None
+        assert spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+
+        path_before_load = list(sys.path)
+        engine = module._load_search_module()
+
+        assert engine is not None
+        assert engine.__file__ == str(ROOT / "search.py")
+        assert sys.modules["providers"] is host_module
+        assert sys.path == path_before_load
+    finally:
+        sys.modules.pop(module_name, None)
+        sys.modules.pop("_wsp_search_engine", None)
+        sys.modules.pop("providers", None)
+        if previous_providers is not None:
+            sys.modules["providers"] = previous_providers
+        sys.path[:] = original_path

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "3.0.0"
+EXPECTED_VERSION = "3.0.1"
 
 
 def _load_plugin_module():

--- a/ui.py
+++ b/ui.py
@@ -420,7 +420,7 @@ def create_server(
     cache_root: str | Path = CACHE_DIR,
     state_path: str | Path | None = None,
     config: Mapping[str, Any] | None = None,
-    plugin_version: str = "3.0.0",
+    plugin_version: str = "3.0.1",
     snapshot_backend: Any = operator_console_v3,
     static_root: str | Path | None = None,
 ) -> ThreadingHTTPServer:


### PR DESCRIPTION
## Summary
- make the lazy in-process search loader temporarily prioritize the Web Search Plus plugin directory over Hermes host packages
- restore the exact original `sys.path` in `finally`, while preserving the existing colliding-module restoration and subprocess fallback
- add a regression test that reproduces a host `providers` package shadowing the plugin's flat sibling module
- prepare the patch release as v3.0.1 across all version surfaces and the changelog

## Root cause
Hermes plugin discovery can leave the plugin directory on `sys.path` behind the host package root. `_load_search_module()` previously moved the plugin directory to the front only when it was absent. After stashing an already-imported host `providers` module, Python therefore imported the host package again instead of Web Search Plus' sibling module. The import failed and set the gateway process' sticky `_search_import_failed` flag, forcing all later calls through the subprocess fallback.

## Verification
- regression test observed RED before the fix with the expected `ImportError`
- `python -m pytest tests/ -q` — 764 passed, 6 subtests passed
- `ruff check .`
- generated provider docs and contract schemas are current
- AJV schema boundary passed
- `python -m compileall -q .`
- `git diff --check`
- changed-file privacy scan passed
- neutral-CWD runtime smoke preloaded `/opt/hermes/providers`, forbade subprocess execution, loaded the in-process engine, restored `sys.path` exactly, and completed a real Serper search

## Risk containment
The temporary path change is limited to the existing locked lazy-import section and is reverted via slice assignment in `finally`. The existing module-stash restoration and subprocess fallback remain intact.
