### PR TITLE
feat: 4.0.3 test DonSeTch 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ## [Unreleased]
 
-## [v4.0.3] — 2026-08-24
+## [v4.0.3] — 2026-08-25
 
 ### Changed
 - Bump the tested DonSeTch version to 3.2.1. Live stdio Search and Fetch still
   work; 2.x binaries now report `incompatible_major`.
+- Correct Architecture `auto_allow` examples so Brave and Parallel match the
+  live registry defaults.
 
 ## [v4.0.2] — 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v4.0.3] — 2026-08-24
+
+### Changed
+- Bump the tested DonSeTch version to 3.2.1. Live stdio Search and Fetch still
+  work; 2.x binaries now report `incompatible_major`.
+
 ## [v4.0.2] — 2026-08-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ It adds two Hermes tools:
 
 > Ported from [web-search-plus-plugin](https://github.com/robbyczgw-cla/web-search-plus-plugin) for the [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin API.
 
-Current release: **v4.0.2** — see the [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
+Current release: **v4.0.3** — see the [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
+
+### What's new in 4.0.3
+
+The local DonSeTch adapter is now tested against 3.2.1. Install `donsetch@3.2.1`. Older 2.x binaries report `incompatible_major`.
 
 ### What's new in 4.0.2
 
@@ -75,7 +79,7 @@ Provider privacy is not uniform. Before sending sensitive queries or URLs, revie
 
 ### Upgrading to 4.0.0
 
-The core tools and existing keyed providers remain available, but the optional Hound integration was removed. If you used Hound, follow the [DonSeTch migration guide](docs/DONSETCH.md#migration-from-hound): install DonSeTch 2.3.1 separately, set `DONSETCH_BIN`, and change explicit `provider="hound"` calls to `provider="donsetch"`.
+The core tools and existing keyed providers remain available, but the optional Hound integration was removed. If you used Hound, follow the [DonSeTch migration guide](docs/DONSETCH.md#migration-from-hound): install DonSeTch 3.2.1 separately, set `DONSETCH_BIN`, and change explicit `provider="hound"` calls to `provider="donsetch"`.
 
 ### Self-hosted / no-paid-key profile
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v4.0.2
+web-search-plus — Hermes Plugin v4.0.3
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "4.0.2"
+__version__ = "4.0.3"
 
 import argparse
 import getpass
@@ -697,7 +697,7 @@ def _donsetch_status(env: Mapping[str, str], config: Mapping[str, Any]) -> Dict[
         return {
             "state": "missing",
             "version": None,
-            "tested_version": "2.3.1",
+            "tested_version": "3.2.1",
             "compatibility": "unknown",
             "binary_configured": bool(_clean_env_value(env.get("DONSETCH_BIN") or "")),
         }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,8 +69,9 @@ Default routing config includes:
     "auto_allow": {
       "serpbase": false,
       "querit": false,
-      "brave": false,
-      "parallel": false
+      "octen": false,
+      "tinyfish": false,
+      "donsetch": false
     },
     "confidence_threshold": 0.3
   }
@@ -107,17 +108,19 @@ Example:
 ```json
 "auto_allow": {
   "serpbase": false,
-  "parallel": false,
   "querit": false,
-  "brave": false
+  "octen": false,
+  "tinyfish": false,
+  "donsetch": false
 }
 ```
 
 With this config:
 
 - `provider="serpbase"` can work when `SERPBASE_API_KEY` is present.
-- `provider="parallel"` can work when `PARALLEL_API_KEY` is present.
-- `provider="auto"` will not select guarded providers such as SerpBase or Parallel unless opted in.
+- `provider="donsetch"` can work when `DONSETCH_BIN` is present.
+- `provider="auto"` will not select SerpBase, Querit, Octen, TinyFish, or DonSeTch unless opted in.
+- Brave and Parallel join automatic routing when their keys are configured.
 - fallback lists will not silently choose guarded providers.
 - `quality_report` can surface guarded providers under `auto_allow_excluded`.
 

--- a/docs/DONSETCH.md
+++ b/docs/DONSETCH.md
@@ -1,7 +1,7 @@
 # DonSeTch local provider
 
 Web Search Plus 4.0 can use [DonSeTch](https://github.com/dondai44423/donsetch)
-2.3.1 as a separately installed local provider for source-only Search and
+3.2.1 as a separately installed local provider for source-only Search and
 Extract. DonSeTch is an independent AGPL-3.0-only project. Web Search Plus
 does not bundle, copy, or redistribute its binary.
 
@@ -16,7 +16,7 @@ routing or fallback.
 The upstream project distributes a platform binary through npm:
 
 ```bash
-npm install -g donsetch@2.3.1
+npm install -g donsetch@3.2.1
 command -v donsetch
 donsetch --version
 donsetch doctor
@@ -99,6 +99,6 @@ longer read by WSP, and `HOUND_MCP_URL` has no effect in version 4.0.
 - In the standalone MCP package, explicit DonSeTch calls get a 195-second outer
   subprocess budget, covering the adapter's 180-second stdio timeout; other
   provider budgets remain unchanged.
-- This integration was tested against DonSeTch 2.3.1 for stdio MCP
+- This integration was tested against DonSeTch 3.2.1 for stdio MCP
   initialization, Search, Fetch, and structured error handling. Successful
   browser/anti-bot execution remains an environment-dependent open gate.

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -97,7 +97,7 @@ Independent web index for search and extraction; works keyless, optional key rai
 
 ### DonSeTch (local MCP)
 
-Local DonSeTch 2.x stdio MCP provider for metasearch, direct extraction, PDF/OCR-aware fetching, and optional browser escalation.
+Local DonSeTch 3.x stdio MCP provider for metasearch, direct extraction, PDF/OCR-aware fetching, and optional browser escalation.
 
 ### Octen via Monid
 

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/4.0.2"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/4.0.3"
 
 
 class ProviderRequestError(Exception):

--- a/operator_console_v3.py
+++ b/operator_console_v3.py
@@ -532,7 +532,7 @@ def build_overview(
     config: Mapping[str, Any] | None = None,
     provider_ids: Sequence[str] | None = None,
     state_path: str | Path | None = None,
-    plugin_version: str = "4.0.2",
+    plugin_version: str = "4.0.3",
     now: Callable[[], float] = time.time,
 ) -> dict[str, Any]:
     root = Path(cache_root)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "4.0.2"
+version: "4.0.3"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/providers.d/donsetch.py
+++ b/providers.d/donsetch.py
@@ -26,7 +26,7 @@ from wsp_sdk import ProviderSpec, extract_result, search_result, source_result
 _ALLOWED_OUTPUT_FORMATS = {"markdown"}
 _ALLOWED_SEARCH_TYPES = {"search", "news"}
 _ALLOWED_INTENTS = {"auto", "web", "code", "paper", "news", "entity"}
-TESTED_VERSION = "2.3.1"
+TESTED_VERSION = "3.2.1"
 STDERR_LIMIT = 2048
 _VERSION_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
 _SECRET_RE = re.compile(
@@ -630,7 +630,7 @@ PROVIDER = ProviderSpec(
     env_var="DONSETCH_BIN",
     display_name="DonSeTch (local MCP)",
     description=(
-        "Local DonSeTch 2.x stdio MCP provider for metasearch, direct extraction, "
+        "Local DonSeTch 3.x stdio MCP provider for metasearch, direct extraction, "
         "PDF/OCR-aware fetching, and optional browser escalation."
     ),
     config_section="donsetch",

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 4.0.2
+Version: 4.0.3
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable, Serper.

--- a/tests/providers_d/test_donsetch_provider.py
+++ b/tests/providers_d/test_donsetch_provider.py
@@ -510,17 +510,17 @@ def test_version_detection_classifies_missing_tested_compatible_and_incompatible
         path.chmod(0o700)
         return str(path)
 
-    tested = module["inspect_donsetch_readiness"](binary=_version_bin("2.3.1"))
+    tested = module["inspect_donsetch_readiness"](binary=_version_bin("3.2.1"))
     assert tested["state"] == "executable"
-    assert tested["version"] == "2.3.1"
+    assert tested["version"] == "3.2.1"
     assert tested["compatibility"] == "tested"
-    assert tested["tested_version"] == "2.3.1"
+    assert tested["tested_version"] == "3.2.1"
     assert "api_key" not in tested
 
-    other = module["inspect_donsetch_readiness"](binary=_version_bin("2.1.0"))
+    other = module["inspect_donsetch_readiness"](binary=_version_bin("3.0.0"))
     assert other["compatibility"] == "compatible_unverified"
-    assert other["version"] == "2.1.0"
+    assert other["version"] == "3.0.0"
 
-    major = module["inspect_donsetch_readiness"](binary=_version_bin("3.0.0"))
+    major = module["inspect_donsetch_readiness"](binary=_version_bin("2.3.1"))
     assert major["compatibility"] == "incompatible_major"
     assert major["state"] == "executable"

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -1,8 +1,12 @@
+from pathlib import Path
+
 import provider_registry as registry
 import config
 import extract
 import search
 import __init__ as plugin
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_provider_registry_is_the_complete_capability_source():
@@ -70,3 +74,11 @@ def test_provider_argparse_choices_stay_in_registry_sync():
     parser = search.build_parser_for_tests()
     provider_action = next(action for action in parser._actions if "--provider" in action.option_strings)
     assert tuple(choice for choice in provider_action.choices if choice != "auto") == registry.SEARCH_PROVIDER_IDS
+
+
+def test_architecture_auto_allow_examples_match_registry_defaults():
+    text = (ROOT / "docs" / "ARCHITECTURE.md").read_text()
+    assert '"brave": false' not in text
+    assert '"parallel": false' not in text
+    for name in registry.DEFAULT_AUTO_ALLOW:
+        assert f'"{name}": false' in text

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "4.0.2"
+EXPECTED_VERSION = "4.0.3"
 
 
 def _load_plugin_module():
@@ -61,7 +61,7 @@ def test_current_release_surfaces_and_attribution():
     env_template = (ROOT / ".env.template").read_text()
     current_surfaces = "\n".join((readme, release_notes, user_guide, env_template))
 
-    assert "Current release: **v4.0.2**" in readme
+    assert "Current release: **v4.0.3**" in readme
     assert "docs/RELEASE_NOTES_V400.md" in readme
     assert "DonSeTch 2.1.0" in release_notes
     assert "explicit-only" in release_notes

--- a/ui.py
+++ b/ui.py
@@ -434,7 +434,7 @@ def create_server(
     cache_root: str | Path = CACHE_DIR,
     state_path: str | Path | None = None,
     config: Mapping[str, Any] | None = None,
-    plugin_version: str = "4.0.2",
+    plugin_version: str = "4.0.3",
     snapshot_backend: Any = operator_console_v3,
     static_root: str | Path | None = None,
 ) -> ThreadingHTTPServer:


### PR DESCRIPTION
## Summary
- Bump the tested DonSeTch version from 2.3.1 to **3.2.1**.
- Live stdio `web_search` and `web_fetch` still work with the existing adapter.
- 2.x binaries now report `incompatible_major`.
- Architecture `auto_allow` examples now match registry defaults (Brave and Parallel stay auto when keyed; SerpBase, Querit, Octen, TinyFish, DonSeTch stay explicit-only).

## Verification
- Local DonSeTch host binary is 3.2.1.
- Live adapter Search + Fetch against 3.2.1 succeeded.
- Plugin suite: 1020 passed.

## Notes
- DonSeTch is still not bundled. Operators install `donsetch@3.2.1` separately.
- No merge/tag in this PR.
