### PR TITLE
chore: prepare Web Search Plus v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [v3.0.2] — 2026-07-14
+
+### Credits
+- #104 by @robbyczgw-cla — repaired and hardened the native v3 Research, Extract cache, bounded-context, retained full-text, and operator-receipt integration paths.
+
 ### 🐛 Fixed
 - Restored true multi-provider Research Mode in the native v3/Hermes path. Research providers now execute as separate authoritative attempts, and source observations retain the provider-attempt provenance of each contributing backend.
 - Restored the complete public Research envelope and its single post-merge quality pass, bypassed the legacy lossy cache, classified started deadline overruns as cancelled attempts, degraded provider/extraction budget limits truthfully, and marked total fan-out failure as a failed response.

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v3.0.1
+web-search-plus — Hermes Plugin v3.0.2
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 import argparse
 import getpass

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/3.0.1"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/3.0.2"
 
 
 class ProviderRequestError(Exception):

--- a/operator_console_v3.py
+++ b/operator_console_v3.py
@@ -407,7 +407,7 @@ def build_overview(
     config: Mapping[str, Any] | None = None,
     provider_ids: Sequence[str] | None = None,
     state_path: str | Path | None = None,
-    plugin_version: str = "3.0.1",
+    plugin_version: str = "3.0.2",
     now: Callable[[], float] = time.time,
 ) -> dict[str, Any]:
     root = Path(cache_root)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "3.0.1"
+version: "3.0.2"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 3.0.1
+Version: 3.0.2
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable, Serper.

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "3.0.1"
+EXPECTED_VERSION = "3.0.2"
 
 
 def _load_plugin_module():

--- a/ui.py
+++ b/ui.py
@@ -420,7 +420,7 @@ def create_server(
     cache_root: str | Path = CACHE_DIR,
     state_path: str | Path | None = None,
     config: Mapping[str, Any] | None = None,
-    plugin_version: str = "3.0.1",
+    plugin_version: str = "3.0.2",
     snapshot_backend: Any = operator_console_v3,
     static_root: str | Path | None = None,
 ) -> ThreadingHTTPServer:


### PR DESCRIPTION
## Summary

- bump all Web Search Plus version surfaces from 3.0.1 to 3.0.2
- move the v3 entrypoint repair notes from `Unreleased` into the dated v3.0.2 section
- credit #104 for the Research, Extract cache, bounded-context, retained full-text, and operator-receipt hardening

## Release inventory

- Previous tag: `v3.0.1`
- Included change: #104 (`fix: repair v3 entrypoint integrations`)
- No other commits have landed on `main` since v3.0.1
- Open provider PR #74 is unrelated and not part of this patch release

## Verification

- `790 passed, 6 subtests passed`
- release metadata/package/User-Agent tests: `21 passed`
- `ruff check .`
- `python3 -m compileall -q .`
- `git diff --check`
- provider, routing, and contract-schema drift checks
- Node schema-boundary validation
- added-line privacy scan
