### PR TITLE
docs: correct v3.4.1 verification count

### DIFF
--- a/docs/RELEASE_NOTES_V341.md
+++ b/docs/RELEASE_NOTES_V341.md
@@ -31,7 +31,7 @@ Hound remains visibly attributed to the independent MIT-licensed [Master-Fetch p
 ## Verification
 
 - Ruff passed
-- 1,020 tests plus 6 schema subtests passed
+- 1,021 tests plus 6 schema subtests passed
 - generated provider documentation and contract-v3 schemas are current
 - Node schema boundary passed after a clean `npm ci`
 - `npm audit --audit-level=high` reports zero vulnerabilities


### PR DESCRIPTION
## Summary

Correct the v3.4.1 release-notes verification count after the final native-filter help regression test increased the suite from 1,020 to 1,021 tests.

## Verification

- `python3 -m pytest -q tests/test_release_metadata.py` — passed
- `git diff --check`

No runtime or package content changes.
