### PR TITLE
docs: update DonSeTch version comment in .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -39,5 +39,5 @@ FIRECRAWL_API_KEY=***
 # SearXNG (self-hosted, no API key needed — just set your instance URL)
 # SEARXNG_INSTANCE_URL=https://your-searxng-instance.example.com
 
-# DonSeTch 2.1.0 (local stdio MCP; explicit-only)
+# DonSeTch 2.3.1 (local stdio MCP; explicit-only)
 # DONSETCH_BIN=/absolute/path/to/donsetch


### PR DESCRIPTION
Trivial follow-up: the tracked .env.template still referenced DonSeTch 2.1.0 while TESTED_VERSION is 2.3.1. Comment-only change.