### PR TITLE
chore(release): Web Search Plus 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v3.4.0] — 2026-07-28
+
 ### ✨ Added
 - Added Octen via Monid as a bundled, source-only Search provider through the public Provider SDK. The adapter supports native freshness plus include/exclude-domain filters and remains explicit-only by default (`auto_allow=false`).
 
@@ -14,6 +16,12 @@
 
 ### 📚 Docs
 - Added a repository-specific contribution guide covering local setup, the source-only provider contract, SDK-based provider intake, CI and generated-artifact gates, changelog hygiene, security reporting, and maintainer-only release boundaries.
+- Rewrote the README introduction in plain product language and added dedicated 3.4 release notes covering Octen-via-Monid behavior, access and billing, security boundaries, and compatibility.
+
+### Release inventory
+- #110 — plain-language README introduction.
+- #112 — repository contribution guide.
+- #113 — explicit Octen source search via Monid.
 
 ## [v3.3.0] — 2026-07-24
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ It adds two Hermes tools:
 
 > Ported from [web-search-plus-plugin](https://github.com/robbyczgw-cla/web-search-plus-plugin) for the [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin API.
 
-Current release: **v3.3.0** — see the [Changelog](CHANGELOG.md) and [3.3 Release Notes](docs/RELEASE_NOTES_V33.md).
+Current release: **v3.4.0** — see the [Changelog](CHANGELOG.md) and [3.4 Release Notes](docs/RELEASE_NOTES_V34.md).
 
-### What's new in 3.3
+### What's new in 3.4
 
-Version 3.3 keeps more useful text when reading pages, combines supporting details more carefully, and can finish broad research sooner when it already has enough good sources. The tools and normal setup stay the same.
+Version 3.4 adds an optional Octen web-search connection through Monid. It is off by default and only runs when you select it explicitly. Existing tools, provider settings, and automatic routing stay the same.
 
-For the technical details, see the [3.3 Release Notes](docs/RELEASE_NOTES_V33.md).
+For the technical details, see the [3.4 Release Notes](docs/RELEASE_NOTES_V34.md).
 
 ---
 
@@ -38,7 +38,7 @@ For the technical details, see the [3.3 Release Notes](docs/RELEASE_NOTES_V33.md
 - **Optional details when you need them.** Quality reports show which service worked and what happened along the way.
 - **Local options are available.** SearXNG, Keenable and the optional Hound connection can reduce your dependence on paid APIs.
 
-Everything new since 3.0 is additive or opt-in; defaults stay stable across upgrades. Full details: [3.3 Release Notes](docs/RELEASE_NOTES_V33.md) · [3.2 Release Notes](docs/RELEASE_NOTES_V32.md) · [3.1 Release Notes](docs/RELEASE_NOTES_V31.md) · [3.0 Release Notes](docs/RELEASE_NOTES_V3.md).
+Everything new since 3.0 is additive or opt-in; defaults stay stable across upgrades. Full details: [3.4 Release Notes](docs/RELEASE_NOTES_V34.md) · [3.3 Release Notes](docs/RELEASE_NOTES_V33.md) · [3.2 Release Notes](docs/RELEASE_NOTES_V32.md) · [3.1 Release Notes](docs/RELEASE_NOTES_V31.md) · [3.0 Release Notes](docs/RELEASE_NOTES_V3.md).
 
 ---
 
@@ -143,7 +143,7 @@ Full parameters, freshness and locale behavior, provider selection, extraction c
 
 - **Installing or configuring providers** → [User Guide](docs/USER_GUIDE.md) · [Hound local provider](docs/HOUND.md)
 - **Upgrading from 2.x** → [3.0 Migration](docs/V3_MIGRATION.md), then [3.1 Migration](docs/V31_MIGRATION.md)
-- **What changed** → [Changelog](CHANGELOG.md) · [3.3 Release Notes](docs/RELEASE_NOTES_V33.md)
+- **What changed** → [Changelog](CHANGELOG.md) · [3.4 Release Notes](docs/RELEASE_NOTES_V34.md)
 - **Troubleshooting** → [FAQ](docs/FAQ.md) · [Operator Console](docs/V3_OPERATOR_CONSOLE.md)
 - **Contributing or building a provider** → [Contributing](CONTRIBUTING.md) · [Provider SDK](docs/PROVIDER_SDK.md) · [Architecture](docs/ARCHITECTURE.md)
 
@@ -152,6 +152,7 @@ The full reference, including the normative v3 contracts for implementers and re
 ### Start & upgrade
 
 - [User Guide](docs/USER_GUIDE.md) — installation, first-run checks, tool usage, and troubleshooting
+- [3.4 Release Notes](docs/RELEASE_NOTES_V34.md) — optional Octen source search via Monid, access/billing, security, and compatibility
 - [3.3 Release Notes](docs/RELEASE_NOTES_V33.md) — heading-aware spans, provenance enrichment, Research quorum, compatibility, and attribution
 - [3.2 Release Notes](docs/RELEASE_NOTES_V32.md) — local Hound integration, keyless trade-offs, compatibility, and attribution
 - [Hound local provider](docs/HOUND.md) — separate installation, loopback service, verification, privacy, and operating costs

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v3.3.0
+web-search-plus — Hermes Plugin v3.4.0
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"
 
 import argparse
 import getpass

--- a/docs/RELEASE_NOTES_V34.md
+++ b/docs/RELEASE_NOTES_V34.md
@@ -1,0 +1,79 @@
+# Web Search Plus 3.4 — Release Notes
+
+Web Search Plus 3.4 adds Octen as an optional source-search provider through
+Monid. Octen is off by default and runs only when explicitly selected; existing
+provider configuration and automatic routing remain unchanged.
+
+## Optional Octen source search via Monid
+
+Set `MONID_API_KEY` from [Monid](https://app.monid.ai/access/api-keys), then
+request the provider explicitly:
+
+```python
+web_search_plus(
+    query="recent vector database research",
+    provider="octen",
+    freshness="month",
+)
+```
+
+The adapter calls Octen's `/search` endpoint through Monid's documented API and
+returns ranked source links and highlights. It supports canonical freshness and
+include/exclude-domain filters.
+
+The integration deliberately does **not** call Octen's answer, Broad Search,
+image/video, or full-content modes. `full_content` is disabled, and Octen never
+enters automatic routing or fallback unless an operator deliberately changes
+its `auto_allow` setting.
+
+## Access, billing, and limits
+
+Octen supplies the search results; Monid provides API access and billing.
+Access and billing use Monid's prepaid wallet; see Monid for current pricing and
+terms. No free-tier claim is made: a Monid API key and wallet balance are
+required.
+
+## Security and failure handling
+
+- Credentials are sent only to Monid's fixed HTTPS API origin.
+- Redirects are rejected so credentials cannot cross origins.
+- Response bodies are capped at 8 MiB.
+- Upstream failures are sanitized and classified without exposing credentials
+  or raw private payloads.
+- Monid lifecycle failures remain distinguishable from Octen provider HTTP
+  failures.
+
+## Provider SDK correctness
+
+Discovered Provider SDK search providers now honor
+`ProviderSpec.supports_freshness`. When a provider successfully applies a
+canonical freshness filter, the public metadata no longer reports that filter
+as unsupported.
+
+## Documentation since 3.3
+
+The README opening now explains the product in plain user language, and the
+repository includes a dedicated contribution guide covering setup, source-only
+provider contracts, Provider SDK intake, generated-artifact checks, security
+reporting, and maintainer-only release boundaries.
+
+## Compatibility
+
+- No Hermes tool is renamed or removed.
+- Existing provider keys and automatic-routing defaults remain valid.
+- Octen is additive, optional, explicit-only, and source-only.
+- Existing result fields remain stable.
+
+## Release inventory
+
+- [#110](https://github.com/robbyczgw-cla/hermes-web-search-plus/pull/110) — plain-language README introduction.
+- [#112](https://github.com/robbyczgw-cla/hermes-web-search-plus/pull/112) — repository contribution guide.
+- [#113](https://github.com/robbyczgw-cla/hermes-web-search-plus/pull/113) — explicit Octen source search via Monid.
+
+## Upgrade
+
+```bash
+hermes plugins update web-search-plus
+```
+
+Reload Hermes after updating so the registered plugin tools use the new code.

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/3.3.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/3.4.0"
 
 
 class ProviderRequestError(Exception):

--- a/operator_console_v3.py
+++ b/operator_console_v3.py
@@ -532,7 +532,7 @@ def build_overview(
     config: Mapping[str, Any] | None = None,
     provider_ids: Sequence[str] | None = None,
     state_path: str | Path | None = None,
-    plugin_version: str = "3.3.0",
+    plugin_version: str = "3.4.0",
     now: Callable[[], float] = time.time,
 ) -> dict[str, Any]:
     root = Path(cache_root)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "3.3.0"
+version: "3.4.0"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 3.3.0
+Version: 3.4.0
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable, Serper.

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "3.3.0"
+EXPECTED_VERSION = "3.4.0"
 
 
 def _load_plugin_module():
@@ -54,15 +54,19 @@ def test_ci_ruff_policy_is_repo_local_and_pinned():
     assert "ruff==0.15.12" in requirements
 
 
-def test_v33_release_surfaces_preserve_upstream_attribution():
+def test_current_release_surfaces_and_attribution():
     readme = (ROOT / "README.md").read_text()
     changelog = (ROOT / "CHANGELOG.md").read_text()
-    release_notes = (ROOT / "docs/RELEASE_NOTES_V33.md").read_text()
+    release_notes = (ROOT / "docs/RELEASE_NOTES_V34.md").read_text()
     user_guide = (ROOT / "docs/USER_GUIDE.md").read_text()
     combined = "\n".join((readme, changelog, release_notes, user_guide))
 
-    assert "Current release: **v3.3.0**" in readme
-    assert "docs/RELEASE_NOTES_V33.md" in readme
+    assert "Current release: **v3.4.0**" in readme
+    assert "docs/RELEASE_NOTES_V34.md" in readme
+    assert "Octen" in release_notes
+    assert "Monid" in release_notes
+    assert "explicit" in release_notes
+    assert "No free-tier claim" in release_notes
     assert "https://github.com/dondai1234/master-fetch" in combined
     assert "Bishesh Bhandari" in combined
     assert "MIT-licensed" in combined or "MIT project" in combined

--- a/ui.py
+++ b/ui.py
@@ -434,7 +434,7 @@ def create_server(
     cache_root: str | Path = CACHE_DIR,
     state_path: str | Path | None = None,
     config: Mapping[str, Any] | None = None,
-    plugin_version: str = "3.3.0",
+    plugin_version: str = "3.4.0",
     snapshot_backend: Any = operator_console_v3,
     static_root: str | Path | None = None,
 ) -> ThreadingHTTPServer:


### PR DESCRIPTION
## Summary

Release Web Search Plus 3.4.0 from the merged `main` candidate.

- publishes the explicit-only, source-only Octen provider through Monid from #113
- documents Monid access/billing and the no-free-tier claim accurately
- includes the Provider SDK freshness reporting fix
- carries forward the plain-language README from #110 and the contribution guide from #112
- updates every runtime version surface, README current-release links, changelog, and dedicated 3.4 release notes

## Release inventory

- #110 — plain-language README introduction
- #112 — repository contribution guide
- #113 — explicit Octen source search via Monid

## Verification

- `961 passed, 6 subtests passed`
- `ruff check --config ruff.toml .`
- provider docs drift check
- contract v3 schema drift check
- AJV schema boundary
- `python3 -m compileall -q .`
- `git diff --check`
- public release-copy and attribution assertions

## Compatibility

No Hermes tool or existing provider behavior is removed. Octen remains additive, explicit-only, source-only, and outside automatic routing/fallback by default.
