### PR TITLE
fix(sdk): isolate dynamic provider receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+## [v3.1.1] — 2026-07-20
+
+### 🐛 Fixed
+- Refresh Operator Privacy provider provenance from the validated live registry so providers registered after the privacy module was imported can emit receipts without weakening the fail-closed rejection of unregistered provider IDs.
+- Isolate the opt-in Provider SDK fixture probe in a temporary cache root, preventing test receipts and cache entries from touching an operator's active WSP state.
+- Bring the contract schema generator back into parity with the 3.1 budget-preflight schema, so the generated-artifact CI gate no longer treats the published response schema as stale.
+- Stabilize receipt-journal concurrency tests with the journal's injected clock, removing wall-clock expiry from thread and cross-process retention assertions.
+
 ## [v3.1.0] — 2026-07-20
 
 ### ✨ Added

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v3.1.0
+web-search-plus — Hermes Plugin v3.1.1
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 import argparse
 import getpass

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/3.1.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/3.1.1"
 
 
 class ProviderRequestError(Exception):

--- a/operator_console_v3.py
+++ b/operator_console_v3.py
@@ -532,7 +532,7 @@ def build_overview(
     config: Mapping[str, Any] | None = None,
     provider_ids: Sequence[str] | None = None,
     state_path: str | Path | None = None,
-    plugin_version: str = "3.1.0",
+    plugin_version: str = "3.1.1",
     now: Callable[[], float] = time.time,
 ) -> dict[str, Any]:
     root = Path(cache_root)

--- a/operator_privacy_v3.py
+++ b/operator_privacy_v3.py
@@ -46,10 +46,6 @@ _ATTEMPT_ID = re.compile(r"^attempt_[a-f0-9]{16}$")
 _ENTRY_ID = re.compile(r"^(?:search|extract)_[a-f0-9]{32}$")
 _WSP_CODE = re.compile(r"^wsp\.[a-z0-9_.-]{1,96}$")
 _SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[a-z0-9.-]+)?$")
-_PROVIDER_VALUES = frozenset({*PROVIDER_SPECS, "auto"})
-_PROVIDER_DISPLAY_NAMES = frozenset(
-    spec.display_name for spec in PROVIDER_SPECS.values()
-)
 _ENUM_VALUES = {
     "status": {
         "ok", "degraded", "failed", "completed", "collected", "not_collected",
@@ -131,7 +127,7 @@ def _validate_string(value: str, field_name: str | None, location: str) -> None:
     ):
         raise ValueError(f"operator payload leaks authorization material at {location}")
     if field_name == "display_name":
-        if value not in _PROVIDER_DISPLAY_NAMES:
+        if not any(value == spec.display_name for spec in PROVIDER_SPECS.values()):
             raise ValueError(f"operator payload string is not known-safe at {location}")
         return
     if field_name in _ENUM_VALUES:
@@ -139,7 +135,7 @@ def _validate_string(value: str, field_name: str | None, location: str) -> None:
             raise ValueError(f"operator payload string is not known-safe at {location}")
         return
     if field_name in _PROVIDER_FIELDS:
-        if value not in _PROVIDER_VALUES:
+        if value != "auto" and value not in PROVIDER_SPECS:
             raise ValueError(f"operator payload string lacks provider provenance at {location}")
         return
     if field_name in _EXECUTION_FIELDS:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "3.1.0"
+version: "3.1.1"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/schemas/v3/response.schema.json
+++ b/schemas/v3/response.schema.json
@@ -1394,40 +1394,68 @@
           ]
         },
         "limit": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "minimum": 0
         },
         "observed": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "minimum": 0
         },
         "verdict": {
           "type": "string",
-          "enum": ["ok", "exceeded"]
+          "enum": [
+            "ok",
+            "exceeded"
+          ]
         }
       },
       "additionalProperties": false,
-      "required": ["check", "limit", "observed", "verdict"]
+      "required": [
+        "check",
+        "limit",
+        "observed",
+        "verdict"
+      ]
     },
     "BudgetPreflightReceiptV3": {
       "type": "object",
       "properties": {
         "action": {
           "type": "string",
-          "enum": ["degrade", "abort"]
+          "enum": [
+            "degrade",
+            "abort"
+          ]
         },
         "checks": {
           "type": "array",
           "minItems": 4,
           "maxItems": 4,
-          "items": {"$ref": "#/$defs/BudgetPreflightCheckV3"}
+          "items": {
+            "$ref": "#/$defs/BudgetPreflightCheckV3"
+          }
         },
         "adjustments": {
           "type": "object",
           "properties": {
-            "max_provider_calls": {"type": "integer", "minimum": 1},
-            "timeout_seconds": {"type": "integer", "minimum": 1},
-            "context_limit": {"type": "integer", "minimum": 1}
+            "max_provider_calls": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "timeout_seconds": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "context_limit": {
+              "type": "integer",
+              "minimum": 1
+            }
           },
           "additionalProperties": false,
           "minProperties": 1
@@ -1442,17 +1470,40 @@
         }
       },
       "additionalProperties": false,
-      "required": ["action", "checks"],
+      "required": [
+        "action",
+        "checks"
+      ],
       "oneOf": [
         {
-          "properties": {"action": {"const": "degrade"}},
-          "required": ["adjustments"],
-          "not": {"required": ["reason"]}
+          "properties": {
+            "action": {
+              "const": "degrade"
+            }
+          },
+          "required": [
+            "adjustments"
+          ],
+          "not": {
+            "required": [
+              "reason"
+            ]
+          }
         },
         {
-          "properties": {"action": {"const": "abort"}},
-          "required": ["reason"],
-          "not": {"required": ["adjustments"]}
+          "properties": {
+            "action": {
+              "const": "abort"
+            }
+          },
+          "required": [
+            "reason"
+          ],
+          "not": {
+            "required": [
+              "adjustments"
+            ]
+          }
         }
       ]
     },
@@ -1695,7 +1746,10 @@
           ]
         },
         "observation_id": {
-          "type": ["string", "null"],
+          "type": [
+            "string",
+            "null"
+          ],
           "pattern": "^obs_"
         },
         "reason": {
@@ -1722,18 +1776,34 @@
       "allOf": [
         {
           "if": {
-            "properties": {"action": {"const": "budget_preflight"}},
-            "required": ["action"]
+            "properties": {
+              "action": {
+                "const": "budget_preflight"
+              }
+            },
+            "required": [
+              "action"
+            ]
           },
           "then": {
             "properties": {
-              "observation_id": {"type": "null"},
-              "reason": {"enum": ["degraded", "aborted"]}
+              "observation_id": {
+                "type": "null"
+              },
+              "reason": {
+                "enum": [
+                  "degraded",
+                  "aborted"
+                ]
+              }
             }
           },
           "else": {
             "properties": {
-              "observation_id": {"type": "string", "pattern": "^obs_"}
+              "observation_id": {
+                "type": "string",
+                "pattern": "^obs_"
+              }
             }
           }
         }

--- a/scripts/gen_contract_v3_schemas.py
+++ b/scripts/gen_contract_v3_schemas.py
@@ -544,6 +544,7 @@ response_defs = {
                     {"type": "null"},
                 ]
             },
+            "budget_preflight": {"$ref": "#/$defs/BudgetPreflightReceiptV3"},
         },
         (
             "policy_id",
@@ -554,6 +555,64 @@ response_defs = {
             "fallback_reason",
         ),
     ),
+    "BudgetPreflightCheckV3": obj(
+        {
+            "check": {
+                "type": "string",
+                "enum": [
+                    "provider_call_cap", "daily_quota", "timeout_budget",
+                    "context_budget",
+                ],
+            },
+            "limit": {"type": ["integer", "null"], "minimum": 0},
+            "observed": {"type": ["integer", "null"], "minimum": 0},
+            "verdict": {"type": "string", "enum": ["ok", "exceeded"]},
+        },
+        ("check", "limit", "observed", "verdict"),
+    ),
+    "BudgetPreflightReceiptV3": {
+        **obj(
+            {
+                "action": {"type": "string", "enum": ["degrade", "abort"]},
+                "checks": {
+                    "type": "array",
+                    "minItems": 4,
+                    "maxItems": 4,
+                    "items": {"$ref": "#/$defs/BudgetPreflightCheckV3"},
+                },
+                "adjustments": {
+                    **obj(
+                        {
+                            "max_provider_calls": {"type": "integer", "minimum": 1},
+                            "timeout_seconds": {"type": "integer", "minimum": 1},
+                            "context_limit": {"type": "integer", "minimum": 1},
+                        }
+                    ),
+                    "minProperties": 1,
+                },
+                "reason": {
+                    "type": "string",
+                    "enum": [
+                        "daily_quota_exhausted", "budget_ledger_unavailable",
+                        "budget_unsatisfiable",
+                    ],
+                },
+            },
+            ("action", "checks"),
+        ),
+        "oneOf": [
+            {
+                "properties": {"action": {"const": "degrade"}},
+                "required": ["adjustments"],
+                "not": {"required": ["reason"]},
+            },
+            {
+                "properties": {"action": {"const": "abort"}},
+                "required": ["reason"],
+                "not": {"required": ["adjustments"]},
+            },
+        ],
+    },
     "SourceDiversityV3": obj(
         {
             "method": {"type": "string", "minLength": 1},
@@ -637,15 +696,16 @@ response_defs = {
                 "enum": [
                     "excluded", "reranked", "demoted",
                     "selected_as_representative", "truncated_by_limit",
+                    "budget_preflight",
                 ],
             },
-            "observation_id": {"type": "string", "pattern": "^obs_"},
+            "observation_id": {"type": ["string", "null"], "pattern": "^obs_"},
             "reason": {
                 "type": "string",
                 "enum": [
                     "spam_domain", "intent_authority", "domain_diversity",
                     "dedup_representative", "max_results", "max_content_bytes",
-                    "max_context_chars",
+                    "max_context_chars", "degraded", "aborted",
                 ],
             },
         },
@@ -727,7 +787,10 @@ response_defs["CandidateDecisionV3"]["oneOf"] = [
         "properties": {
             "decision": {"const": "not_attempted"},
             "reason_code": {
-                "enum": ["provider_unavailable", "not_attempted_after_success"],
+                "enum": [
+                    "provider_unavailable", "not_attempted_after_success",
+                    "budget_denied",
+                ],
             },
             "attempt_id": {"type": "null"},
         }
@@ -761,6 +824,25 @@ response_defs["StoredContentV3"]["allOf"] = [
                 "reference": {"type": "null"},
                 "full_text_sha256": {"type": "null"},
                 "full_text_chars": {"type": "null"},
+            }
+        },
+    }
+]
+response_defs["PolicyActionV3"]["allOf"] = [
+    {
+        "if": {
+            "properties": {"action": {"const": "budget_preflight"}},
+            "required": ["action"],
+        },
+        "then": {
+            "properties": {
+                "observation_id": {"type": "null"},
+                "reason": {"enum": ["degraded", "aborted"]},
+            }
+        },
+        "else": {
+            "properties": {
+                "observation_id": {"type": "string", "pattern": "^obs_"},
             }
         },
     }

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 3.1.0
+Version: 3.1.1
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable, Serper.

--- a/tests/providers_d/test_example_fixture.py
+++ b/tests/providers_d/test_example_fixture.py
@@ -18,10 +18,12 @@ def test_fixture_provider_is_absent_without_the_explicit_opt_in() -> None:
     assert "example-fixture" not in provider_registry.DEFAULT_AUTO_ALLOW
 
 
-def test_fixture_provider_zero_core_edit_path_with_opt_in() -> None:
+def test_fixture_provider_zero_core_edit_path_with_opt_in(tmp_path: Path) -> None:
     env = dict(os.environ)
     env[provider_registry.NON_PRODUCTION_DISCOVERY_ENV] = "1"
     env["PYTHONPATH"] = str(REPO_ROOT)
+    isolated_cache = tmp_path / "cache"
+    env["WSP_CACHE_DIR"] = str(isolated_cache)
     proc = subprocess.run(
         [sys.executable, str(PROBE)],
         cwd=REPO_ROOT,
@@ -32,3 +34,4 @@ def test_fixture_provider_zero_core_edit_path_with_opt_in() -> None:
     )
     assert proc.returncode == 0, proc.stderr
     assert "FIXTURE_PROBE_OK" in proc.stdout
+    assert (isolated_cache / "operator" / "v3" / "receipts.jsonl").is_file()

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "3.1.0"
+EXPECTED_VERSION = "3.1.1"
 
 
 def _load_plugin_module():

--- a/tests/test_ws3_receipt_journal.py
+++ b/tests/test_ws3_receipt_journal.py
@@ -5,6 +5,7 @@ import json
 import multiprocessing
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -46,11 +47,13 @@ def fixture(name: str) -> dict[str, Any]:
 
 def append_journal_in_process(args: tuple[str, int, dict[str, Any]]) -> bool:
     root, index, source = args
+    fixture_now = float(source["timestamp"]) + 1.0
     journal_module = importlib.import_module("operator_receipts_v3")
     journal = journal_module.OperatorReceiptJournal(
         root,
         max_records=100,
         max_bytes=1_000_000,
+        now=lambda: fixture_now,
     )
     return journal.append(dict(source, execution_id=f"exec_{index:032x}"))
 
@@ -345,6 +348,31 @@ def test_privacy_choke_accepts_fixtures_but_rejects_allowed_key_freetext() -> No
         )
 
 
+def test_privacy_choke_tracks_providers_registered_after_import(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    privacy = importlib.import_module("operator_privacy_v3")
+    registry = importlib.import_module("provider_registry")
+
+    monkeypatch.setitem(
+        registry.PROVIDER_SPECS,
+        "sdk-fixture",
+        SimpleNamespace(display_name="SDK fixture provider"),
+    )
+
+    assert privacy.assert_operator_payload_safe(
+        {
+            "schema_version": 1,
+            "provider": "sdk-fixture",
+            "display_name": "SDK fixture provider",
+        }
+    ) is None
+    with pytest.raises(ValueError, match="provider provenance"):
+        privacy.assert_operator_payload_safe(
+            {"schema_version": 1, "provider": "unregistered-provider"}
+        )
+
+
 def test_completed_receipt_rejects_missing_candidate_and_outcome_drift() -> None:
     contract = importlib.import_module("contract_v3")
     good = contract.complete_routing_receipt_v3(
@@ -535,12 +563,14 @@ def test_journal_ttl_prunes_only_owned_records(tmp_path: Path) -> None:
 def test_concurrent_journal_appends_do_not_lose_owned_records(tmp_path: Path) -> None:
     journal_module = importlib.import_module("operator_receipts_v3")
     source = fixture("receipts.json")["receipts"][0]
+    fixture_now = float(source["timestamp"]) + 1.0
 
     def append(index: int) -> bool:
         journal = journal_module.OperatorReceiptJournal(
             tmp_path,
             max_records=100,
             max_bytes=1_000_000,
+            now=lambda: fixture_now,
         )
         return journal.append(
             dict(source, execution_id=f"exec_{index:032x}")
@@ -549,7 +579,10 @@ def test_concurrent_journal_appends_do_not_lose_owned_records(tmp_path: Path) ->
     with ThreadPoolExecutor(max_workers=8) as pool:
         results = list(pool.map(append, range(24)))
 
-    records = journal_module.OperatorReceiptJournal(tmp_path).load(limit=100)
+    records = journal_module.OperatorReceiptJournal(
+        tmp_path,
+        now=lambda: fixture_now,
+    ).load(limit=100)
     assert all(results)
     assert {item["execution_id"] for item in records} == {
         f"exec_{index:032x}" for index in range(24)
@@ -561,6 +594,7 @@ def test_cross_process_journal_appends_do_not_lose_owned_records(
 ) -> None:
     journal_module = importlib.import_module("operator_receipts_v3")
     source = fixture("receipts.json")["receipts"][0]
+    fixture_now = float(source["timestamp"]) + 1.0
     work = [(str(tmp_path), index, source) for index in range(12)]
 
     with ProcessPoolExecutor(
@@ -569,7 +603,10 @@ def test_cross_process_journal_appends_do_not_lose_owned_records(
     ) as pool:
         results = list(pool.map(append_journal_in_process, work))
 
-    records = journal_module.OperatorReceiptJournal(tmp_path).load(limit=100)
+    records = journal_module.OperatorReceiptJournal(
+        tmp_path,
+        now=lambda: fixture_now,
+    ).load(limit=100)
     assert all(results)
     assert {item["execution_id"] for item in records} == {
         f"exec_{index:032x}" for index in range(12)

--- a/ui.py
+++ b/ui.py
@@ -434,7 +434,7 @@ def create_server(
     cache_root: str | Path = CACHE_DIR,
     state_path: str | Path | None = None,
     config: Mapping[str, Any] | None = None,
-    plugin_version: str = "3.1.0",
+    plugin_version: str = "3.1.1",
     snapshot_backend: Any = operator_console_v3,
     static_root: str | Path | None = None,
 ) -> ThreadingHTTPServer:


### PR DESCRIPTION
## Summary

- Refresh Operator Privacy provider provenance from the validated live registry, so SDK providers registered after the privacy module was imported can emit receipts while unknown provider IDs remain fail-closed.
- Run the opt-in Provider SDK fixture probe against a temporary `WSP_CACHE_DIR`, preventing test receipts and cache entries from touching operator state.
- Bring the contract schema generator back into parity with the already-published 3.1 budget-preflight schema.
- Make receipt-journal concurrency tests deterministic through the existing injected clock.
- Bump all release surfaces to 3.1.1.

## Safety

- No provider request, routing, credential, or user configuration behavior changed.
- Unregistered provider IDs are still rejected by the shared privacy choke point.
- The generated response schema is semantically unchanged; its 3.1 additions are now reproducible by the generator and canonically formatted.
- The concurrency fix is test-only and does not change journal retention behavior.

## Verification

- TDD regression reproduced the stale provider-provenance failure before the fix.
- `882 passed, 6 subtests passed`
- `ruff check .`
- `python -m compileall -q .`
- `scripts/gen_provider_docs.py --check`
- `scripts/gen_contract_v3_schemas.py --check`
- AJV schema boundary: all checks passed
- `git diff --check`
- Added-line privacy scan: clean
