### PR TITLE
fix: harden DonSeTch stdio session and readiness for 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [v4.0.1] — 2026-08-17
+
+### Fixed
+- DonSeTch multi-URL extraction now reuses one initialized stdio MCP session per `web_extract_plus` request instead of starting a new process for every URL.
+- DonSeTch subprocesses are reaped on timeout, initialize failure, tool errors, malformed MCP output, and broken pipes.
+- `setup.py status` reports DonSeTch binary readiness (missing / not executable / version / compatibility) instead of treating `DONSETCH_BIN` as an API key.
+
+### Changed
+- Bump the tested DonSeTch version to 2.3.1 (live-tested for stdio Search and multi-URL Fetch).
+- DonSeTch captures a bounded, sanitized stderr excerpt for diagnostics. Successful Search/Extract payloads do not include raw stderr.
+
 ## [v4.0.0] — 2026-08-16
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ It adds two Hermes tools:
 
 > Ported from [web-search-plus-plugin](https://github.com/robbyczgw-cla/web-search-plus-plugin) for the [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin API.
 
-Current release: **v4.0.0** — see the [Changelog](CHANGELOG.md) and [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
+Current release: **v4.0.1** — see the [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
+
+### What's new in 4.0.1
+
+DonSeTch now reuses one stdio MCP session for every URL in a single extract call, reaps the child on timeout or MCP failure, and reports binary readiness from `setup.py status`. Search and Extract stay explicit-only.
 
 ### What's new in 4.0.0
 
@@ -67,7 +71,7 @@ Provider privacy is not uniform. Before sending sensitive queries or URLs, revie
 
 ### Upgrading to 4.0.0
 
-The core tools and existing keyed providers remain available, but the optional Hound integration was removed. If you used Hound, follow the [DonSeTch migration guide](docs/DONSETCH.md#migration-from-hound): install DonSeTch 2.1.0 separately, set `DONSETCH_BIN`, and change explicit `provider="hound"` calls to `provider="donsetch"`.
+The core tools and existing keyed providers remain available, but the optional Hound integration was removed. If you used Hound, follow the [DonSeTch migration guide](docs/DONSETCH.md#migration-from-hound): install DonSeTch 2.3.1 separately, set `DONSETCH_BIN`, and change explicit `provider="hound"` calls to `provider="donsetch"`.
 
 ### Self-hosted / no-paid-key profile
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v4.0.0
+web-search-plus — Hermes Plugin v4.0.1
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"
 
 import argparse
 import getpass
@@ -684,6 +684,26 @@ def _profile_status(config: Mapping[str, Any], env: Mapping[str, str]) -> Dict[s
     }
 
 
+def _donsetch_status(env: Mapping[str, str], config: Mapping[str, Any]) -> Dict[str, Any]:
+    """DonSeTch readiness is a binary path, not an API key."""
+    try:
+        spec = PROVIDER_SPECS.get("donsetch")
+        inspect = getattr(getattr(spec, "execute_search", None), "__globals__", {}).get(
+            "inspect_donsetch_readiness"
+        )
+    except Exception:
+        inspect = None
+    if inspect is None:
+        return {
+            "state": "missing",
+            "version": None,
+            "tested_version": "2.3.1",
+            "compatibility": "unknown",
+            "binary_configured": bool(_clean_env_value(env.get("DONSETCH_BIN") or "")),
+        }
+    return inspect(key=_clean_env_value(env.get("DONSETCH_BIN") or ""), config=dict(config))
+
+
 def _status_payload(env: Optional[Mapping[str, str]] = None, config: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
     active_env = env if env is not None else os.environ
     active_config = dict(config or _default_behavior_config())
@@ -691,6 +711,7 @@ def _status_payload(env: Optional[Mapping[str, str]] = None, config: Optional[Ma
         "providers": _provider_config_status(active_env),
         "profile": _profile_status(active_config, active_env),
         "routing": active_config,
+        "donsetch": _donsetch_status(active_env, active_config),
     }
 
 
@@ -1156,6 +1177,15 @@ def _web_search_plus_cli_command(args: Any) -> None:
         else:
             print(_render_setup_guidance(env=env, fancy=not getattr(args, "plain", False)))
             print("\n" + _routing_summary(config))
+            donsetch = payload.get("donsetch") or {}
+            if donsetch.get("binary_configured") or donsetch.get("state") != "missing":
+                print(
+                    "\nDonSeTch binary: "
+                    f"state={donsetch.get('state')}, "
+                    f"version={donsetch.get('version') or 'unknown'}, "
+                    f"compatibility={donsetch.get('compatibility')}, "
+                    f"tested={donsetch.get('tested_version')}"
+                )
             if payload["profile"]["active"] == "self_hosted":
                 print("\n" + _render_profile_checks(payload["profile"]))
         return

--- a/docs/DONSETCH.md
+++ b/docs/DONSETCH.md
@@ -1,7 +1,7 @@
 # DonSeTch local provider
 
 Web Search Plus 4.0 can use [DonSeTch](https://github.com/dondai44423/donsetch)
-2.1.0 as a separately installed local provider for source-only Search and
+2.3.1 as a separately installed local provider for source-only Search and
 Extract. DonSeTch is an independent AGPL-3.0-only project. Web Search Plus
 does not bundle, copy, or redistribute its binary.
 
@@ -16,7 +16,7 @@ routing or fallback.
 The upstream project distributes a platform binary through npm:
 
 ```bash
-npm install -g donsetch@2.1.0
+npm install -g donsetch@2.3.1
 command -v donsetch
 donsetch --version
 donsetch doctor
@@ -99,6 +99,6 @@ longer read by WSP, and `HOUND_MCP_URL` has no effect in version 4.0.
 - In the standalone MCP package, explicit DonSeTch calls get a 195-second outer
   subprocess budget, covering the adapter's 180-second stdio timeout; other
   provider budgets remain unchanged.
-- This integration was tested against DonSeTch 2.1.0 for stdio MCP
+- This integration was tested against DonSeTch 2.3.1 for stdio MCP
   initialization, Search, Fetch, and structured error handling. Successful
   browser/anti-bot execution remains an environment-dependent open gate.

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/4.0.0"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/4.0.1"
 
 
 class ProviderRequestError(Exception):

--- a/operator_console_v3.py
+++ b/operator_console_v3.py
@@ -532,7 +532,7 @@ def build_overview(
     config: Mapping[str, Any] | None = None,
     provider_ids: Sequence[str] | None = None,
     state_path: str | Path | None = None,
-    plugin_version: str = "4.0.0",
+    plugin_version: str = "4.0.1",
     now: Callable[[], float] = time.time,
 ) -> dict[str, Any]:
     root = Path(cache_root)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "4.0.0"
+version: "4.0.1"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/providers.d/donsetch.py
+++ b/providers.d/donsetch.py
@@ -1,19 +1,22 @@
 """Local DonSeTch MCP provider for WSP search and extraction.
 
-DonSeTch is launched as an isolated stdio MCP subprocess for each provider
-request.  The adapter projects its structured ``web_search`` and ``web_fetch``
-responses into WSP's source-only envelopes.  No shell is used and the binary
-path is supplied through ``DONSETCH_BIN`` or the ``donsetch.binary`` config
-field.
+DonSeTch is launched as an isolated stdio MCP subprocess. Search uses one
+process per request. A single extract request reuses one initialized session
+for every URL, then shuts the child down. The adapter projects structured
+``web_search`` and ``web_fetch`` responses into WSP's source-only envelopes.
+No shell is used. The binary path comes from ``DONSETCH_BIN`` or the
+``donsetch.binary`` config field — it is a filesystem path, not an API key.
 """
 
 from __future__ import annotations
 
 import json
 import os
+import re
 import select
 import shutil
 import subprocess
+import threading
 import time
 from typing import Any
 from urllib.parse import urlsplit
@@ -23,6 +26,16 @@ from wsp_sdk import ProviderSpec, extract_result, search_result, source_result
 _ALLOWED_OUTPUT_FORMATS = {"markdown"}
 _ALLOWED_SEARCH_TYPES = {"search", "news"}
 _ALLOWED_INTENTS = {"auto", "web", "code", "paper", "news", "entity"}
+TESTED_VERSION = "2.3.1"
+STDERR_LIMIT = 2048
+_VERSION_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
+_SECRET_RE = re.compile(
+    r"(?i)\b(api[_-]?key|token|secret|password|authorization|bearer)\b\s*[:=]\s*\S+"
+)
+_HOME_RE = re.compile(r"(?i)(/root|/home/[^/\s]+|/Users/[^/\s]+)")
+
+_last_stderr = ""
+_stderr_lock = threading.Lock()
 
 
 def _bounded_int(value: Any, default: int, minimum: int, maximum: int) -> int:
@@ -93,20 +106,106 @@ def _url_allowed_by_domains(
     )
 
 
-def _resolve_binary(key: str | None, config: dict[str, Any]) -> str:
+def _candidate_binary(key: str | None, config: dict[str, Any]) -> str:
     section = config.get("donsetch", {}) if isinstance(config, dict) else {}
     if not isinstance(section, dict):
         section = {}
     candidate = key or section.get("binary") or section.get("api_key")
     if not isinstance(candidate, str) or not candidate.strip():
-        candidate = shutil.which("donsetch")
-    else:
-        candidate = candidate.strip()
-        if not os.path.isabs(candidate):
-            candidate = shutil.which(candidate) or ""
+        return shutil.which("donsetch") or ""
+    candidate = candidate.strip()
+    if not os.path.isabs(candidate):
+        return shutil.which(candidate) or ""
+    return candidate
+
+
+def _resolve_binary(key: str | None, config: dict[str, Any]) -> str:
+    candidate = _candidate_binary(key, config)
     if not candidate or not os.path.isfile(candidate) or not os.access(candidate, os.X_OK):
         raise RuntimeError("donsetch_binary_not_configured")
     return candidate
+
+
+def sanitize_stderr(text: str, limit: int = STDERR_LIMIT) -> str:
+    if not isinstance(text, str) or not text:
+        return ""
+    cleaned = _SECRET_RE.sub(lambda match: f"{match.group(1)}=[redacted]", text)
+    cleaned = _HOME_RE.sub("[path]", cleaned)
+    if len(cleaned) > limit:
+        return cleaned[:limit] + "…"
+    return cleaned
+
+
+def _remember_stderr(text: str) -> None:
+    global _last_stderr
+    with _stderr_lock:
+        _last_stderr = sanitize_stderr(text)
+
+
+def _last_stderr_excerpt() -> str:
+    with _stderr_lock:
+        return _last_stderr
+
+
+def _parse_version(text: str) -> str | None:
+    match = _VERSION_RE.search(text or "")
+    if not match:
+        return None
+    return f"{int(match.group(1))}.{int(match.group(2))}.{int(match.group(3))}"
+
+
+def _compatibility(version: str | None) -> str:
+    if not version:
+        return "unknown"
+    major, minor, patch = (int(part) for part in version.split("."))
+    tested_major, tested_minor, tested_patch = (int(part) for part in TESTED_VERSION.split("."))
+    if (major, minor, patch) == (tested_major, tested_minor, tested_patch):
+        return "tested"
+    if major == tested_major:
+        return "compatible_unverified"
+    return "incompatible_major"
+
+
+def inspect_donsetch_readiness(
+    *,
+    binary: str | None = None,
+    key: str | None = None,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Describe local DonSeTch binary readiness without treating the path as a key."""
+    report = {
+        "state": "missing",
+        "version": None,
+        "tested_version": TESTED_VERSION,
+        "compatibility": "unknown",
+        "binary_configured": False,
+    }
+    candidate = binary if isinstance(binary, str) else _candidate_binary(key, config or {})
+    if not candidate:
+        return report
+    report["binary_configured"] = True
+    if not os.path.isfile(candidate):
+        return report
+    if not os.access(candidate, os.X_OK):
+        report["state"] = "not_executable"
+        return report
+    report["state"] = "executable"
+    try:
+        completed = subprocess.run(
+            [candidate, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return report
+    version = _parse_version((completed.stdout or "") + "\n" + (completed.stderr or ""))
+    report["version"] = version
+    report["compatibility"] = _compatibility(version)
+    return report
 
 
 def _mcp_response_from_stdout(stdout: str, request_id: int) -> dict[str, Any]:
@@ -167,83 +266,177 @@ def _mcp_result(message: dict[str, Any], request_id: int) -> dict[str, Any]:
     return result
 
 
-def _call_donsetch_tool(
-    binary: str,
-    tool: str,
-    arguments: dict[str, Any],
-    timeout_seconds: int,
-) -> dict[str, Any]:
-    initialize = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": "initialize",
-        "params": {
-            "protocolVersion": "2025-11-25",
-            "capabilities": {},
-            "clientInfo": {"name": "web-search-plus", "version": "4.0.0"},
-        },
+def _payload_from_tool_result(result: dict[str, Any]) -> dict[str, Any]:
+    if result.get("isError") or result.get("is_error"):
+        raise RuntimeError("donsetch_tool_error")
+    structured = result.get("structuredContent")
+    if not isinstance(structured, dict):
+        structured = result.get("structured_content")
+    if not isinstance(structured, dict):
+        structured = {}
+    return {
+        "structured": structured,
+        "text": _text_content(result.get("content")),
     }
-    initialized = {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}
-    call = {
-        "jsonrpc": "2.0",
-        "id": 2,
-        "method": "tools/call",
-        "params": {"name": tool, "arguments": arguments},
-    }
-    process = None
-    deadline = time.monotonic() + timeout_seconds
-    try:
-        process = subprocess.Popen(
-            [binary, "mcp"],
+
+
+class DonsetchSession:
+    """One initialized DonSeTch stdio MCP process for one WSP request."""
+
+    def __init__(self, binary: str, timeout_seconds: int):
+        self.binary = binary
+        self.timeout_seconds = timeout_seconds
+        self._process: subprocess.Popen[str] | None = None
+        self._next_id = 1
+        self._deadline = 0.0
+        self._stderr = ""
+        self._stderr_thread: threading.Thread | None = None
+        self._closed = False
+
+    def __enter__(self) -> DonsetchSession:
+        try:
+            self._start()
+            self._initialize()
+            return self
+        except Exception:
+            self.close()
+            raise
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self.close()
+        return False
+
+    def _start(self) -> None:
+        self._deadline = time.monotonic() + self.timeout_seconds
+        self._process = subprocess.Popen(
+            [self.binary, "mcp"],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
             text=True,
             encoding="utf-8",
             errors="replace",
             bufsize=1,
             env=os.environ.copy(),
         )
-        if process.stdin is None:
+        self._stderr_thread = threading.Thread(target=self._collect_stderr, daemon=True)
+        self._stderr_thread.start()
+        if self._process.stdin is None or self._process.stdout is None:
             raise RuntimeError("donsetch_process_failed")
-        process.stdin.write(json.dumps(initialize, separators=(",", ":")) + "\n")
-        process.stdin.flush()
-        _mcp_result(_read_mcp_message(process, 1, deadline), 1)
-        process.stdin.write(json.dumps(initialized, separators=(",", ":")) + "\n")
-        process.stdin.write(json.dumps(call, separators=(",", ":")) + "\n")
-        process.stdin.flush()
-        result = _mcp_result(_read_mcp_message(process, 2, deadline), 2)
-        if result.get("isError") or result.get("is_error"):
-            raise RuntimeError("donsetch_tool_error")
-        structured = result.get("structuredContent")
-        if not isinstance(structured, dict):
-            structured = result.get("structured_content")
-        if not isinstance(structured, dict):
-            structured = {}
-        return {
-            "structured": structured,
-            "text": _text_content(result.get("content")),
-        }
+
+    def _collect_stderr(self) -> None:
+        process = self._process
+        if process is None or process.stderr is None:
+            return
+        chunks: list[str] = []
+        try:
+            while True:
+                piece = process.stderr.read(256)
+                if not piece:
+                    break
+                chunks.append(piece)
+                joined = "".join(chunks)
+                if len(joined) > STDERR_LIMIT:
+                    chunks = [joined[:STDERR_LIMIT]]
+                    # Keep draining so the child cannot block on a full pipe.
+        except OSError:
+            pass
+        self._stderr = "".join(chunks)[:STDERR_LIMIT]
+        _remember_stderr(self._stderr)
+
+    def _write(self, payload: dict[str, Any]) -> None:
+        process = self._process
+        if process is None or process.stdin is None:
+            raise RuntimeError("donsetch_process_failed")
+        try:
+            process.stdin.write(json.dumps(payload, separators=(",", ":")) + "\n")
+            process.stdin.flush()
+        except (BrokenPipeError, OSError) as exc:
+            raise RuntimeError("donsetch_process_failed") from exc
+
+    def _initialize(self) -> None:
+        request_id = self._next_id
+        self._next_id += 1
+        self._write(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": {"name": "web-search-plus", "version": TESTED_VERSION},
+                },
+            }
+        )
+        assert self._process is not None
+        _mcp_result(_read_mcp_message(self._process, request_id, self._deadline), request_id)
+        self._write({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+
+    def call(self, tool: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        request_id = self._next_id
+        self._next_id += 1
+        self._write(
+            {
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": "tools/call",
+                "params": {"name": tool, "arguments": arguments},
+            }
+        )
+        assert self._process is not None
+        result = _mcp_result(_read_mcp_message(self._process, request_id, self._deadline), request_id)
+        return _payload_from_tool_result(result)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        process = self._process
+        if process is None:
+            _remember_stderr(self._stderr)
+            return
+        if process.stdin is not None:
+            try:
+                process.stdin.close()
+            except OSError:
+                pass
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                try:
+                    process.wait(timeout=1)
+                except subprocess.TimeoutExpired:
+                    pass
+        if process.stderr is not None:
+            try:
+                process.stderr.close()
+            except OSError:
+                pass
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=0.5)
+        _remember_stderr(self._stderr)
+        self._process = None
+
+
+def _call_donsetch_tool(
+    binary: str,
+    tool: str,
+    arguments: dict[str, Any],
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    try:
+        with DonsetchSession(binary, timeout_seconds) as session:
+            return session.call(tool, arguments)
     except FileNotFoundError:
         raise RuntimeError("donsetch_binary_not_configured") from None
     except TimeoutError:
         raise RuntimeError("donsetch_timeout") from None
     except (BrokenPipeError, OSError):
         raise RuntimeError("donsetch_process_failed") from None
-    finally:
-        if process is not None:
-            if process.stdin is not None:
-                try:
-                    process.stdin.close()
-                except OSError:
-                    pass
-            if process.poll() is None:
-                process.terminate()
-                try:
-                    process.wait(timeout=1)
-                except subprocess.TimeoutExpired:
-                    process.kill()
-                    process.wait()
 
 
 def _search_intent(args: Any) -> str:
@@ -405,23 +598,29 @@ def execute_extract(
         tier = "auto"
 
     projected = []
-    for requested_url in [str(url) for url in urls]:
-        payload = _call_donsetch_tool(
-            binary,
-            "web_fetch",
-            {
-                "url": requested_url,
-                "max_chars": max_chars,
-                "media": bool(include_images),
-                "tier": tier,
-            },
-            timeout_seconds,
-        )
-        result = _project_fetch_item(payload, requested_url)
-        if include_raw_html and not result.get("error"):
-            # DonSeTch deliberately returns Markdown; do not label it HTML.
-            result["raw_error"] = "donsetch_raw_html_unsupported"
-        projected.append(result)
+    try:
+        with DonsetchSession(binary, timeout_seconds) as session:
+            for requested_url in [str(url) for url in urls]:
+                payload = session.call(
+                    "web_fetch",
+                    {
+                        "url": requested_url,
+                        "max_chars": max_chars,
+                        "media": bool(include_images),
+                        "tier": tier,
+                    },
+                )
+                result = _project_fetch_item(payload, requested_url)
+                if include_raw_html and not result.get("error"):
+                    # DonSeTch deliberately returns Markdown; do not label it HTML.
+                    result["raw_error"] = "donsetch_raw_html_unsupported"
+                projected.append(result)
+    except FileNotFoundError:
+        raise RuntimeError("donsetch_binary_not_configured") from None
+    except TimeoutError:
+        raise RuntimeError("donsetch_timeout") from None
+    except (BrokenPipeError, OSError):
+        raise RuntimeError("donsetch_process_failed") from None
     return extract_result(prov, projected)
 
 

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 4.0.0
+Version: 4.0.1
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable, Serper.

--- a/tests/providers_d/test_donsetch_provider.py
+++ b/tests/providers_d/test_donsetch_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
 from types import SimpleNamespace
 
@@ -169,25 +170,35 @@ def test_extract_projects_markdown_and_marks_raw_html_as_unsupported(monkeypatch
     spec, module = _provider()
     calls = []
 
-    def fake_call(binary, tool, arguments, timeout):
-        calls.append((tool, arguments))
-        return {
-            "structured": {
-                "url": "https://example.org/page",
-                "title": "Example",
-                "status": 200,
-                "content_ok": True,
-                "content_kind": "Article",
-                "quality": 0.8,
-                "lang": "en",
-                "site": "example.org",
-                "verdict": "ContentOk",
-                "pdf": None,
-            },
-            "text": "# Example\n\nBody",
-        }
+    class FakeSession:
+        def __init__(self, _binary, _timeout):
+            pass
 
-    monkeypatch.setitem(module, "_call_donsetch_tool", fake_call)
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def call(self, tool, arguments):
+            calls.append((tool, arguments))
+            return {
+                "structured": {
+                    "url": "https://example.org/page",
+                    "title": "Example",
+                    "status": 200,
+                    "content_ok": True,
+                    "content_kind": "Article",
+                    "quality": 0.8,
+                    "lang": "en",
+                    "site": "example.org",
+                    "verdict": "ContentOk",
+                    "pdf": None,
+                },
+                "text": "# Example\n\nBody",
+            }
+
+    monkeypatch.setitem(module, "DonsetchSession", FakeSession)
     result = spec.execute_extract(
         None,
         "donsetch",
@@ -212,20 +223,30 @@ def test_extract_render_js_requests_browser_tier(monkeypatch):
     spec, module = _provider()
     seen = []
 
-    def fake_call(_binary, _tool, arguments, _timeout):
-        seen.append(arguments)
-        return {
-            "structured": {
-                "url": arguments["url"],
-                "status": 200,
-                "content_ok": True,
-                "content_kind": "Page",
-                "verdict": "ContentOk",
-            },
-            "text": "content",
-        }
+    class FakeSession:
+        def __init__(self, _binary, _timeout):
+            pass
 
-    monkeypatch.setitem(module, "_call_donsetch_tool", fake_call)
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def call(self, _tool, arguments):
+            seen.append(arguments)
+            return {
+                "structured": {
+                    "url": arguments["url"],
+                    "status": 200,
+                    "content_ok": True,
+                    "content_kind": "Page",
+                    "verdict": "ContentOk",
+                },
+                "text": "content",
+            }
+
+    monkeypatch.setitem(module, "DonsetchSession", FakeSession)
     spec.execute_extract(
         None,
         "donsetch",
@@ -257,3 +278,247 @@ def test_extract_rejects_non_markdown_without_network(monkeypatch):
             {},
             False,
         )
+
+
+_FAKE_MCP = r'''#!/usr/bin/env python3
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+mode = os.environ.get("DONSETCH_FAKE_MODE", "ok")
+state = Path(os.environ["DONSETCH_FAKE_STATE"])
+pid_path = state / "pid"
+init_path = state / "initialize_count"
+call_path = state / "call_count"
+pid_path.write_text(str(os.getpid()), encoding="utf-8")
+
+def bump(path):
+    current = int(path.read_text(encoding="utf-8")) if path.exists() else 0
+    path.write_text(str(current + 1), encoding="utf-8")
+    return current + 1
+
+def reply(message, payload):
+    print(json.dumps({"jsonrpc": "2.0", "id": message["id"], **payload}), flush=True)
+
+def fetch_ok(url):
+    return {
+        "result": {
+            "content": [{"type": "text", "text": f"body:{url}"}],
+            "structuredContent": {
+                "url": url,
+                "status": 200,
+                "content_ok": True,
+                "content_kind": "Page",
+                "verdict": "ContentOk",
+                "title": "ok",
+            },
+        }
+    }
+
+if mode == "stderr":
+    sys.stderr.write("token=supersecretvalue " + ("x" * 4000) + "\n")
+    sys.stderr.flush()
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    try:
+        message = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    method = message.get("method")
+    if method == "initialize":
+        bump(init_path)
+        if mode == "init-error":
+            reply(message, {"error": {"code": -32000, "message": "nope"}})
+            break
+        if mode == "malformed":
+            print("{not-json", flush=True)
+            continue
+        reply(message, {"result": {}})
+        if mode == "hang":
+            time.sleep(30)
+    elif method == "notifications/initialized":
+        continue
+    elif method == "tools/call":
+        bump(call_path)
+        if mode == "tool-error":
+            reply(message, {"result": {"isError": True, "content": [{"type": "text", "text": "boom"}]}})
+            continue
+        if mode == "broken-json":
+            print("[[[", flush=True)
+            continue
+        args = message.get("params", {}).get("arguments", {})
+        url = args.get("url") or "https://example.org/search"
+        reply(message, fetch_ok(url) if message["params"]["name"] == "web_fetch" else {
+            "result": {
+                "content": [{"type": "text", "text": "hits"}],
+                "structuredContent": {
+                    "results": [{"url": url, "title": "hit", "snippet": "s"}],
+                    "engines": [],
+                    "intent": "auto",
+                    "cached": False,
+                    "weak": False,
+                    "elapsed_ms": 1,
+                },
+            }
+        })
+'''
+
+
+def _write_fake(tmp_path, mode="ok"):
+    state = tmp_path / "state"
+    state.mkdir()
+    binary = tmp_path / "donsetch"
+    binary.write_text(_FAKE_MCP, encoding="utf-8")
+    binary.chmod(0o700)
+    env = {
+        "DONSETCH_FAKE_MODE": mode,
+        "DONSETCH_FAKE_STATE": str(state),
+    }
+    return binary, state, env
+
+
+def _alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def test_multi_url_extract_reuses_one_initialized_mcp_session(tmp_path, monkeypatch):
+    spec, _module = _provider()
+    binary, state, env = _write_fake(tmp_path)
+    monkeypatch.setenv("DONSETCH_FAKE_MODE", env["DONSETCH_FAKE_MODE"])
+    monkeypatch.setenv("DONSETCH_FAKE_STATE", env["DONSETCH_FAKE_STATE"])
+    result = spec.execute_extract(
+        None,
+        "donsetch",
+        ["https://example.org/a", "https://example.org/b", "https://example.org/c"],
+        str(binary),
+        "markdown",
+        False,
+        False,
+        False,
+        {"donsetch": {"timeout": 5}},
+        False,
+    )
+    assert (state / "initialize_count").read_text(encoding="utf-8") == "1"
+    assert (state / "call_count").read_text(encoding="utf-8") == "3"
+    assert [item["url"] for item in result["results"]] == [
+        "https://example.org/a",
+        "https://example.org/b",
+        "https://example.org/c",
+    ]
+    pid = int((state / "pid").read_text(encoding="utf-8"))
+    assert _alive(pid) is False
+
+
+def test_session_closes_after_successful_search(tmp_path, monkeypatch):
+    spec, _module = _provider()
+    binary, state, env = _write_fake(tmp_path)
+    monkeypatch.setenv("DONSETCH_FAKE_MODE", env["DONSETCH_FAKE_MODE"])
+    monkeypatch.setenv("DONSETCH_FAKE_STATE", env["DONSETCH_FAKE_STATE"])
+    result = spec.execute_search(
+        None,
+        "donsetch",
+        _search_args(),
+        str(binary),
+        {"donsetch": {"timeout": 5}},
+        {},
+    )
+    assert result["provider"] == "donsetch"
+    assert (state / "initialize_count").read_text(encoding="utf-8") == "1"
+    assert (state / "call_count").read_text(encoding="utf-8") == "1"
+    pid = int((state / "pid").read_text(encoding="utf-8"))
+    assert _alive(pid) is False
+
+
+@pytest.mark.parametrize(
+    ("mode", "error"),
+    [
+        ("hang", "donsetch_timeout"),
+        ("malformed", "donsetch_timeout|donsetch_mcp_failed|donsetch_mcp_contract_failed"),
+        ("init-error", "donsetch_mcp_initialize_failed"),
+        ("tool-error", "donsetch_tool_error"),
+        ("broken-json", "donsetch_mcp_failed|donsetch_mcp_contract_failed|donsetch_timeout"),
+    ],
+)
+def test_failed_mcp_paths_raise_typed_errors_and_reap_child(tmp_path, monkeypatch, mode, error):
+    spec, _module = _provider()
+    binary, state, env = _write_fake(tmp_path, mode=mode)
+    monkeypatch.setenv("DONSETCH_FAKE_MODE", mode)
+    monkeypatch.setenv("DONSETCH_FAKE_STATE", env["DONSETCH_FAKE_STATE"])
+    with pytest.raises(RuntimeError, match=error):
+        spec.execute_extract(
+            None,
+            "donsetch",
+            ["https://example.org/page"],
+            str(binary),
+            "markdown",
+            False,
+            False,
+            False,
+            {"donsetch": {"timeout": 1}},
+            False,
+        )
+    pid = int((state / "pid").read_text(encoding="utf-8"))
+    assert _alive(pid) is False
+
+
+def test_stderr_capture_is_bounded_sanitized_and_absent_from_success(tmp_path, monkeypatch):
+    spec, module = _provider()
+    binary, state, env = _write_fake(tmp_path, mode="stderr")
+    monkeypatch.setenv("DONSETCH_FAKE_MODE", "stderr")
+    monkeypatch.setenv("DONSETCH_FAKE_STATE", env["DONSETCH_FAKE_STATE"])
+    result = spec.execute_search(
+        None,
+        "donsetch",
+        _search_args(),
+        str(binary),
+        {"donsetch": {"timeout": 5}},
+        {},
+    )
+    dumped = json.dumps(result)
+    assert "supersecretvalue" not in dumped
+    excerpt = module["sanitize_stderr"](module["_last_stderr_excerpt"]())
+    assert len(excerpt) <= module["STDERR_LIMIT"] + 1
+    assert "supersecretvalue" not in excerpt
+    assert "token=[redacted]" in excerpt
+
+
+def test_version_detection_classifies_missing_tested_compatible_and_incompatible(tmp_path):
+    _spec, module = _provider()
+    missing = module["inspect_donsetch_readiness"](binary="")
+    assert missing["state"] == "missing"
+
+    blocked = tmp_path / "blocked"
+    blocked.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    blocked.chmod(0o600)
+    not_exec = module["inspect_donsetch_readiness"](binary=str(blocked))
+    assert not_exec["state"] == "not_executable"
+
+    def _version_bin(text: str):
+        path = tmp_path / f"bin-{text.replace('.', '-')}"
+        path.write_text(f"#!/bin/sh\necho 'DonSeTch {text}'\n", encoding="utf-8")
+        path.chmod(0o700)
+        return str(path)
+
+    tested = module["inspect_donsetch_readiness"](binary=_version_bin("2.3.1"))
+    assert tested["state"] == "executable"
+    assert tested["version"] == "2.3.1"
+    assert tested["compatibility"] == "tested"
+    assert tested["tested_version"] == "2.3.1"
+    assert "api_key" not in tested
+
+    other = module["inspect_donsetch_readiness"](binary=_version_bin("2.1.0"))
+    assert other["compatibility"] == "compatible_unverified"
+    assert other["version"] == "2.1.0"
+
+    major = module["inspect_donsetch_readiness"](binary=_version_bin("3.0.0"))
+    assert major["compatibility"] == "incompatible_major"
+    assert major["state"] == "executable"

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "4.0.0"
+EXPECTED_VERSION = "4.0.1"
 
 
 def _load_plugin_module():
@@ -61,7 +61,7 @@ def test_current_release_surfaces_and_attribution():
     env_template = (ROOT / ".env.template").read_text()
     current_surfaces = "\n".join((readme, release_notes, user_guide, env_template))
 
-    assert "Current release: **v4.0.0**" in readme
+    assert "Current release: **v4.0.1**" in readme
     assert "docs/RELEASE_NOTES_V400.md" in readme
     assert "DonSeTch 2.1.0" in release_notes
     assert "explicit-only" in release_notes

--- a/ui.py
+++ b/ui.py
@@ -434,7 +434,7 @@ def create_server(
     cache_root: str | Path = CACHE_DIR,
     state_path: str | Path | None = None,
     config: Mapping[str, Any] | None = None,
-    plugin_version: str = "4.0.0",
+    plugin_version: str = "4.0.1",
     snapshot_backend: Any = operator_console_v3,
     static_root: str | Path | None = None,
 ) -> ThreadingHTTPServer:


### PR DESCRIPTION
## Summary
- Live-tested against **DonSeTch 2.3.1** (stdio Search + multi-URL Fetch); TESTED_VERSION bumped from 2.1.0.
- Reuse one initialized DonSeTch stdio MCP session for every URL in a single `web_extract_plus` call.
- Reap the DonSeTch child on timeout, initialize failure, tool errors, malformed MCP output, and broken pipes.
- Capture a bounded, sanitized stderr excerpt for diagnostics. Successful Search/Extract responses stay clean.
- Report DonSeTch binary readiness from `setup.py status` (`missing` / `not_executable` / `executable`, plus `2.3.1` tested vs other 2.x / incompatible major). `DONSETCH_BIN` is treated as a path, not an API key.
- Refresh the GitHub repository description and topics after the Hound → DonSeTch migration.

## Test Plan
- [x] Focused DonSeTch provider tests (session reuse, cleanup, stderr, version classes)
- [x] `ruff check --config ruff.toml .`
- [x] `python3 -m pytest tests/ -q` (1014 passed locally; the previous AJV miss was missing `node_modules`, then `node tests/schema_boundary_v3.mjs` passed after `npm ci`)
- [x] `python scripts/gen_provider_docs.py --check`
- [x] `python scripts/gen_contract_v3_schemas.py --check`
- [x] `python3 -m compileall -q .`

## Notes
- DonSeTch stays separately installed, explicit-only, and out of automatic routing.
- Tested DonSeTch version remains 2.1.0. Newer 2.x versions are accepted with a `compatible_unverified` warning and are not hard-blocked.
- No new provider, no contract change, no homepage/PyPI in this PR.

