### PR TITLE
feat(provider): add explicit Octen search via Monid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### ✨ Added
+- Added Octen via Monid as a bundled, source-only Search provider through the public Provider SDK. The adapter supports native freshness plus include/exclude-domain filters and remains explicit-only by default (`auto_allow=false`).
+
+### 🔒 Security and cost controls
+- Send credentials only to Monid's fixed HTTPS API origin, reject redirects, cap response bodies at 8 MiB, sanitize upstream failures, and keep Monid lifecycle errors separate from Octen provider HTTP errors.
+- Keep Octen's answer, Broad Search, image/video, and full-content modes outside this integration. Search highlights are enabled for source snippets while billable full content is explicitly disabled.
+
+### 🐛 Fixed
+- Honor `ProviderSpec.supports_freshness` for discovered SDK Search providers so a successfully applied canonical freshness filter is no longer reported as unsupported.
+
 ### 📚 Docs
 - Added a repository-specific contribution guide covering local setup, the source-only provider contract, SDK-based provider intake, CI and generated-artifact gates, changelog hygiene, security reporting, and maintainer-only release boundaries.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd ~/.hermes/plugins/web-search-plus
 python3 search.py --query "Hermes Agent latest release" --provider auto --quality-report
 ```
 
-Web Search Plus supports 13 search and 9 extraction providers — you do **not** need them all. One search-capable key or configured local endpoint enables `web_search_plus`; one extraction-capable key or endpoint enables `web_extract_plus`; more providers just make controlled routing more flexible. The setup helper stores keys in the active Hermes environment file — never commit them to the repository.
+Web Search Plus supports 14 search and 9 extraction providers — you do **not** need them all. One search-capable key or configured local endpoint enables `web_search_plus`; one extraction-capable key or endpoint enables `web_extract_plus`; more providers just make controlled routing more flexible. The setup helper stores keys in the active Hermes environment file — never commit them to the repository.
 
 ### Upgrading from 2.x? Relax.
 
@@ -86,6 +86,16 @@ python3 ~/.hermes/plugins/web-search-plus/setup.py status
 ```
 
 It selects the derived `self_hosted` profile: automatic search uses only your SearXNG instance and keyless Keenable, while automatic extraction runs through Keenable's public fetch tier (SearXNG does not extract; the public tier is rate-limited and has no SLA). Configure SearXNG with `searxng.base_url` (the older `instance_url` still works); the preset enables Keenable's existing public tier without writing a key. See the [Self-hosted profile guide](docs/USER_GUIDE.md#self-hosted-profile) for prerequisites and explicit-provider behavior.
+
+### Optional Octen source search via Monid
+
+Set `MONID_API_KEY` from [Monid](https://app.monid.ai/access/api-keys) to use [Octen](https://octen.ai) as an explicit source-search provider:
+
+```python
+web_search_plus(query="recent vector database research", provider="octen", freshness="month")
+```
+
+The adapter executes Octen's `/search` endpoint through Monid's documented HTTP API for ranked links and highlights. It supports freshness and domain filters, explicitly disables full-content retrieval, and does not call Octen's answer or Broad Search APIs. Access and billing use Monid's prepaid wallet; see Monid for current pricing and terms. Octen stays outside automatic routing and fallback unless you deliberately enable `auto_allow`.
 
 ### Local Hound provider
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -24,6 +24,7 @@ and the plugin provider catalog; regenerate it with `python scripts/gen_provider
 | SearXNG | ✅ | — | `SEARXNG_INSTANCE_URL` | — | yes (priority 11) | Free if self-hosted | https://docs.searxng.org/admin/installation.html |
 | Keenable | ✅ | ✅ | `KEENABLE_API_KEY` | yes (`KEENABLE_ALLOW_PUBLIC` opt-in) | yes (priority 12) | Keyless public tier; optional key for higher limits | https://keenable.ai |
 | Hound (local MCP) | ✅ | ✅ | `HOUND_MCP_URL` | — | explicit-only (`auto_allow=false`) | Free local sidecar; no API key | https://github.com/dondai1234/master-fetch |
+| Octen via Monid | ✅ | — | `MONID_API_KEY` | — | explicit-only (`auto_allow=false`) | No free-tier claim; Monid API key and wallet balance required | https://app.monid.ai/access/api-keys |
 
 `priority N` is the provider's position in the default routing priority list.
 Providers marked explicit-only stay out of `provider="auto"` routing and fallback
@@ -96,3 +97,7 @@ Independent web index for search and extraction; works keyless, optional key rai
 ### Hound (local MCP)
 
 Local key-free metasearch and browser-backed extraction through a loopback Hound sidecar. Hound is an independent MIT-licensed project by Bishesh Bhandari.
+
+### Octen via Monid
+
+Explicit-only Octen source-result web search through Monid, with native recency and domain filtering.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -17,6 +17,7 @@ optional_env:
   - SEARXNG_INSTANCE_URL
   - KEENABLE_API_KEY
   - HOUND_MCP_URL
+  - MONID_API_KEY
 provides_tools:
   - web_search_plus
   - web_extract_plus

--- a/providers.d/octen.py
+++ b/providers.d/octen.py
@@ -1,0 +1,292 @@
+"""Explicit-only Octen source-search provider via Monid for Web Search Plus.
+
+The adapter calls Octen's Web Search endpoint through Monid's HTTP API and
+deliberately excludes answer, broad-search, and full-content modes. WSP remains
+the routing and evidence layer; Octen contributes ranked source results only.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from collections.abc import Mapping
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from wsp_sdk import (
+    ProviderConfigError,
+    ProviderRequestError,
+    ProviderSpec,
+    register_provider,
+    search_result,
+    source_result,
+)
+
+_API_URL = "https://api.monid.ai/v1/run"
+_MAX_RESPONSE_BYTES = 8 * 1024 * 1024
+_TRANSIENT_STATUS = {429, 500, 502, 503, 504}
+_FRESHNESS_VALUES = {"day", "week", "month", "year"}
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Keep the API key on the fixed Monid origin."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_OPENER = build_opener(_NoRedirectHandler())
+
+
+def _open_request(request: Request, timeout: int):
+    return _OPENER.open(request, timeout=timeout)
+
+
+def _timeout(config: Mapping[str, Any]) -> int:
+    section = config.get("octen", {})
+    raw = section.get("timeout", 30) if isinstance(section, Mapping) else 30
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        raise ProviderConfigError("octen_timeout_invalid") from None
+    if not 1 <= value <= 120:
+        raise ProviderConfigError("octen_timeout_invalid")
+    return value
+
+
+def _clean_domains(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _retry_after(error: HTTPError) -> float | None:
+    if error.code != 429:
+        return None
+    try:
+        value = error.headers.get("Retry-After")
+        if value is None:
+            return None
+        parsed = float(value)
+    except (AttributeError, TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _status(code: Any) -> tuple[int | None, bool]:
+    if isinstance(code, bool) or not isinstance(code, int):
+        return None, False
+    return code, code in _TRANSIENT_STATUS
+
+
+def _read_payload(response: Any) -> dict[str, Any]:
+    raw = response.read(_MAX_RESPONSE_BYTES + 1)
+    if len(raw) > _MAX_RESPONSE_BYTES:
+        raise ProviderRequestError("octen_response_too_large", transient=True)
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise ProviderRequestError("octen_invalid_response", transient=True) from None
+    if not isinstance(payload, dict):
+        raise ProviderRequestError("octen_invalid_response", transient=True)
+    return payload
+
+
+def _request(body: Mapping[str, Any], api_key: str, timeout: int) -> dict[str, Any]:
+    envelope = {"provider": "octen", "endpoint": "/search", "input": dict(body)}
+    request = Request(
+        _API_URL,
+        data=json.dumps(envelope, separators=(",", ":")).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+        method="POST",
+    )
+    try:
+        with _open_request(request, timeout) as response:
+            payload = _read_payload(response)
+    except HTTPError as exc:
+        status_code, transient = _status(exc.code)
+        raise ProviderRequestError(
+            f"octen_http_{exc.code}",
+            status_code=status_code,
+            transient=transient,
+            retry_after=_retry_after(exc),
+        ) from None
+    except (URLError, TimeoutError, socket.timeout, OSError):
+        raise ProviderRequestError("octen_unavailable", transient=True) from None
+
+    if payload.get("provider") != "octen" or payload.get("endpoint") != "/search":
+        raise ProviderRequestError("octen_monid_invalid_envelope", transient=True)
+
+    run_status = payload.get("status")
+    if run_status == "FAILED":
+        raise ProviderRequestError("octen_monid_failed", status_code=500, transient=True)
+    if run_status != "COMPLETED":
+        raise ProviderRequestError("octen_monid_not_completed", transient=True)
+
+    provider_response = payload.get("providerResponse")
+    provider_status = (
+        provider_response.get("httpStatus") if isinstance(provider_response, Mapping) else None
+    )
+    if isinstance(provider_status, int) and not isinstance(provider_status, bool):
+        if not 200 <= provider_status < 300:
+            status_code, transient = _status(provider_status)
+            raise ProviderRequestError(
+                f"octen_provider_http_{provider_status}",
+                status_code=status_code,
+                transient=transient,
+            )
+    else:
+        raise ProviderRequestError("octen_monid_invalid_response", transient=True)
+
+    output = payload.get("output")
+    if not isinstance(output, Mapping):
+        raise ProviderRequestError("octen_monid_invalid_response", transient=True)
+    code = output.get("code")
+    if code != 0:
+        status_code, transient = _status(code)
+        suffix = code if isinstance(code, int) and not isinstance(code, bool) else "unknown"
+        raise ProviderRequestError(
+            f"octen_api_{suffix}",
+            status_code=status_code,
+            transient=transient,
+        )
+    return payload
+
+
+def _string(value: Any) -> str:
+    return value if isinstance(value, str) else ""
+
+
+def _metadata(envelope: Mapping[str, Any], payload: Mapping[str, Any]) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    run_id = envelope.get("runId")
+    if isinstance(run_id, str) and run_id:
+        output["monid_run_id"] = run_id
+
+    request_id = payload.get("request_id")
+    if isinstance(request_id, str) and request_id:
+        output["request_id"] = request_id
+
+    meta = payload.get("meta")
+    if not isinstance(meta, Mapping):
+        return output
+    latency = meta.get("latency")
+    if isinstance(latency, (int, float)) and not isinstance(latency, bool):
+        output["latency_ms"] = latency
+
+    usage = meta.get("usage")
+    if isinstance(usage, Mapping):
+        projected_usage: dict[str, int] = {}
+        queries = usage.get("num_search_queries")
+        tokens = usage.get("full_content_tokens")
+        if isinstance(queries, int) and not isinstance(queries, bool) and queries >= 0:
+            projected_usage["search_queries"] = queries
+        if isinstance(tokens, int) and not isinstance(tokens, bool) and tokens >= 0:
+            projected_usage["full_content_tokens"] = tokens
+        if projected_usage:
+            output["usage"] = projected_usage
+
+    billing = envelope.get("billing")
+    actual_cost = billing.get("actualCost") if isinstance(billing, Mapping) else None
+    if isinstance(actual_cost, Mapping):
+        value = actual_cost.get("value")
+        if (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and actual_cost.get("unit") == "MICRO_DOLLAR"
+        ):
+            output["cost_usd"] = value / 1_000_000
+    return output
+
+
+def execute_search(search_module, prov, args, key, config, routing_info):
+    if not isinstance(key, str) or not key.strip():
+        raise ProviderConfigError("monid_api_key_required")
+
+    count = max(1, min(int(args.max_results), 100))
+    body: dict[str, Any] = {
+        "query": str(args.query),
+        "count": count,
+        # Octen also supports a news topic. WSP's public SDK does not yet expose
+        # native search-vertical metadata, so this first adapter stays truthful
+        # and uses general search even when a caller requests search_type=news.
+        "topic": "general",
+        "highlight": {"enable": True, "max_tokens": 300},
+        "full_content": {"enable": False},
+        "format": "text",
+    }
+    include_domains = _clean_domains(getattr(args, "include_domains", None))
+    exclude_domains = _clean_domains(getattr(args, "exclude_domains", None))
+    if include_domains:
+        body["include_domains"] = include_domains
+    if exclude_domains:
+        body["exclude_domains"] = exclude_domains
+
+    freshness = getattr(args, "freshness", None)
+    if freshness not in _FRESHNESS_VALUES:
+        freshness = getattr(args, "time_range", None)
+    if freshness in _FRESHNESS_VALUES:
+        body["time_range"] = freshness
+
+    envelope = _request(body, key.strip(), _timeout(config))
+    payload = envelope.get("output")
+    if not isinstance(payload, Mapping):
+        raise ProviderRequestError("octen_monid_invalid_response", transient=True)
+    data = payload.get("data")
+    raw_results = data.get("results") if isinstance(data, Mapping) else None
+    if not isinstance(raw_results, list):
+        raise ProviderRequestError("octen_invalid_response", transient=True)
+
+    projected = []
+    for item in raw_results[:count]:
+        if not isinstance(item, Mapping):
+            continue
+        url = _string(item.get("url")).strip()
+        if not url.startswith(("https://", "http://")):
+            continue
+        fields: dict[str, Any] = {
+            "title": _string(item.get("title")),
+            "snippet": _string(item.get("highlight")),
+        }
+        optional = {
+            "date": item.get("time_published"),
+            "author": item.get("authors"),
+            "favicon": item.get("favicon"),
+            "last_crawled": item.get("time_last_crawled"),
+        }
+        for field, value in optional.items():
+            if isinstance(value, str) and value:
+                fields[field] = value
+        projected.append(source_result(url, **fields))
+
+    return search_result(
+        prov,
+        str(args.query),
+        projected,
+        metadata=_metadata(envelope, payload),
+    )
+
+
+PROVIDER = register_provider(
+    ProviderSpec(
+        id="octen",
+        kind="search",
+        env_var="MONID_API_KEY",
+        display_name="Octen via Monid",
+        description="Explicit-only Octen source-result web search through Monid, with native recency and domain filtering.",
+        config_section="octen",
+        capability_labels=("search", "freshness"),
+        upstream_capabilities=("search", "highlights", "freshness", "domain-filtering"),
+        auto_allowed_by_default=False,
+        recommended=False,
+        supports_freshness=True,
+        free_tier="No free-tier claim; Monid API key and wallet balance required",
+        signup_url="https://app.monid.ai/access/api-keys",
+        execute_search=execute_search,
+    )
+)

--- a/providers.py
+++ b/providers.py
@@ -80,16 +80,41 @@ def normalize_freshness(value: Optional[str]) -> Optional[str]:
     return normalized
 
 
+def _sdk_provider_supports_freshness(provider: str) -> bool:
+    """Return a discovered provider's declared native freshness support.
+
+    The registry import stays lazy because provider discovery imports this
+    module during normal plugin startup. Built-ins continue to use the explicit
+    native-value table above; SDK providers use canonical WSP freshness values.
+    """
+    try:
+        from provider_registry import PROVIDER_SPECS
+
+        spec = PROVIDER_SPECS.get(provider)
+    except (ImportError, AttributeError):
+        return False
+    return bool(
+        spec is not None
+        and spec.execute_search is not None
+        and spec.supports_freshness
+    )
+
+
 def provider_supports_freshness(provider: str) -> bool:
     """Return whether a provider's current API call can apply a freshness filter."""
-    return provider in PROVIDER_FRESHNESS_FORMATS
+    return provider in PROVIDER_FRESHNESS_FORMATS or _sdk_provider_supports_freshness(provider)
 
 
 def map_freshness_for_provider(provider: str, freshness: Optional[str]) -> Optional[str]:
     """Translate the unified freshness value into the provider's native format."""
     if not freshness:
         return None
-    return PROVIDER_FRESHNESS_FORMATS.get(provider, {}).get(freshness)
+    native = PROVIDER_FRESHNESS_FORMATS.get(provider, {}).get(freshness)
+    if native is not None:
+        return native
+    if freshness in FRESHNESS_VALUES and _sdk_provider_supports_freshness(provider):
+        return freshness
+    return None
 
 
 def freshness_metadata(provider: str, requested: str) -> Dict[str, Any]:

--- a/tests/providers_d/test_octen_provider.py
+++ b/tests/providers_d/test_octen_provider.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from urllib.error import HTTPError
+from urllib.request import Request
+
+import pytest
+
+import provider_registry
+import providers
+from http_client import ProviderRequestError
+
+
+class FakeResponse:
+    def __init__(self, payload, *, raw: bytes | None = None):
+        self._raw = raw if raw is not None else json.dumps(payload).encode("utf-8")
+        self.headers = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, size=-1):
+        return self._raw if size < 0 else self._raw[:size]
+
+
+def _provider_globals():
+    spec = provider_registry.PROVIDER_SPECS["octen"]
+    return spec, spec.execute_search.__globals__
+
+
+def _args(**overrides):
+    values = {
+        "query": "octen contract query",
+        "max_results": 3,
+        "freshness": "week",
+        "time_range": None,
+        "include_domains": ["docs.python.org"],
+        "exclude_domains": ["spam.example"],
+        "search_type": "search",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_octen_registers_as_explicit_only_search_provider():
+    spec = provider_registry.PROVIDER_SPECS["octen"]
+
+    assert spec.kind == "search"
+    assert spec.env_var == "MONID_API_KEY"
+    assert spec.display_name == "Octen via Monid"
+    assert spec.keyless is False
+    assert spec.auto_allowed_by_default is False
+    assert spec.supports_freshness is True
+    assert spec.free_tier == "No free-tier claim; Monid API key and wallet balance required"
+    assert spec.capability_labels == ("search", "freshness")
+    assert spec.upstream_capabilities == ("search", "highlights", "freshness", "domain-filtering")
+    assert spec.execute_search is not None
+    assert "octen" in provider_registry.SEARCH_PROVIDER_IDS
+    assert "octen" not in provider_registry.EXTRACT_PROVIDER_IDS
+    assert "octen" not in provider_registry.DEFAULT_PROVIDER_PRIORITY
+    assert provider_registry.DEFAULT_AUTO_ALLOW["octen"] is False
+
+
+def test_octen_refuses_redirects_to_keep_credentials_on_the_fixed_origin():
+    _spec, module = _provider_globals()
+    request = Request("https://api.monid.ai/v1/run")
+
+    redirected = module["_NoRedirectHandler"]().redirect_request(
+        request,
+        None,
+        302,
+        "Found",
+        {},
+        "https://attacker.example/collect",
+    )
+
+    assert redirected is None
+
+
+def test_sdk_freshness_capability_drives_truthful_metadata():
+    assert providers.provider_supports_freshness("octen") is True
+    assert providers.map_freshness_for_provider("octen", "week") == "week"
+    assert providers.freshness_metadata("octen", "week") == {
+        "requested": "week",
+        "applied": True,
+        "provider": "octen",
+        "native_value": "week",
+    }
+
+
+def test_octen_projects_request_and_source_only_response(monkeypatch):
+    spec, module = _provider_globals()
+    captured = {}
+
+    def fake_open(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return FakeResponse(
+            {
+                "runId": "run-safe-id",
+                "provider": "octen",
+                "endpoint": "/search",
+                "status": "COMPLETED",
+                "providerResponse": {"httpStatus": 200},
+                "billing": {
+                    "actualCost": {"value": 1000, "unit": "MICRO_DOLLAR", "currency": "USD"}
+                },
+                "output": {
+                    "code": 0,
+                    "msg": "success",
+                    "request_id": "req-safe-id",
+                    "data": {
+                        "query": "octen contract query",
+                        "results": [
+                            {
+                                "title": "Python docs",
+                                "url": "https://docs.python.org/3/",
+                                "highlight": "Official Python documentation.",
+                                "authors": "Python Software Foundation",
+                                "time_published": "2026-01-02T03:04:05Z",
+                                "time_last_crawled": "2026-07-27T03:04:05Z",
+                                "favicon": "https://docs.python.org/favicon.ico",
+                            },
+                            {"title": "Missing URL", "highlight": "must be dropped"},
+                        ],
+                    },
+                    "meta": {
+                        "usage": {"num_search_queries": 1, "full_content_tokens": 0},
+                        "latency": 64,
+                        "warning": None,
+                    },
+                },
+            }
+        )
+
+    monkeypatch.setitem(module, "_open_request", fake_open)
+    result = spec.execute_search(
+        None,
+        "octen",
+        _args(),
+        "monid-test-key",
+        {"octen": {"timeout": 17}},
+        {},
+    )
+
+    request = captured["request"]
+    body = json.loads(request.data.decode("utf-8"))
+    assert request.full_url == "https://api.monid.ai/v1/run"
+    assert request.get_method() == "POST"
+    assert request.headers["Authorization"] == "Bearer monid-test-key"
+    assert request.headers["Content-type"] == "application/json"
+    assert captured["timeout"] == 17
+    assert body == {
+        "provider": "octen",
+        "endpoint": "/search",
+        "input": {
+            "query": "octen contract query",
+            "count": 3,
+            "topic": "general",
+            "include_domains": ["docs.python.org"],
+            "exclude_domains": ["spam.example"],
+            "time_range": "week",
+            "highlight": {"enable": True, "max_tokens": 300},
+            "full_content": {"enable": False},
+            "format": "text",
+        },
+    }
+
+    assert result == {
+        "provider": "octen",
+        "query": "octen contract query",
+        "results": [
+            {
+                "url": "https://docs.python.org/3/",
+                "title": "Python docs",
+                "snippet": "Official Python documentation.",
+                "date": "2026-01-02T03:04:05Z",
+                "author": "Python Software Foundation",
+                "favicon": "https://docs.python.org/favicon.ico",
+                "last_crawled": "2026-07-27T03:04:05Z",
+            }
+        ],
+        "images": [],
+        "metadata": {
+            "monid_run_id": "run-safe-id",
+            "request_id": "req-safe-id",
+            "latency_ms": 64,
+            "usage": {"search_queries": 1, "full_content_tokens": 0},
+            "cost_usd": 0.001,
+        },
+    }
+
+
+def test_octen_does_not_claim_news_vertical_support(monkeypatch):
+    spec, module = _provider_globals()
+    captured = {}
+
+    def fake_open(request, timeout):
+        captured["body"] = json.loads(request.data.decode("utf-8"))
+        return FakeResponse(
+            {
+                "runId": "run-news",
+                "provider": "octen",
+                "endpoint": "/search",
+                "status": "COMPLETED",
+                "providerResponse": {"httpStatus": 200},
+                "output": {
+                    "code": 0,
+                    "msg": "success",
+                    "data": {"query": "news", "results": []},
+                    "meta": {"usage": {}, "latency": 10},
+                },
+            }
+        )
+
+    monkeypatch.setitem(module, "_open_request", fake_open)
+    spec.execute_search(None, "octen", _args(query="news", search_type="news"), "key", {}, {})
+
+    assert captured["body"]["input"]["topic"] == "general"
+
+
+@pytest.mark.parametrize(
+    "upstream_status,expected_status,transient",
+    [(401, 401, False), (402, 402, False), (403, 403, False), (429, 429, True), (503, 503, True)],
+)
+def test_octen_classifies_http_failures_without_leaking_upstream_text(
+    monkeypatch, upstream_status, expected_status, transient
+):
+    spec, module = _provider_globals()
+
+    def fake_open(request, timeout):
+        raise HTTPError(
+            request.full_url,
+            upstream_status,
+            "secret upstream detail",
+            {"Retry-After": "2"},
+            None,
+        )
+
+    monkeypatch.setitem(module, "_open_request", fake_open)
+    with pytest.raises(ProviderRequestError) as caught:
+        spec.execute_search(None, "octen", _args(), "key", {}, {})
+
+    assert caught.value.status_code == expected_status
+    assert caught.value.transient is transient
+    assert caught.value.retry_after == (2.0 if upstream_status == 429 else None)
+    assert "secret upstream detail" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "payload,expected_status,transient",
+    [
+        ({"status": "FAILED", "provider": "octen", "endpoint": "/search"}, 500, True),
+        (
+            {
+                "status": "COMPLETED",
+                "provider": "octen",
+                "endpoint": "/search",
+                "providerResponse": {"httpStatus": 429, "error": {"message": "private rate-limit detail"}},
+                "output": None,
+            },
+            429,
+            True,
+        ),
+        (
+            {
+                "status": "COMPLETED",
+                "provider": "octen",
+                "endpoint": "/search",
+                "providerResponse": {"httpStatus": 500, "error": {"message": "private backend detail"}},
+                "output": None,
+            },
+            500,
+            True,
+        ),
+    ],
+)
+def test_octen_classifies_monid_and_provider_failures_without_leaking_message(
+    monkeypatch, payload, expected_status, transient
+):
+    spec, module = _provider_globals()
+    monkeypatch.setitem(module, "_open_request", lambda *_args: FakeResponse(payload))
+
+    with pytest.raises(ProviderRequestError) as caught:
+        spec.execute_search(None, "octen", _args(), "key", {}, {})
+
+    assert caught.value.status_code == expected_status
+    assert caught.value.transient is transient
+    assert "private" not in str(caught.value)
+
+
+def test_octen_rejects_confused_or_async_monid_envelopes(monkeypatch):
+    spec, module = _provider_globals()
+    bad_payloads = [
+        {"status": "RUNNING", "provider": "octen", "endpoint": "/search"},
+        {"status": "COMPLETED", "provider": "other", "endpoint": "/search"},
+        {"status": "COMPLETED", "provider": "octen", "endpoint": "/other"},
+    ]
+    for payload in bad_payloads:
+        monkeypatch.setitem(module, "_open_request", lambda *_args, p=payload: FakeResponse(p))
+        with pytest.raises(ProviderRequestError):
+            spec.execute_search(None, "octen", _args(), "key", {}, {})
+
+
+def test_octen_rejects_invalid_or_oversized_responses(monkeypatch):
+    spec, module = _provider_globals()
+
+    monkeypatch.setitem(module, "_open_request", lambda *_args: FakeResponse({}, raw=b"not-json"))
+    with pytest.raises(ProviderRequestError, match="^octen_invalid_response$"):
+        spec.execute_search(None, "octen", _args(), "key", {}, {})
+
+    oversized = b"{" + b"x" * (module["_MAX_RESPONSE_BYTES"] + 1)
+    monkeypatch.setitem(module, "_open_request", lambda *_args: FakeResponse({}, raw=oversized))
+    with pytest.raises(ProviderRequestError, match="^octen_response_too_large$"):
+        spec.execute_search(None, "octen", _args(), "key", {}, {})

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -263,7 +263,7 @@ def test_setup_dry_run_uses_target_env_path_for_dashboard(tmp_path, monkeypatch,
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "Providers: 1/15 configured" in out
+    assert "Providers: 1/16 configured" in out
     assert "Active: You.com" in out
     assert "Brave Search" not in out.split("Setup plan:", 1)[0]
 
@@ -279,7 +279,7 @@ def test_status_uses_target_env_path_for_dashboard(tmp_path, monkeypatch, capsys
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "Providers: 1/15 configured" in out
+    assert "Providers: 1/16 configured" in out
     assert "Active: Linkup" in out
     assert "Brave Search" not in out
 
@@ -422,7 +422,7 @@ def test_setup_dry_run_can_auto_deny_provider(tmp_path, capsys):
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "auto-allow false: hound, parallel, querit, serpbase" in out
+    assert "auto-allow false: hound, octen, parallel, querit, serpbase" in out
     assert not env_path.exists()
     assert not config_path.exists()
 

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -21,7 +21,7 @@ def test_provider_registry_is_the_complete_capability_source():
         "searxng",
         "keenable",
     )
-    assert registry.SEARCH_PROVIDER_IDS[-1] == "hound"
+    assert registry.SEARCH_PROVIDER_IDS[-2:] == ("hound", "octen")
     assert registry.EXTRACT_PROVIDER_IDS == (
         "tavily", "exa", "linkup", "parallel", "firecrawl", "you", "keenable", "serper", "hound"
     )
@@ -41,6 +41,7 @@ def test_provider_registry_is_the_complete_capability_source():
         "querit": False,
         "parallel": False,
         "hound": False,
+        "octen": False,
     }
     assert "research" in registry.PROVIDER_SPECS["tavily"].capability_labels
 

--- a/tests/test_routing_v2.py
+++ b/tests/test_routing_v2.py
@@ -23,7 +23,10 @@ def test_default_auto_allow_blocks_explicit_only_providers():
     assert auto_allow["serpbase"] is False
     assert auto_allow["querit"] is False
     assert auto_allow["parallel"] is False
+    assert auto_allow["hound"] is False
+    assert auto_allow["octen"] is False
     assert auto_allow.get("brave", True) is True
+    assert set(auto_allow) == {"serpbase", "querit", "parallel", "hound", "octen"}
 
 
 
@@ -35,6 +38,11 @@ def test_legacy_auto_allow_config_inherits_new_guarded_provider_defaults():
 
     assert validated["auto_routing"]["auto_allow"].get("brave", True) is True
     assert validated["auto_routing"]["auto_allow"]["parallel"] is False
+    assert validated["auto_routing"]["auto_allow"]["hound"] is False
+    assert validated["auto_routing"]["auto_allow"]["octen"] is False
+    assert set(validated["auto_routing"]["auto_allow"]) == {
+        "serpbase", "querit", "parallel", "hound", "octen",
+    }
 
 
 


### PR DESCRIPTION
## Summary

- add Octen via Monid as a bundled Search provider through the public `providers.d` SDK
- execute Octen's `/search` endpoint through Monid's documented `POST /v1/run` API with native freshness and include/exclude-domain filters
- keep the provider explicit-only with `auto_allow=false`; it does not enter default routing or fallback
- keep answer, Broad Search, news-vertical, extraction, image/video, and full-content modes outside this integration
- make discovered providers' `ProviderSpec.supports_freshness` declaration drive truthful freshness metadata

## Safety and cost controls

- send credentials only to Monid's fixed HTTPS API origin and reject redirects
- cap response bodies at 8 MiB
- sanitize upstream error text and keep Monid lifecycle failures separate from Octen provider HTTP failures
- request highlights for source snippets while explicitly setting `full_content.enable=false`
- preserve upstream ranking order without inventing a provider relevance score

## Public surface

- document `MONID_API_KEY`, Monid's role, and explicit provider selection
- update the generated provider reference, plugin manifest, onboarding counts, and guarded-provider defaults
- avoid static pricing, quality, latency, partnership, or endorsement claims; current access terms remain linked to Monid

## Validation

- `ruff check --config ruff.toml .`
- `python -m pytest tests/ -q` — **961 passed, 6 subtests passed**
- `python scripts/gen_provider_docs.py --check`
- `python scripts/gen_contract_v3_schemas.py --check`
- `node tests/schema_boundary_v3.mjs`
- `git diff --check`
- provider module is byte-identical to the portable MCP counterpart

## Live-test note

A live HTTP smoke against Monid's documented `POST /v1/run` endpoint completed synchronously with `provider=octen`, Octen provider HTTP status 200, and three source results. Credentials and result contents are not included in this PR.