### PR TITLE
fix: mark truncated research source summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### 🐛 Fixed
+- Research source summaries in the public formatter now mark 500-character previews with the exact original length instead of silently truncating them.
+
 ## [v3.4.1] — 2026-07-30
 
 ### ✨ Added

--- a/__init__.py
+++ b/__init__.py
@@ -1644,7 +1644,10 @@ def _format_results(data: dict) -> str:
             content = (src.get("content") or src.get("raw_content") or "").strip()
             lines.append(f"{i}. {url}")
             if content:
-                lines.append(f"   {content[:500]}")
+                summary = content[:500]
+                if len(content) > 500:
+                    summary += f" [TRUNCATED: showing first 500 of {len(content)} characters]"
+                lines.append(f"   {summary}")
         lines.append("")
 
     for i, r in enumerate(results, 1):

--- a/tests/test_source_summary_formatter.py
+++ b/tests/test_source_summary_formatter.py
@@ -1,0 +1,30 @@
+import __init__ as plugin
+
+
+def test_research_source_summary_marks_truncation_and_original_length():
+    content = "\n".join(
+        f"Apple product {index:03d}: official specification entry"
+        for index in range(80)
+    )
+    assert len(content) > 500
+
+    output = plugin._format_results(
+        {
+            "provider": "research",
+            "results": [
+                {
+                    "title": "Apple official result",
+                    "url": "https://www.apple.com/",
+                    "snippet": "Official Apple source",
+                }
+            ],
+            "source_summaries": [
+                {"url": "https://www.apple.com/", "content": content}
+            ],
+        }
+    )
+
+    marker = f"[TRUNCATED: showing first 500 of {len(content)} characters]"
+    assert content[:500] in output
+    assert marker in output
+    assert "Apple product 079:" not in output


### PR DESCRIPTION
## Summary

- Mark truncated Research `source_summaries` previews with an explicit `TRUNCATED` marker.
- Include the exact original character count so a 500-character preview is not mistaken for complete source content.
- Add a regression test covering a long 80-entry Apple source list.

## Validation

- 1,022 Python tests passed.
- 6 schema subtests passed.
- Ruff, compilation, and `git diff --check` passed.
- Isolated no-credential smoke passed through the registered `web_extract_plus` handler with the official Apple URL.
- The related MCP boundary was audited separately; its structured `source_summaries` payload is preserved losslessly and requires no code change.
