### PR TITLE
feat(provider): add explicit-only TinyFish Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### ✨ Added
 - Exa now applies the unified `freshness` filter (`day`, `week`, `month`, `year`) by translating it into absolute UTC `startPublishedDate`/`endPublishedDate` bounds on `/search` and `/findSimilar`. Result metadata reports the applied date range instead of the unified token. Contributed by [@kesku](https://github.com/kesku) in [#111](https://github.com/robbyczgw-cla/hermes-web-search-plus/pull/111).
+- Added TinyFish as a bundled source-only Search provider. The adapter supports native news, freshness, locale, and domain filters and remains explicit-only by default (`auto_allow=false`).
+
+### 🔒 Security and privacy
+- TinyFish requests are restricted to its fixed HTTPS Search API origin, reject redirects, cap response bodies at 2 MiB, and never use the optional `purpose`, `fetch`, Agent, or Browser paths.
+- Document TinyFish's standard-Terms training/fine-tuning allowance in the provider metadata and README instead of presenting explicit-only routing as a privacy control.
+- Link the repository to the maintained provider-by-provider Privacy & Terms guide on websearchplus.xyz.
 
 ## [v3.4.0] — 2026-07-28
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ cd ~/.hermes/plugins/web-search-plus
 python3 search.py --query "Hermes Agent latest release" --provider auto --quality-report
 ```
 
-Web Search Plus supports 14 search and 9 extraction providers — you do **not** need them all. One search-capable key or configured local endpoint enables `web_search_plus`; one extraction-capable key or endpoint enables `web_extract_plus`; more providers just make controlled routing more flexible. The setup helper stores keys in the active Hermes environment file — never commit them to the repository.
+Web Search Plus supports 15 search and 9 extraction providers — you do **not** need them all. One search-capable key or configured local endpoint enables `web_search_plus`; one extraction-capable key or endpoint enables `web_extract_plus`; more providers just make controlled routing more flexible. The setup helper stores keys in the active Hermes environment file — never commit them to the repository.
+
+Provider privacy is not uniform. Before sending sensitive queries or URLs, review the maintained [Provider Privacy & Terms guide](https://websearchplus.xyz/providers.html#privacy-terms), which distinguishes standard self-serve terms from enterprise-only ZDR or no-training options.
 
 ### Upgrading from 2.x? Relax.
 
@@ -96,6 +98,16 @@ web_search_plus(query="recent vector database research", provider="octen", fresh
 ```
 
 The adapter executes Octen's `/search` endpoint through Monid's documented HTTP API for ranked links and highlights. It supports freshness and domain filters, explicitly disables full-content retrieval, and does not call Octen's answer or Broad Search APIs. Access and billing use Monid's prepaid wallet; see Monid for current pricing and terms. Octen stays outside automatic routing and fallback unless you deliberately enable `auto_allow`.
+
+### Optional TinyFish source search
+
+Set `TINYFISH_API_KEY` from your own [TinyFish account](https://agent.tinyfish.ai/api-keys) to use its direct Search API explicitly. Web Search Plus does not provide, pool, proxy, or share TinyFish credentials.
+
+```python
+web_search_plus(query="recent agent framework releases", provider="tinyfish", freshness="week")
+```
+
+The adapter calls only TinyFish's fixed source-search endpoint and returns ranked links and snippets. It never sends the optional `purpose` or `fetch` parameters and does not call TinyFish Agent or Browser APIs. Domain filters and result hosts are accepted only as ASCII/Punycode hostnames; raw Unicode hostnames are rejected fail-closed. TinyFish remains outside automatic routing and fallback: its [standard Terms](https://www.tinyfish.ai/terms) permit Customer Data to be used for model training and fine-tuning, and its [Privacy Policy](https://www.tinyfish.ai/privacy-policy) does not provide a fixed deletion period. Treat the integration as high risk unless your contract supplies stronger terms; see the [provider/privacy matrix](https://websearchplus.xyz/providers.html#privacy-terms).
 
 ### Local Hound provider
 
@@ -142,6 +154,7 @@ Full parameters, freshness and locale behavior, provider selection, extraction c
 **Where to go next:**
 
 - **Installing or configuring providers** → [User Guide](docs/USER_GUIDE.md) · [Hound local provider](docs/HOUND.md)
+- **Comparing provider privacy and terms** → [Provider Privacy & Terms](https://websearchplus.xyz/providers.html#privacy-terms)
 - **Upgrading from 2.x** → [3.0 Migration](docs/V3_MIGRATION.md), then [3.1 Migration](docs/V31_MIGRATION.md)
 - **What changed** → [Changelog](CHANGELOG.md) · [3.4 Release Notes](docs/RELEASE_NOTES_V34.md)
 - **Troubleshooting** → [FAQ](docs/FAQ.md) · [Operator Console](docs/V3_OPERATOR_CONSOLE.md)
@@ -166,6 +179,7 @@ The full reference, including the normative v3 contracts for implementers and re
 ### Configure & operate
 
 - [Provider Reference](docs/PROVIDERS.md) — generated capabilities, environment variables, defaults, and signup links
+- [Provider Privacy & Terms](https://websearchplus.xyz/providers.html#privacy-terms) — provider-specific training, retention, ZDR, and contract caveats
 - [Routing v2 Reference](docs/ROUTING.md) — generated routing classes, preferences, and demotions
 - [Operator Console](docs/V3_OPERATOR_CONSOLE.md) — local read-only visibility and troubleshooting
 - [Provider Benchmarks](docs/V3_BENCHMARKS.md) — search and extraction comparison with privacy and quota guidance

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -25,6 +25,7 @@ and the plugin provider catalog; regenerate it with `python scripts/gen_provider
 | Keenable | ✅ | ✅ | `KEENABLE_API_KEY` | yes (`KEENABLE_ALLOW_PUBLIC` opt-in) | yes (priority 12) | Keyless public tier; optional key for higher limits | https://keenable.ai |
 | Hound (local MCP) | ✅ | ✅ | `HOUND_MCP_URL` | — | explicit-only (`auto_allow=false`) | Free local sidecar; no API key | https://github.com/dondai1234/master-fetch |
 | Octen via Monid | ✅ | — | `MONID_API_KEY` | — | explicit-only (`auto_allow=false`) | No free-tier claim; Monid API key and wallet balance required | https://app.monid.ai/access/api-keys |
+| TinyFish Search | ✅ | — | `TINYFISH_API_KEY` | — | explicit-only (`auto_allow=false`) | Search does not consume credits; API access required (30 rpm Free/PAYG) | https://agent.tinyfish.ai/api-keys |
 
 `priority N` is the provider's position in the default routing priority list.
 Providers marked explicit-only stay out of `provider="auto"` routing and fallback
@@ -101,3 +102,7 @@ Local key-free metasearch and browser-backed extraction through a loopback Hound
 ### Octen via Monid
 
 Explicit-only Octen source-result web search through Monid, with native recency and domain filtering.
+
+### TinyFish Search
+
+Direct source-only TinyFish web/news search using your own account/API key. WSP does not provide, pool, proxy, or share TinyFish credentials. Domain filters and result hosts are accepted only as ASCII/Punycode hostnames. Privacy warning: TinyFish's standard Terms permit Customer Data to be used for model training and fine-tuning; review https://www.tinyfish.ai/terms and https://www.tinyfish.ai/privacy-policy before use. Explicit-only by default.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -18,6 +18,7 @@ optional_env:
   - KEENABLE_API_KEY
   - HOUND_MCP_URL
   - MONID_API_KEY
+  - TINYFISH_API_KEY
 provides_tools:
   - web_search_plus
   - web_extract_plus

--- a/providers.d/tinyfish.py
+++ b/providers.d/tinyfish.py
@@ -1,0 +1,410 @@
+"""Explicit-only TinyFish source-search provider for Web Search Plus.
+
+The adapter calls TinyFish's fixed Search API origin and projects structured
+ranked sources only. It deliberately omits purpose, fetch, Agent, Browser, and
+other content-expanding modes. TinyFish remains explicit-only because its
+standard Terms permit Customer Data to be used for model training/fine-tuning.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import socket
+import unicodedata
+from collections.abc import Mapping
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+from wsp_sdk import (
+    ProviderConfigError,
+    ProviderRequestError,
+    ProviderSpec,
+    register_provider,
+    search_result,
+    source_result,
+)
+
+_API_URL = "https://api.search.tinyfish.ai/"
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_QUERY_CHARS = 2_000
+_MAX_DOMAIN_COUNT = 20
+_MAX_DOMAIN_CHARS = 253
+_MAX_DOMAIN_LIST_CHARS = 2_048
+_MAX_REQUEST_URL_CHARS = 8_192
+_MAX_URL_CHARS = 8_192
+_MAX_TITLE_CHARS = 1_000
+_MAX_SNIPPET_CHARS = 8_000
+_TRANSIENT_STATUS = {429, 500, 503}
+_FRESHNESS_MINUTES = {
+    "day": 24 * 60,
+    "week": 7 * 24 * 60,
+    "month": 30 * 24 * 60,
+    "year": 365 * 24 * 60,
+}
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Keep the API key on TinyFish's fixed Search API origin."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+_OPENER = build_opener(_NoRedirectHandler())
+
+
+def _open_request(request: Request, timeout: int):
+    return _OPENER.open(request, timeout=timeout)
+
+
+def _timeout(config: Mapping[str, Any]) -> int:
+    section = config.get("tinyfish", {})
+    raw = section.get("timeout", 30) if isinstance(section, Mapping) else 30
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        raise ProviderConfigError("tinyfish_timeout_invalid") from None
+    if not 1 <= value <= 120:
+        raise ProviderConfigError("tinyfish_timeout_invalid")
+    return value
+
+
+def _canonical_hostname(hostname: str) -> str:
+    if (
+        not hostname
+        or hostname.endswith("..")
+        or any(
+            character.isspace() or unicodedata.category(character).startswith("C")
+            for character in hostname
+        )
+    ):
+        return ""
+    token = hostname[:-1] if hostname.endswith(".") else hostname
+    if not token.isascii():
+        return ""
+    canonical = token.lower()
+    labels = canonical.split(".")
+    if (
+        not canonical
+        or len(canonical) > _MAX_DOMAIN_CHARS
+        or len(labels) < 2
+        or any(
+            not re.fullmatch(r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?", label)
+            for label in labels
+        )
+    ):
+        return ""
+    return canonical
+
+
+def _clean_domains(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple)):
+        return []
+    if len(value) > _MAX_DOMAIN_COUNT:
+        raise ProviderConfigError("tinyfish_domains_invalid")
+
+    raw_items: list[str] = []
+    for item in value:
+        if (
+            not isinstance(item, str)
+            or not item
+            or any(
+                character.isspace()
+                or unicodedata.category(character).startswith("C")
+                for character in item
+            )
+        ):
+            raise ProviderConfigError("tinyfish_domains_invalid")
+        has_root_dot = item.endswith(".")
+        if len(item) > _MAX_DOMAIN_CHARS + (1 if has_root_dot else 0):
+            raise ProviderConfigError("tinyfish_domains_invalid")
+        raw_items.append(item)
+    if len(",".join(raw_items)) > _MAX_DOMAIN_LIST_CHARS:
+        raise ProviderConfigError("tinyfish_domains_invalid")
+
+    domains: list[str] = []
+    for item in raw_items:
+        raw = item.lower()
+        if raw.endswith(".."):
+            raise ProviderConfigError("tinyfish_domains_invalid")
+        has_root_dot = raw.endswith(".")
+        token = raw[:-1] if has_root_dot else raw
+        wildcard = token.startswith("*.")
+        hostname = token[2:] if wildcard else token
+        canonical = _canonical_hostname(hostname)
+        if not canonical:
+            raise ProviderConfigError("tinyfish_domains_invalid")
+        normalized = f"*.{canonical}" if wildcard else canonical
+        if len(normalized) > _MAX_DOMAIN_CHARS:
+            raise ProviderConfigError("tinyfish_domains_invalid")
+        if normalized not in domains:
+            domains.append(normalized)
+
+    if len(",".join(domains)) > _MAX_DOMAIN_LIST_CHARS:
+        raise ProviderConfigError("tinyfish_domains_invalid")
+    return domains
+
+
+def _retry_after(error: HTTPError) -> float | None:
+    if error.code != 429:
+        return None
+    try:
+        value = error.headers.get("Retry-After")
+        if value is None:
+            return None
+        parsed = float(value)
+    except (AttributeError, TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) and parsed >= 0 else None
+
+
+def _read_payload(response: Any) -> dict[str, Any]:
+    raw = response.read(_MAX_RESPONSE_BYTES + 1)
+    if len(raw) > _MAX_RESPONSE_BYTES:
+        raise ProviderRequestError("tinyfish_response_too_large", transient=True)
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise ProviderRequestError("tinyfish_invalid_response", transient=True) from None
+    if not isinstance(payload, dict) or not isinstance(payload.get("results"), list):
+        raise ProviderRequestError("tinyfish_invalid_response", transient=True)
+    return payload
+
+
+def _safe_url(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > _MAX_URL_CHARS
+        or any(
+            character.isspace() or unicodedata.category(character).startswith("C")
+            for character in value
+        )
+    ):
+        return ""
+    url = value
+    try:
+        parsed = urlsplit(url)
+        hostname = parsed.hostname or ""
+        port = parsed.port
+    except ValueError:
+        return ""
+    canonical_hostname = _canonical_hostname(hostname)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not canonical_hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or (port is not None and not 1 <= port <= 65_535)
+    ):
+        return ""
+    return url
+
+
+def _bounded_string(value: Any, limit: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    cleaned = "".join(
+        character
+        for character in value
+        if character in {" ", "\n", "\t"}
+        or (
+            not unicodedata.category(character).startswith("C")
+            and not character.isspace()
+        )
+    ).strip()
+    return cleaned[:limit]
+
+
+def _domain_matches(hostname: str, domain: str) -> bool:
+    normalized = domain.strip().lower().rstrip(".")
+    if normalized.startswith("*."):
+        normalized = normalized[2:]
+    return bool(normalized) and (
+        hostname == normalized or hostname.endswith(f".{normalized}")
+    )
+
+
+def _url_allowed_by_domains(
+    url: str,
+    include_domains: list[str],
+    exclude_domains: list[str],
+) -> bool:
+    try:
+        hostname = _canonical_hostname(urlsplit(url).hostname or "")
+    except ValueError:
+        return False
+    if not hostname or any(_domain_matches(hostname, domain) for domain in exclude_domains):
+        return False
+    return not include_domains or any(
+        _domain_matches(hostname, domain) for domain in include_domains
+    )
+
+
+def _request(params: Mapping[str, Any], api_key: str, timeout: int) -> dict[str, Any]:
+    request_url = f"{_API_URL}?{urlencode(params)}"
+    if len(request_url) > _MAX_REQUEST_URL_CHARS:
+        raise ProviderConfigError("tinyfish_request_too_large")
+    request = Request(
+        request_url,
+        headers={"X-API-Key": api_key, "Accept": "application/json"},
+        method="GET",
+    )
+    try:
+        with _open_request(request, timeout) as response:
+            return _read_payload(response)
+    except HTTPError as exc:
+        transient = exc.code in _TRANSIENT_STATUS
+        raise ProviderRequestError(
+            f"tinyfish_http_{exc.code}",
+            status_code=exc.code,
+            transient=transient,
+            retry_after=_retry_after(exc),
+        ) from None
+    except (URLError, TimeoutError, socket.timeout, OSError):
+        raise ProviderRequestError("tinyfish_unavailable", transient=True) from None
+
+
+def _query(args: Any) -> str:
+    value = getattr(args, "query", None)
+    if not isinstance(value, str):
+        raise ProviderConfigError("tinyfish_query_invalid")
+    value = value.strip()
+    if not value or len(value) > _MAX_QUERY_CHARS:
+        raise ProviderConfigError("tinyfish_query_invalid")
+    return value
+
+
+def _query_params(
+    args: Any,
+    query: str,
+    include_domains: list[str],
+    exclude_domains: list[str],
+) -> dict[str, Any]:
+    params: dict[str, Any] = {"query": query}
+
+    country = getattr(args, "country", None)
+    if isinstance(country, str) and country.strip():
+        params["location"] = country.strip().upper()
+    language = getattr(args, "language", None)
+    if isinstance(language, str) and language.strip():
+        params["language"] = language.strip().lower()
+
+    if include_domains:
+        params["include_domains"] = ",".join(include_domains)
+    if exclude_domains:
+        params["exclude_domains"] = ",".join(exclude_domains)
+
+    params["domain_type"] = (
+        "news" if getattr(args, "search_type", "search") == "news" else "web"
+    )
+    freshness = getattr(args, "freshness", None)
+    if freshness not in _FRESHNESS_MINUTES:
+        freshness = getattr(args, "time_range", None)
+    if freshness in _FRESHNESS_MINUTES:
+        params["recency_minutes"] = _FRESHNESS_MINUTES[freshness]
+
+    # Intentionally omitted: purpose, fetch, include_thumbnail, and pagination.
+    # WSP asks TinyFish only for source results and applies its own result bound.
+    return params
+
+
+def execute_search(search_module, prov, args, key, config, routing_info):
+    if not isinstance(key, str) or not key.strip():
+        raise ProviderConfigError("tinyfish_api_key_required")
+
+    try:
+        count = max(1, min(int(getattr(args, "max_results", 5)), 100))
+    except (TypeError, ValueError):
+        raise ProviderConfigError("tinyfish_max_results_invalid") from None
+
+    query = _query(args)
+    include_domains = _clean_domains(getattr(args, "include_domains", None))
+    exclude_domains = _clean_domains(getattr(args, "exclude_domains", None))
+    payload = _request(
+        _query_params(args, query, include_domains, exclude_domains),
+        key.strip(),
+        _timeout(config),
+    )
+    raw_results = payload.get("results")
+    if not isinstance(raw_results, list):
+        raise ProviderRequestError("tinyfish_invalid_response", transient=True)
+
+    projected = []
+    for item in raw_results:
+        if len(projected) >= count:
+            break
+        if not isinstance(item, Mapping):
+            continue
+        url = _safe_url(item.get("url"))
+        if not url or not _url_allowed_by_domains(url, include_domains, exclude_domains):
+            continue
+
+        fields: dict[str, Any] = {
+            "title": _bounded_string(item.get("title"), _MAX_TITLE_CHARS),
+            "snippet": _bounded_string(item.get("snippet"), _MAX_SNIPPET_CHARS),
+        }
+        optional_strings = {
+            "date": item.get("date"),
+            "source": item.get("site_name"),
+            "author": item.get("publisher"),
+        }
+        for field, value in optional_strings.items():
+            projected_value = _bounded_string(value, 1_000)
+            if projected_value:
+                fields[field] = projected_value
+        position = item.get("position")
+        if isinstance(position, int) and not isinstance(position, bool) and position >= 1:
+            fields["position"] = position
+        projected.append(source_result(url, **fields))
+
+    metadata: dict[str, int] = {}
+    for field in ("total_results", "page"):
+        value = payload.get(field)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            metadata[field] = value
+
+    return search_result(
+        prov,
+        query,
+        projected,
+        metadata=metadata,
+    )
+
+
+PROVIDER = register_provider(
+    ProviderSpec(
+        id="tinyfish",
+        kind="search",
+        env_var="TINYFISH_API_KEY",
+        display_name="TinyFish Search",
+        description=(
+            "Direct source-only TinyFish web/news search using your own account/API key. "
+            "WSP does not provide, pool, proxy, or share TinyFish credentials. "
+            "Domain filters and result hosts are accepted only as ASCII/Punycode hostnames. "
+            "Privacy warning: TinyFish's "
+            "standard Terms permit Customer Data to be used for model training and "
+            "fine-tuning; review https://www.tinyfish.ai/terms and "
+            "https://www.tinyfish.ai/privacy-policy before use. Explicit-only by default."
+        ),
+        config_section="tinyfish",
+        capability_labels=("search", "news", "freshness", "privacy-warning"),
+        upstream_capabilities=(
+            "search",
+            "news",
+            "research-paper",
+            "freshness",
+            "domain-filtering",
+        ),
+        auto_allowed_by_default=False,
+        recommended=False,
+        supports_freshness=True,
+        free_tier="Search does not consume credits; API access required (30 rpm Free/PAYG)",
+        signup_url="https://agent.tinyfish.ai/api-keys",
+        execute_search=execute_search,
+    )
+)

--- a/tests/providers_d/test_tinyfish_provider.py
+++ b/tests/providers_d/test_tinyfish_provider.py
@@ -1,0 +1,632 @@
+from __future__ import annotations
+
+import json
+from email.message import Message
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.error import HTTPError
+from urllib.parse import parse_qs, urlsplit
+from urllib.request import Request
+
+import pytest
+
+import provider_registry
+import providers
+from http_client import ProviderRequestError
+from provider_adapter_protocol import validate_adapter_result
+
+
+class FakeResponse:
+    def __init__(self, payload=None, *, raw: bytes | None = None):
+        self._raw = raw if raw is not None else json.dumps(payload).encode("utf-8")
+        self.headers = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def read(self, size=-1):
+        return self._raw if size < 0 else self._raw[:size]
+
+
+def _provider_globals():
+    spec = provider_registry.PROVIDER_SPECS["tinyfish"]
+    return spec, spec.execute_search.__globals__
+
+
+def _args(**overrides):
+    values = {
+        "query": "tinyfish contract query",
+        "max_results": 3,
+        "freshness": "week",
+        "time_range": None,
+        "include_domains": ["docs.python.org", "example.com"],
+        "exclude_domains": ["spam.example"],
+        "search_type": "search",
+        "country": "at",
+        "language": "de",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def test_tinyfish_registers_as_privacy_warned_explicit_only_search_provider():
+    spec = provider_registry.PROVIDER_SPECS["tinyfish"]
+
+    assert spec.kind == "search"
+    assert spec.env_var == "TINYFISH_API_KEY"
+    assert spec.display_name == "TinyFish Search"
+    assert spec.keyless is False
+    assert spec.auto_allowed_by_default is False
+    assert spec.supports_freshness is True
+    assert spec.free_tier == "Search does not consume credits; API access required (30 rpm Free/PAYG)"
+    assert spec.capability_labels == ("search", "news", "freshness", "privacy-warning")
+    assert spec.upstream_capabilities == (
+        "search",
+        "news",
+        "research-paper",
+        "freshness",
+        "domain-filtering",
+    )
+    assert "training" in spec.description.lower()
+    assert "fine-tuning" in spec.description.lower()
+    assert "your own account/api key" in spec.description.lower()
+    assert "does not provide, pool, proxy, or share" in spec.description.lower()
+    assert "tinyfish.ai/terms" in spec.description
+    assert spec.execute_search is not None
+    assert "tinyfish" in provider_registry.SEARCH_PROVIDER_IDS
+    assert "tinyfish" not in provider_registry.EXTRACT_PROVIDER_IDS
+    assert "tinyfish" not in provider_registry.DEFAULT_PROVIDER_PRIORITY
+    assert provider_registry.DEFAULT_AUTO_ALLOW["tinyfish"] is False
+
+
+def test_tinyfish_freshness_capability_drives_truthful_metadata():
+    assert providers.provider_supports_freshness("tinyfish") is True
+    assert providers.map_freshness_for_provider("tinyfish", "week") == "week"
+    assert providers.freshness_metadata("tinyfish", "week") == {
+        "requested": "week",
+        "applied": True,
+        "provider": "tinyfish",
+        "native_value": "week",
+    }
+
+
+def test_tinyfish_projects_get_request_and_source_only_response(monkeypatch):
+    spec, module = _provider_globals()
+    captured = {}
+
+    def fake_open(request, timeout):
+        captured["request"] = request
+        captured["timeout"] = timeout
+        return FakeResponse(
+            {
+                "query": "tinyfish contract query",
+                "results": [
+                    {
+                        "position": 1,
+                        "site_name": "docs.python.org",
+                        "title": "Python docs",
+                        "snippet": "Official Python documentation.",
+                        "url": "https://docs.python.org/3/",
+                        "date": "2026-07-01",
+                    },
+                    {
+                        "position": 2,
+                        "site_name": "example.com",
+                        "title": "Example",
+                        "snippet": "Example source.",
+                        "url": "https://example.com/source",
+                    },
+                ],
+                "total_results": 2,
+                "page": 0,
+            }
+        )
+
+    monkeypatch.setitem(module, "_open_request", fake_open)
+    result = spec.execute_search(
+        None,
+        "tinyfish",
+        _args(),
+        "tinyfish-test-key",
+        {"tinyfish": {"timeout": 17}},
+        {},
+    )
+
+    request = captured["request"]
+    parsed = urlsplit(request.full_url)
+    params = parse_qs(parsed.query)
+    assert (parsed.scheme, parsed.netloc, parsed.path) == (
+        "https",
+        "api.search.tinyfish.ai",
+        "/",
+    )
+    assert request.get_method() == "GET"
+    assert request.data is None
+    assert request.headers["X-api-key"] == "tinyfish-test-key"
+    assert request.headers["Accept"] == "application/json"
+    assert captured["timeout"] == 17
+    assert params == {
+        "query": ["tinyfish contract query"],
+        "location": ["AT"],
+        "language": ["de"],
+        "include_domains": ["docs.python.org,example.com"],
+        "exclude_domains": ["spam.example"],
+        "domain_type": ["web"],
+        "recency_minutes": ["10080"],
+    }
+    assert "fetch" not in params
+    assert "purpose" not in params
+    assert "include_thumbnail" not in params
+    assert "limit" not in params
+
+    assert result == {
+        "provider": "tinyfish",
+        "query": "tinyfish contract query",
+        "results": [
+            {
+                "url": "https://docs.python.org/3/",
+                "title": "Python docs",
+                "snippet": "Official Python documentation.",
+                "date": "2026-07-01",
+                "source": "docs.python.org",
+                "position": 1,
+            },
+            {
+                "url": "https://example.com/source",
+                "title": "Example",
+                "snippet": "Example source.",
+                "source": "example.com",
+                "position": 2,
+            },
+        ],
+        "images": [],
+        "metadata": {"total_results": 2, "page": 0},
+    }
+    assert validate_adapter_result("tinyfish", "search", result) is result
+
+
+def test_tinyfish_maps_news_and_unified_freshness(monkeypatch):
+    spec, module = _provider_globals()
+    captured = {}
+
+    def fake_open(request, _timeout):
+        captured["params"] = parse_qs(urlsplit(request.full_url).query)
+        return FakeResponse({"query": "news", "results": [], "total_results": 0, "page": 0})
+
+    monkeypatch.setitem(module, "_open_request", fake_open)
+    spec.execute_search(
+        None,
+        "tinyfish",
+        _args(
+            query="news",
+            search_type="news",
+            freshness="day",
+            include_domains=[],
+            exclude_domains=[],
+            country=None,
+            language=None,
+        ),
+        "tinyfish-test-key",
+        {},
+        {},
+    )
+
+    assert captured["params"] == {
+        "query": ["news"],
+        "domain_type": ["news"],
+        "recency_minutes": ["1440"],
+    }
+
+
+def test_tinyfish_skips_malformed_and_unsafe_results_without_spending_slots(monkeypatch):
+    spec, module = _provider_globals()
+
+    monkeypatch.setitem(
+        module,
+        "_open_request",
+        lambda *_args: FakeResponse(
+            {
+                "query": "safe",
+                "results": [
+                    None,
+                    {"url": "javascript:alert(1)", "title": "bad"},
+                    {"url": "https://user:pass@example.com/private", "title": "credential URL"},
+                    {"url": "https://one.example/", "title": 123, "snippet": None, "position": True},
+                    {"url": "http://two.example/", "title": "Two", "snippet": "ok", "position": 5},
+                ],
+                "total_results": 5,
+                "page": 0,
+            }
+        ),
+    )
+
+    result = spec.execute_search(
+        None,
+        "tinyfish",
+        _args(max_results=2, include_domains=[], exclude_domains=[], freshness=None),
+        "tinyfish-test-key",
+        {},
+        {},
+    )
+
+    assert result["results"] == [
+        {"url": "https://one.example/", "title": "", "snippet": ""},
+        {
+            "url": "http://two.example/",
+            "title": "Two",
+            "snippet": "ok",
+            "position": 5,
+        },
+    ]
+
+
+def test_tinyfish_requires_key_and_valid_timeout():
+    spec, _module = _provider_globals()
+
+    with pytest.raises(Exception, match="tinyfish_api_key_required"):
+        spec.execute_search(None, "tinyfish", _args(), None, {}, {})
+    with pytest.raises(Exception, match="tinyfish_timeout_invalid"):
+        spec.execute_search(
+            None,
+            "tinyfish",
+            _args(),
+            "key",
+            {"tinyfish": {"timeout": 0}},
+            {},
+        )
+
+
+def test_tinyfish_refuses_redirects_to_keep_credentials_on_fixed_origin():
+    _spec, module = _provider_globals()
+    request = Request("https://api.search.tinyfish.ai?query=safe")
+
+    redirected = module["_NoRedirectHandler"]().redirect_request(
+        request,
+        None,
+        302,
+        "Found",
+        {},
+        "https://attacker.example/collect",
+    )
+
+    assert redirected is None
+
+
+def test_tinyfish_bounds_response_and_classifies_rate_limit(monkeypatch):
+    spec, module = _provider_globals()
+
+    monkeypatch.setitem(
+        module,
+        "_open_request",
+        lambda *_args: FakeResponse(raw=b"x" * (module["_MAX_RESPONSE_BYTES"] + 1)),
+    )
+    with pytest.raises(ProviderRequestError, match="tinyfish_response_too_large"):
+        spec.execute_search(None, "tinyfish", _args(), "key", {}, {})
+
+    headers = Message()
+    headers["Retry-After"] = "2.5"
+
+    def rate_limited(*_args):
+        raise HTTPError(
+            "https://api.search.tinyfish.ai?query=safe",
+            429,
+            "Too Many Requests",
+            headers,
+            None,
+        )
+
+    monkeypatch.setitem(module, "_open_request", rate_limited)
+    with pytest.raises(ProviderRequestError) as exc_info:
+        spec.execute_search(None, "tinyfish", _args(), "key", {}, {})
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.transient is True
+    assert exc_info.value.retry_after == 2.5
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {},
+        {"results": None},
+        {"results": "wrong"},
+    ],
+)
+def test_tinyfish_rejects_malformed_top_level_payloads(monkeypatch, payload):
+    spec, module = _provider_globals()
+    monkeypatch.setitem(module, "_open_request", lambda *_args: FakeResponse(payload))
+
+    with pytest.raises(ProviderRequestError, match="tinyfish_invalid_response"):
+        spec.execute_search(None, "tinyfish", _args(), "key", {}, {})
+
+
+def test_tinyfish_wildcard_deliberately_matches_root_and_subdomains(monkeypatch):
+    spec, module = _provider_globals()
+    assert spec.execute_search is not None
+    monkeypatch.setitem(
+        module,
+        "_open_request",
+        lambda *_args: FakeResponse(
+            {
+                "results": [
+                    {"url": "https://example.com/root", "title": "root", "snippet": "ok"},
+                    {"url": "https://docs.example.com/page", "title": "sub", "snippet": "ok"},
+                    {"url": "https://blocked.example.com/page", "title": "blocked", "snippet": "no"},
+                    {"url": "https://example.com.evil.test/page", "title": "lookalike", "snippet": "no"},
+                    {"url": "https://other.test/page", "title": "other", "snippet": "no"},
+                ]
+            }
+        ),
+    )
+
+    result = spec.execute_search(
+        None,
+        "tinyfish",
+        _args(
+            max_results=5,
+            include_domains=["*.example.com"],
+            exclude_domains=["blocked.example.com"],
+            freshness=None,
+        ),
+        "key",
+        {},
+        {},
+    )
+
+    assert [item["url"] for item in result["results"]] == [
+        "https://example.com/root",
+        "https://docs.example.com/page",
+    ]
+
+
+def test_tinyfish_keeps_punycode_and_ascii_hosts_distinct(monkeypatch):
+    spec, module = _provider_globals()
+    assert spec.execute_search is not None
+    monkeypatch.setitem(
+        module,
+        "_open_request",
+        lambda *_args: FakeResponse(
+            {
+                "results": [
+                    {
+                        "url": "https://xn--fa-hia.de/source",
+                        "title": "punycode host",
+                    },
+                    {"url": "https://fass.de/source", "title": "ASCII host"},
+                    {"url": "https://faß.de/source", "title": "raw Unicode host"},
+                ]
+            }
+        ),
+    )
+
+    ascii_included = spec.execute_search(
+        None,
+        "tinyfish",
+        _args(
+            max_results=3,
+            include_domains=["fass.de"],
+            exclude_domains=[],
+            freshness=None,
+        ),
+        "key",
+        {},
+        {},
+    )
+    punycode_included = spec.execute_search(
+        None,
+        "tinyfish",
+        _args(
+            max_results=3,
+            include_domains=["xn--fa-hia.de"],
+            exclude_domains=[],
+            freshness=None,
+        ),
+        "key",
+        {},
+        {},
+    )
+
+    assert [item["url"] for item in ascii_included["results"]] == [
+        "https://fass.de/source"
+    ]
+    assert [item["url"] for item in punycode_included["results"]] == [
+        "https://xn--fa-hia.de/source"
+    ]
+    assert module["_safe_url"]("https://faß.de/source") == ""
+
+
+def test_tinyfish_rejects_unsafe_urls_and_bounds_untrusted_text(monkeypatch):
+    spec, module = _provider_globals()
+    assert spec.execute_search is not None
+    title = "\u202e" + "T" * (module["_MAX_TITLE_CHARS"] + 20)
+    snippet = "\u009b" + "S" * (module["_MAX_SNIPPET_CHARS"] + 20)
+    monkeypatch.setitem(
+        module,
+        "_open_request",
+        lambda *_args: FakeResponse(
+            {
+                "results": [
+                    {"url": "data:text/plain,bad", "title": "bad"},
+                    {"url": "https://", "title": "bad"},
+                    {"url": "/relative", "title": "bad"},
+                    {"url": "https://example.com/white space", "title": "bad"},
+                    {"url": "https://example.com/control\npath", "title": "bad"},
+                    {"url": "https://bad_domain.example/path", "title": "bad host"},
+                    {"url": "https://safe.example:99999/path", "title": "bad port"},
+                    {"url": "\nhttps://safe.example/path", "title": "leading C0"},
+                    {"url": "\u0085https://safe.example/path", "title": "leading C1"},
+                    {"url": "https://safe.example/path\u0085", "title": "trailing C1"},
+                    {"url": "https://safe.example/\u009bx", "title": "C1 control"},
+                    {"url": "https://safe.example/\u202ereversed", "title": "bidi control"},
+                    {"url": "https://safe.example/" + "x" * module["_MAX_URL_CHARS"], "title": "too long"},
+                    {"url": "https://safe.example/page", "title": title, "snippet": snippet},
+                ]
+            }
+        ),
+    )
+
+    result = spec.execute_search(
+        None,
+        "tinyfish",
+        _args(max_results=10, include_domains=[], exclude_domains=[], freshness=None),
+        "key",
+        {},
+        {},
+    )
+
+    assert len(result["results"]) == 1
+    assert len(result["results"][0]["title"]) == module["_MAX_TITLE_CHARS"]
+    assert len(result["results"][0]["snippet"]) == module["_MAX_SNIPPET_CHARS"]
+    assert "\u202e" not in result["results"][0]["title"]
+    assert "\u009b" not in result["results"][0]["snippet"]
+
+
+@pytest.mark.parametrize(
+    "domains",
+    [
+        ["example.com"] * 21,
+        ["localhost"],
+        [""],
+        [123],
+        ["https://example.com"],
+        ["bad_domain.example"],
+        ["safe.example\u202e.evil"],
+        ["Münich.example"],
+        ["faß.de"],
+        [" example.com"],
+        ["example.com "],
+        ["\nexample.com"],
+        ["example.com\u0085"],
+        [f"{'a' * 64}.example"],
+        [f"{'a' * 250}.example"],
+        ["example.com" + "." * 5_000],
+        [f"*.{'a' * 63}.{'b' * 63}.{'c' * 63}.{'d' * 60}"],
+        [f"{'a' * 63}.{'b' * 63}.{'c' * 63}.{index:02d}.example" for index in range(20)],
+    ],
+)
+def test_tinyfish_rejects_invalid_or_unbounded_domain_filters(domains):
+    spec, _module = _provider_globals()
+    assert spec.execute_search is not None
+    with pytest.raises(Exception, match="tinyfish_domains_invalid"):
+        spec.execute_search(
+            None,
+            "tinyfish",
+            _args(include_domains=domains, exclude_domains=[]),
+            "key",
+            {},
+            {},
+        )
+
+
+def test_tinyfish_canonicalizes_and_deduplicates_domains(monkeypatch):
+    spec, module = _provider_globals()
+    assert spec.execute_search is not None
+    captured = {}
+
+    def fake_open(request, _timeout):
+        captured["params"] = parse_qs(urlsplit(request.full_url).query)
+        return FakeResponse({"results": []})
+
+    monkeypatch.setitem(module, "_open_request", fake_open)
+    spec.execute_search(
+        None,
+        "tinyfish",
+        _args(
+            include_domains=["Example.COM.", "example.com", "*.XN--MNICH-KVA.example"],
+            exclude_domains=[],
+        ),
+        "key",
+        {},
+        {},
+    )
+    assert captured["params"]["include_domains"] == [
+        "example.com,*.xn--mnich-kva.example"
+    ]
+
+
+def test_tinyfish_rejects_oversized_encoded_request():
+    _spec, module = _provider_globals()
+    with pytest.raises(Exception, match="tinyfish_request_too_large"):
+        module["_request"](
+            {"query": "?" * module["_MAX_REQUEST_URL_CHARS"]},
+            "key",
+            30,
+        )
+
+
+def test_tinyfish_public_docs_disclose_byok_and_training_contract():
+    root = Path(__file__).resolve().parents[2]
+    for relative in ("README.md", "docs/PROVIDERS.md"):
+        text = (root / relative).read_text(encoding="utf-8").lower()
+        assert "tinyfish" in text
+        assert "your own" in text
+        assert "does not provide, pool, proxy, or share" in text
+        assert "training" in text
+        assert "fine-tuning" in text
+
+
+@pytest.mark.parametrize("query", [None, "", "   ", "x" * 2_001])
+def test_tinyfish_enforces_official_query_limit(query):
+    spec, _module = _provider_globals()
+    assert spec.execute_search is not None
+    with pytest.raises(Exception, match="tinyfish_query_invalid"):
+        spec.execute_search(None, "tinyfish", _args(query=query), "key", {}, {})
+
+
+@pytest.mark.parametrize(
+    ("status", "transient"),
+    [
+        (400, False),
+        (401, False),
+        (402, False),
+        (403, False),
+        (404, False),
+        (429, True),
+        (500, True),
+        (503, True),
+    ],
+)
+def test_tinyfish_http_status_classification_is_opaque(monkeypatch, status, transient):
+    spec, module = _provider_globals()
+    assert spec.execute_search is not None
+
+    def fail(*_args):
+        raise HTTPError(
+            "https://api.search.tinyfish.ai/?query=must-not-leak",
+            status,
+            "upstream detail must not leak",
+            Message(),
+            None,
+        )
+
+    monkeypatch.setitem(module, "_open_request", fail)
+    with pytest.raises(ProviderRequestError) as exc_info:
+        spec.execute_search(None, "tinyfish", _args(), "secret-key", {}, {})
+
+    assert exc_info.value.status_code == status
+    assert exc_info.value.transient is transient
+    rendered = str(exc_info.value)
+    assert "must-not-leak" not in rendered
+    assert "upstream detail" not in rendered
+    assert "secret-key" not in rendered
+
+
+@pytest.mark.parametrize("header", ["-1", "nan", "inf", "not-a-number"])
+def test_tinyfish_ignores_invalid_retry_after(header):
+    _spec, module = _provider_globals()
+    headers = Message()
+    headers["Retry-After"] = header
+    error = HTTPError("https://api.search.tinyfish.ai/", 429, "rate", headers, None)
+    assert module["_retry_after"](error) is None
+
+
+@pytest.mark.parametrize("raw", [b"\xff", b"{not-json", b""])
+def test_tinyfish_rejects_invalid_utf8_and_json(monkeypatch, raw):
+    spec, module = _provider_globals()
+    assert spec.execute_search is not None
+    monkeypatch.setitem(module, "_open_request", lambda *_args: FakeResponse(raw=raw))
+    with pytest.raises(ProviderRequestError, match="tinyfish_invalid_response"):
+        spec.execute_search(None, "tinyfish", _args(), "key", {}, {})

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -263,7 +263,7 @@ def test_setup_dry_run_uses_target_env_path_for_dashboard(tmp_path, monkeypatch,
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "Providers: 1/16 configured" in out
+    assert "Providers: 1/17 configured" in out
     assert "Active: You.com" in out
     assert "Brave Search" not in out.split("Setup plan:", 1)[0]
 
@@ -279,7 +279,7 @@ def test_status_uses_target_env_path_for_dashboard(tmp_path, monkeypatch, capsys
     args.func(args)
 
     out = capsys.readouterr().out
-    assert "Providers: 1/16 configured" in out
+    assert "Providers: 1/17 configured" in out
     assert "Active: Linkup" in out
     assert "Brave Search" not in out
 

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -21,7 +21,7 @@ def test_provider_registry_is_the_complete_capability_source():
         "searxng",
         "keenable",
     )
-    assert registry.SEARCH_PROVIDER_IDS[-2:] == ("hound", "octen")
+    assert registry.SEARCH_PROVIDER_IDS[-3:] == ("hound", "octen", "tinyfish")
     assert registry.EXTRACT_PROVIDER_IDS == (
         "tavily", "exa", "linkup", "parallel", "firecrawl", "you", "keenable", "serper", "hound"
     )
@@ -42,6 +42,7 @@ def test_provider_registry_is_the_complete_capability_source():
         "parallel": False,
         "hound": False,
         "octen": False,
+        "tinyfish": False,
     }
     assert "research" in registry.PROVIDER_SPECS["tavily"].capability_labels
 

--- a/tests/test_routing_v2.py
+++ b/tests/test_routing_v2.py
@@ -26,7 +26,9 @@ def test_default_auto_allow_blocks_explicit_only_providers():
     assert auto_allow["hound"] is False
     assert auto_allow["octen"] is False
     assert auto_allow.get("brave", True) is True
-    assert set(auto_allow) == {"serpbase", "querit", "parallel", "hound", "octen"}
+    assert set(auto_allow) == {
+        "serpbase", "querit", "parallel", "hound", "octen", "tinyfish",
+    }
 
 
 
@@ -41,7 +43,7 @@ def test_legacy_auto_allow_config_inherits_new_guarded_provider_defaults():
     assert validated["auto_routing"]["auto_allow"]["hound"] is False
     assert validated["auto_routing"]["auto_allow"]["octen"] is False
     assert set(validated["auto_routing"]["auto_allow"]) == {
-        "serpbase", "querit", "parallel", "hound", "octen",
+        "serpbase", "querit", "parallel", "hound", "octen", "tinyfish",
     }
 
 


### PR DESCRIPTION
## Summary

- add TinyFish as a direct, source-only Search provider
- keep TinyFish BYOK and explicit-only; it is excluded from default routing and automatic provider selection
- enforce the fixed TinyFish Search API origin, reject redirects, bound requests/responses, and project structured sources only
- document the standard Terms risk around Customer Data training/fine-tuning and link the public provider privacy/terms guide

## Security and privacy

- Web Search Plus does not provide, pool, proxy, or share TinyFish credentials
- the adapter sends `GET` requests only to `https://api.search.tinyfish.ai/` with `X-API-Key`
- redirects are rejected so credentials cannot cross origins
- query, domain filters, request URLs, responses, projected URLs, titles, and snippets are bounded
- domain filters and result hosts accept only validated ASCII/Punycode; raw Unicode hostnames are rejected fail-closed
- malformed responses and unsafe URLs are rejected or omitted without exposing upstream details, queries, or credentials
- TinyFish remains `auto_allowed_by_default=False` and is not recommended for automatic routing

TinyFish's standard Terms permit Customer Data to be used for model training and fine-tuning. This integration deliberately reduces the technical scope to direct Search, but does not claim to remove that contractual risk. Users should review the linked Terms and Privacy Policy before use.

## Verification

- `python -m pytest -q -p no:cacheprovider`
  - `1020 passed, 6 subtests passed`
- deterministic bounds/control-character fuzz gate: 30,000 domain tokens + 30,000 result URLs
- `ruff check providers.d/tinyfish.py tests/providers_d/test_tinyfish_provider.py`
- `python -m compileall -q providers.d/tinyfish.py tests/providers_d/test_tinyfish_provider.py`
- `git diff --check`
- staged secret/security scan: clean

No live TinyFish API request was made because no authorized TinyFish credential was used; the request/response contract is covered by deterministic adapter tests.
