### PR TITLE
fix: 4.0.4 query boundaries and runtime cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Preserve queries beginning with `-` through structured search requests and subprocess adapters. Treat `spans_query` as data even when it resembles a CLI flag.
+- Reject malformed section shapes in the shared budget-preflight helper.
+- Update the schema-test dependency `fast-uri` to 3.1.7 to remove its URI parsing advisories.
+
+### Changed
+
+- Share daily-budget settings and adapter-signature validation without removing either enforcement boundary.
+- Replace prose-only compatibility assertions with export and defensive-copy checks; remove the nonexistent `search_provider` from the compatibility inventory.
+- Remove empty section headers and the pass-through contract-error factory.
+
 ## [v4.0.3] — 2026-08-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v4.0.4] — 2026-09-04
+
 ### Fixed
 
 - Preserve queries beginning with `-` through structured search requests and subprocess adapters. Treat `spans_query` as data even when it resembles a CLI flag.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ It adds two Hermes tools:
 
 > Ported from [web-search-plus-plugin](https://github.com/robbyczgw-cla/web-search-plus-plugin) for the [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin API.
 
-Current release: **v4.0.3** — see the [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
+Current release: **v4.0.4** — see the [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
+
+### What's new in 4.0.4
+
+Queries beginning with `-`, such as `-site:reddit.com`, now remain search text across the API and subprocess paths. This patch also consolidates budget and adapter checks while preserving existing interfaces. See the [4.0.4 release notes](docs/RELEASE_NOTES_V404.md).
 
 ### What's new in 4.0.3
 

--- a/__init__.py
+++ b/__init__.py
@@ -1465,7 +1465,7 @@ def _run_search_subprocess(
     cmd = [
         sys.executable,
         str(_SEARCH_SCRIPT),
-        "--query", query,
+        f"--query={query}",
         "--provider", provider,
         "--max-results", str(count),
         "--compact",
@@ -1586,7 +1586,7 @@ def _run_extract_subprocess(
     if spans:
         cmd.append("--spans")
     if spans_query is not None:
-        cmd.extend(["--spans-query", spans_query])
+        cmd.append(f"--spans-query={spans_query}")
 
     env = os.environ.copy()
     try:

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v4.0.3
+web-search-plus — Hermes Plugin v4.0.4
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "4.0.3"
+__version__ = "4.0.4"
 
 import argparse
 import getpass

--- a/budget_preflight_v3.py
+++ b/budget_preflight_v3.py
@@ -2,8 +2,30 @@
 
 from __future__ import annotations
 
+import os
+import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, Literal, Mapping, Sequence
+
+
+def daily_preflight_budget(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the optional global provider-call ledger settings for attempts."""
+    raw_off = os.environ.get("WSP_BUDGET_PREFLIGHT_OFF")
+    if raw_off is not None and raw_off.strip().strip('"').strip("'").lower() not in {
+        "", "0", "false", "no", "off",
+    }:
+        return {}
+    section = config.get("budget_preflight", {})
+    if not isinstance(section, dict):
+        raise ValueError("budget_preflight must be an object")
+    limit = section.get("max_daily_provider_calls")
+    if section.get("enabled") is not True or isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
+        return {}
+    return {
+        "daily_budget_scope": "daily_provider_calls",
+        "daily_budget_window": time.strftime("%Y-%m-%d", time.gmtime()),
+        "daily_budget_limit_units": limit,
+    }
 
 
 CHECK_NAMES = (

--- a/docs/RELEASE_NOTES_V404.md
+++ b/docs/RELEASE_NOTES_V404.md
@@ -1,0 +1,16 @@
+# Web Search Plus 4.0.4
+
+## Fixed
+
+- Preserve queries such as `--help` and `-site:reddit.com` as search text through structured requests and subprocess adapters. Apply the same treatment to `spans_query`.
+- Reject malformed section shapes in the shared budget-preflight helper.
+
+## Maintenance
+
+- Share daily-budget settings and adapter-signature validation while retaining both enforcement boundaries.
+- Replace prose-only compatibility assertions with checks of real exports and defensive copies. Remove the nonexistent `search_provider` entry from the compatibility inventory, not an implementation.
+- Remove empty section headers and the pass-through contract-error factory.
+
+No provider, tool-schema, or configuration migration is required.
+
+The schema-test dependency `fast-uri` is updated to 3.1.7 to remove its URI parsing advisories.

--- a/extract.py
+++ b/extract.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
+from budget_preflight_v3 import daily_preflight_budget as _daily_preflight_budget
+
 from config import (
     ProviderConfigError,
     SELF_HOSTED_EXTRACT_PROVIDER_IDS,
@@ -80,24 +82,6 @@ def _extract_provider_auto_allowed(provider: str, auto_config: Dict[str, Any]) -
     if not isinstance(auto_allow, dict):
         return default_allowed
     return bool(auto_allow.get(provider, default_allowed))
-
-
-def _daily_preflight_budget(config: Dict[str, Any]) -> Dict[str, Any]:
-    """Return the optional global provider-call ledger settings for attempts."""
-    raw_off = os.environ.get("WSP_BUDGET_PREFLIGHT_OFF")
-    if raw_off is not None and raw_off.strip().strip('"').strip("'").lower() not in {
-        "", "0", "false", "no", "off",
-    }:
-        return {}
-    section = config.get("budget_preflight") or {}
-    limit = section.get("max_daily_provider_calls") if isinstance(section, dict) else None
-    if section.get("enabled") is not True or isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
-        return {}
-    return {
-        "daily_budget_scope": "daily_provider_calls",
-        "daily_budget_window": time.strftime("%Y-%m-%d", time.gmtime()),
-        "daily_budget_limit_units": limit,
-    }
 
 
 def resolve_extract_provider_priority(config: Optional[Dict[str, Any]] = None) -> List[str]:

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/4.0.3"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/4.0.4"
 
 
 class ProviderRequestError(Exception):

--- a/operator_console_v3.py
+++ b/operator_console_v3.py
@@ -532,7 +532,7 @@ def build_overview(
     config: Mapping[str, Any] | None = None,
     provider_ids: Sequence[str] | None = None,
     state_path: str | Path | None = None,
-    plugin_version: str = "4.0.3",
+    plugin_version: str = "4.0.4",
     now: Callable[[], float] = time.time,
 ) -> dict[str, Any]:
     root = Path(cache_root)

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,9 +34,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "4.0.3"
+version: "4.0.4"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/provider_adapter_protocol.py
+++ b/provider_adapter_protocol.py
@@ -139,10 +139,6 @@ def assert_dispatch_conformance(
         raise RuntimeError("provider adapter protocol violation: " + ";".join(errors))
 
 
-def _contract_failure(code: str) -> ProviderContractFailure:
-    return ProviderContractFailure(code)
-
-
 def validate_adapter_result(
     provider: str,
     capability: str,
@@ -155,32 +151,32 @@ def validate_adapter_result(
     """
 
     if capability not in {"search", "extract"}:
-        raise _contract_failure("unsupported_capability")
+        raise ProviderContractFailure("unsupported_capability")
     if not isinstance(payload, dict):
-        raise _contract_failure("envelope_not_mutable_mapping")
+        raise ProviderContractFailure("envelope_not_mutable_mapping")
     if payload.get("provider") != provider:
-        raise _contract_failure("provider_mismatch")
+        raise ProviderContractFailure("provider_mismatch")
 
     results = payload.get("results")
     if not isinstance(results, list):
-        raise _contract_failure("results_not_list")
+        raise ProviderContractFailure("results_not_list")
     for item in results:
         if not isinstance(item, dict):
-            raise _contract_failure("result_not_mapping")
+            raise ProviderContractFailure("result_not_mapping")
         url = item.get("url")
         if not isinstance(url, str) or (capability == "search" and not url):
-            raise _contract_failure("result_url_invalid")
+            raise ProviderContractFailure("result_url_invalid")
 
     answer = payload.get("answer")
     if answer not in {None, ""}:
-        raise _contract_failure("non_source_answer")
+        raise ProviderContractFailure("non_source_answer")
 
     if capability == "search":
         if not isinstance(payload.get("query"), str):
-            raise _contract_failure("search_query_invalid")
+            raise ProviderContractFailure("search_query_invalid")
         if "images" in payload and not isinstance(payload["images"], list):
-            raise _contract_failure("search_images_invalid")
+            raise ProviderContractFailure("search_images_invalid")
         if "metadata" in payload and not isinstance(payload["metadata"], dict):
-            raise _contract_failure("search_metadata_invalid")
+            raise ProviderContractFailure("search_metadata_invalid")
 
     return payload

--- a/provider_registry.py
+++ b/provider_registry.py
@@ -9,11 +9,16 @@ from __future__ import annotations
 
 import ast
 import importlib.util
-import inspect
 import os
 import re
 from pathlib import Path
 from typing import Dict, Iterable
+
+from provider_adapter_protocol import (
+    SEARCH_ADAPTER_PARAMETERS as _SEARCH_PARAMETERS,
+    EXTRACT_ADAPTER_PARAMETERS as _EXTRACT_PARAMETERS,
+    _signature_matches,
+)
 
 from wsp_sdk import (
     DuplicateProviderError,
@@ -34,14 +39,6 @@ def _non_production_discovery_allowed() -> bool:
 
 _PROVIDER_ID_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _ENV_VAR_PATTERN = re.compile(r"^[A-Z][A-Z0-9_]*$")
-_SEARCH_PARAMETERS = (
-    "search_module", "prov", "args", "key", "config", "routing_info",
-)
-_EXTRACT_PARAMETERS = (
-    "extract_module", "prov", "urls", "key", "output_format",
-    "include_images", "include_raw_html", "render_js", "config",
-    "keyless_allowed",
-)
 
 
 # These records retain every pre-SDK default explicitly.  Discovered providers
@@ -206,20 +203,6 @@ def _refresh_derived_surfaces() -> None:
     KEYLESS_PROVIDER_IDS = tuple(spec.provider for spec in _provider_specs if spec.keyless)
     KEYLESS_EXTRACT_PROVIDER_IDS = tuple(
         spec.provider for spec in _provider_specs if spec.keyless and spec.supports_extract
-    )
-
-
-def _signature_matches(adapter: object, expected: tuple[str, ...]) -> bool:
-    if not callable(adapter):
-        return False
-    try:
-        parameters = tuple(inspect.signature(adapter).parameters.values())
-    except (TypeError, ValueError):
-        return False
-    return tuple(parameter.name for parameter in parameters) == expected and all(
-        parameter.kind in {inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD}
-        and parameter.default is inspect.Parameter.empty
-        for parameter in parameters
     )
 
 

--- a/search.py
+++ b/search.py
@@ -583,6 +583,15 @@ def build_parser_for_tests() -> argparse.ArgumentParser:
     return parser
 
 
+class _StoreQueryText(argparse.Action):
+    """Preserve literal -- on Python 3.10 as well as newer argparse versions."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        # Python 3.10 strips '--' even from a single attached option value.
+        # With nargs=None this empty list cannot represent omitted input.
+        setattr(namespace, self.dest, "--" if values == [] else values)
+
+
 def build_parser(config: Dict[str, Any]) -> argparse.ArgumentParser:
     """Build the search.py CLI argument parser.
 
@@ -675,7 +684,7 @@ Full docs: See README.md and SKILL.md
     )
     parser.add_argument(
         "--query", "-q", 
-        help="Search query"
+        action=_StoreQueryText, help="Search query"
     )
     parser.add_argument(
         "--extract-urls",
@@ -693,7 +702,7 @@ Full docs: See README.md and SKILL.md
     parser.add_argument("--include-raw-html", action="store_true", help="Include raw HTML when supported")
     parser.add_argument("--render-js", action="store_true", help="Render JavaScript before extraction when supported")
     parser.add_argument("--spans", action="store_true", help="Select deterministic semantic spans from extracted text")
-    parser.add_argument("--spans-query", help="Query used to rank extracted semantic spans")
+    parser.add_argument("--spans-query", action=_StoreQueryText, help="Query used to rank extracted semantic spans")
     parser.add_argument(
         "--max-results", "-n", 
         type=int, 

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 4.0.3
+Version: 4.0.4
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable, Serper.

--- a/search.py
+++ b/search.py
@@ -26,6 +26,7 @@ Examples:
 
 from __future__ import annotations
 
+
 import argparse
 import json
 import os
@@ -49,6 +50,8 @@ from cache import (
     cache_put,
     cache_stats,
 )
+from budget_preflight_v3 import daily_preflight_budget as _daily_preflight_budget
+
 from config import (  # noqa: F401 - re-exported for backward-compatible tests/imports
     DEFAULT_CONFIG,
     ProviderConfigError,
@@ -138,7 +141,6 @@ COMPATIBILITY_SHIM_DEPRECATION = {
     "public_surface": [
         "QueryAnalyzer",
         "auto_route_provider",
-        "search_provider",
         "extract_plus",
         "get_cached_result",
         "cache_search_result",
@@ -191,111 +193,6 @@ def explain_routing(*args, **kwargs):
 
 def _provider_auto_allowed(*args, **kwargs):
     return _routing._provider_auto_allowed(*args, **kwargs)
-
-
-
-
-
-
-# =============================================================================
-# Intelligent Auto-Routing Engine
-# =============================================================================
-
-
-
-
-
-
-
-
-
-
-
-
-
-# ProviderRequestError and TRANSIENT_HTTP_CODES live in http_client.py.
-# Provider cooldown/backoff constants live in provider_health.py.
-
-
-
-
-
-
-# =============================================================================
-# HTTP Client
-# =============================================================================
-
-
-
-# HTTP request helpers live in http_client.py and are imported above for backward-compatible monkeypatching.
-
-
-# =============================================================================
-# Serper (Google Search API)
-# =============================================================================
-
-
-
-# =============================================================================
-# SerpBase (Google SERP API)
-# =============================================================================
-
-
-
-
-
-
-
-# =============================================================================
-# Brave Search
-# =============================================================================
-
-
-
-# =============================================================================
-# Tavily (Research Search)
-# =============================================================================
-
-
-
-# =============================================================================
-# Querit (Multi-lingual search API for AI, with rich metadata and real-time information)
-# =============================================================================
-
-
-
-
-
-# =============================================================================
-# Linkup Search
-# =============================================================================
-
-
-
-# =============================================================================
-# Firecrawl Search
-# =============================================================================
-
-
-
-
-
-# =============================================================================
-# Extract Plus (URL Content Extraction)
-# =============================================================================
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -1862,60 +1759,34 @@ def _plan_search_v3(request: RequestV3, config: Dict[str, Any]) -> ProviderPlan:
     return ProviderPlan(tuple(candidates), selected, routing_metadata=dict(routed))
 
 
-def _daily_preflight_budget(config: Dict[str, Any]) -> Dict[str, Any]:
-    """Return the optional global provider-call ledger settings for attempts."""
-    raw_off = os.environ.get("WSP_BUDGET_PREFLIGHT_OFF")
-    if raw_off is not None and raw_off.strip().strip('"').strip("'").lower() not in {
-        "", "0", "false", "no", "off",
-    }:
-        return {}
-    section = config.get("budget_preflight") or {}
-    limit = section.get("max_daily_provider_calls") if isinstance(section, dict) else None
-    if section.get("enabled") is not True or isinstance(limit, bool) or not isinstance(limit, int) or limit < 1:
-        return {}
-    return {
-        "daily_budget_scope": "daily_provider_calls",
-        "daily_budget_window": time.strftime("%Y-%m-%d", time.gmtime()),
-        "daily_budget_limit_units": limit,
-    }
-
-
 def _search_args_from_v3(request: RequestV3, config: Dict[str, Any]):
+    # Keep CLI defaults, but never parse request data as command-line syntax.
+    args = build_parser(config).parse_args([])
     options = request.options
     routing_request = request.routing
-    argv: List[str] = [
-        "--query", request.input["query"],
-        "--provider", str(routing_request.get("provider") or "auto"),
-        "--max-results", str(options.get("max_results", 5)),
-    ]
-    if options.get("depth", "normal") != "normal":
-        argv += ["--exa-depth", str(options["depth"])]
-    if options.get("time_range"):
-        argv += ["--time-range", str(options["time_range"])]
-    if options.get("freshness"):
-        argv += ["--freshness", str(options["freshness"])]
-    if options.get("search_type"):
-        argv += ["--search-type", str(options["search_type"])]
-    if options.get("include_domains"):
-        argv += ["--include-domains", *options["include_domains"]]
-    if options.get("exclude_domains"):
-        argv += ["--exclude-domains", *options["exclude_domains"]]
-    if options.get("mode", "normal") != "normal":
-        argv += ["--mode", str(options["mode"]), "--research-time-budget", str(options.get("research_time_budget", 55.0))]
-    if options.get("quality_report"):
-        argv += ["--quality-report"]
+    args.query = request.input["query"]
+    args.provider = routing_request.get("provider") or "auto"
+    args.max_results = options.get("max_results", 5)
+    args.exa_depth = options.get("depth", "normal")
+    for name in ("time_range", "freshness", "search_type", "quality_report"):
+        if options.get(name):
+            setattr(args, name, options[name])
+    for name in ("include_domains", "exclude_domains"):
+        if options.get(name):
+            setattr(args, name, list(options[name]))
+    args.mode = options.get("mode", "normal")
+    if args.mode != "normal":
+        args.research_time_budget = options.get("research_time_budget", 55.0)
     locale = options.get("locale") or {}
-    if locale.get("language"):
-        argv += ["--language", str(locale["language"])]
-    if locale.get("country"):
-        argv += ["--country", str(locale["country"])]
+    for name in ("language", "country"):
+        if locale.get(name):
+            setattr(args, name, locale[name])
     if routing_request.get("allow_fallback") and routing_request.get("mode") == "fixed":
-        argv += ["--allow-fallback"]
+        args.allow_fallback = True
     if request.cache.get("mode") == "bypass":
-        argv += ["--no-cache"]
+        args.no_cache = True
     if "ttl_seconds" in request.cache:
-        argv += ["--cache-ttl", str(request.cache["ttl_seconds"])]
-    args = build_parser(config).parse_args(argv)
+        args.cache_ttl = request.cache["ttl_seconds"]
     args._v3_no_legacy_cache_write = True
     return args
 

--- a/tests/test_compatibility_shims.py
+++ b/tests/test_compatibility_shims.py
@@ -1,26 +1,23 @@
-import importlib.util
-from pathlib import Path
+import search
 
-SEARCH_PATH = Path(__file__).resolve().parents[1] / "search.py"
-search_spec = importlib.util.spec_from_file_location("wsp_search_shim_policy_under_test", SEARCH_PATH)
-assert search_spec is not None
-search = importlib.util.module_from_spec(search_spec)
-assert search_spec.loader is not None
-search_spec.loader.exec_module(search)
+import pytest
 
 
-def test_compatibility_shim_policy_documents_public_surface_and_removal_path():
+PUBLIC_EXPORTS = (
+    "QueryAnalyzer", "auto_route_provider", "extract_plus",
+    "get_cached_result", "cache_search_result", "clear_cache", "get_cache_stats",
+)
+
+
+def test_legacy_public_exports_remain_callable():
+    for name in PUBLIC_EXPORTS:
+        assert callable(getattr(search, name)), name
+    assert set(search.get_compatibility_shim_policy()["public_surface"]) == set(PUBLIC_EXPORTS)
+
+
+@pytest.mark.parametrize("field", ["public_surface", "internal_shims"])
+def test_policy_lists_are_defensive_copies(field):
     policy = search.get_compatibility_shim_policy()
-
-    assert policy["tracking_issue"] == "#34"
-    assert "ProviderSpec registry" in policy["removal_target"]
-    assert "one documented minor release window" in policy["removal_target"]
-    assert "v2.3" not in policy["removal_target"]
-    assert "QueryAnalyzer" in policy["public_surface"]
-    assert "extract_plus" in policy["public_surface"]
-    assert "extract_url_content" not in policy["public_surface"]
-    assert "_sync_provider_dependencies" in policy["internal_shims"]
-    assert "do not remove wrappers" in policy["policy"]
-
-    policy["public_surface"].append("mutated")
-    assert "mutated" not in search.get_compatibility_shim_policy()["public_surface"]
+    original = policy[field].copy()
+    policy[field].append("mutated")
+    assert search.get_compatibility_shim_policy()[field] == original

--- a/tests/test_query_boundaries.py
+++ b/tests/test_query_boundaries.py
@@ -1,0 +1,72 @@
+"""Public search requests must remain data, never command-line options."""
+import pytest
+
+import extract
+import search
+from config import _deepcopy_default_config
+from contract_v3 import RequestV3
+
+
+@pytest.fixture
+def runtime_config(tmp_path, monkeypatch):
+    config = _deepcopy_default_config()
+    config['serper']['api_key'] = 'test-serper-key'
+    config.setdefault('v3', {})
+    config['v3']['state_path'] = str(tmp_path / 'state.sqlite3')
+    config['v3']['cache_dir'] = str(tmp_path / 'cache')
+    config['quality']['filter_spam'] = False
+    monkeypatch.setattr(search, 'load_config', lambda: config)
+    return config
+
+
+@pytest.mark.parametrize('query', ['--help', '-site:reddit.com', '--', '-q=other', 'normal query', '日本語 query'])
+def test_public_search_preserves_query(query, runtime_config, monkeypatch):
+    seen = []
+
+    def provider(**kwargs):
+        seen.append(kwargs['query'])
+        return {
+            'provider': 'serper', 'query': kwargs['query'],
+            'results': [{'title': 'Fixture source', 'url': 'https://example.org/source', 'snippet': 'Source text'}],
+            'images': [], 'answer': '', 'metadata': {},
+        }
+
+    monkeypatch.setattr(search, 'search_serper', provider)
+    result = search.run_search_request(query=query, provider='serper', count=1)
+    assert seen == [query]
+    assert result['query'] == query
+    assert result['results'][0]['url'] == 'https://example.org/source'
+
+
+def test_v3_argument_projection_preserves_controls(runtime_config):
+    request = RequestV3.from_dict({
+        'contract_version': '3.0',
+        'capability': 'search', 'input': {'query': '--help'},
+        'routing': {'provider': 'serper', 'mode': 'fixed', 'allow_fallback': True},
+        'options': {
+            'max_results': 7, 'depth': 'normal', 'time_range': 'week',
+            'freshness': 'day', 'search_type': 'news',
+            'include_domains': ['example.org'], 'exclude_domains': ['example.net'],
+            'mode': 'research', 'research_time_budget': 12, 'quality_report': True,
+            'locale': {'country': 'at', 'language': 'de'},
+        },
+        'cache': {'mode': 'bypass', 'ttl_seconds': 120},
+    })
+    args = search._search_args_from_v3(request, runtime_config)
+    assert (args.query, args.provider, args.max_results) == ('--help', 'serper', 7)
+    assert (args.time_range, args.freshness, args.search_type) == ('week', 'day', 'news')
+    assert args.include_domains == ['example.org']
+    assert args.exclude_domains == ['example.net']
+    assert (args.country, args.language) == ('at', 'de')
+    assert (args.mode, args.research_time_budget, args.quality_report) == ('research', 12, True)
+    assert args.allow_fallback is True
+    assert args.no_cache is True
+    assert args.cache_ttl == 120
+
+
+@pytest.mark.parametrize('module', [search, extract], ids=['search', 'extract'])
+@pytest.mark.parametrize('section', ['bad-shape', ['bad-shape'], True])
+def test_invalid_budget_section_is_a_config_error(module, section, monkeypatch):
+    monkeypatch.delenv('WSP_BUDGET_PREFLIGHT_OFF', raising=False)
+    with pytest.raises(ValueError, match='budget_preflight must be an object'):
+        module._daily_preflight_budget({'budget_preflight': section})

--- a/tests/test_query_subprocess_boundaries.py
+++ b/tests/test_query_subprocess_boundaries.py
@@ -1,0 +1,31 @@
+import importlib.util
+from pathlib import Path
+import search
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+spec = importlib.util.spec_from_file_location("query_boundary_plugin", Path(__file__).resolve().parents[1] / "__init__.py")
+assert spec is not None and spec.loader is not None
+boundary = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(boundary)
+
+
+@pytest.mark.parametrize("text", ["--help", "-site:reddit.com", "--", "normal query"])
+@pytest.mark.parametrize("capability", ["search", "extract"])
+def test_subprocess_arguments_preserve_free_text(text, capability, monkeypatch):
+    seen = []
+
+    def run(cmd, **kwargs):
+        args = search.build_parser({}).parse_args(cmd[2:])
+        seen.append(args.query if capability == "search" else args.spans_query)
+        return SimpleNamespace(returncode=0, stdout=json.dumps({"results": [], "query": text}), stderr="")
+
+    monkeypatch.setattr(boundary.subprocess, "run", run)
+    if capability == "search":
+        boundary._run_search_subprocess(text, provider="serper")
+    else:
+        boundary._run_extract_subprocess(["https://example.org"], provider="serper", spans=True, spans_query=text)
+    assert seen == [text]

--- a/tests/test_query_subprocess_boundaries.py
+++ b/tests/test_query_subprocess_boundaries.py
@@ -13,7 +13,7 @@ boundary = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(boundary)
 
 
-@pytest.mark.parametrize("text", ["--help", "-site:reddit.com", "--", "normal query"])
+@pytest.mark.parametrize("text", ["--help", "-site:reddit.com", "--", "", "normal query"])
 @pytest.mark.parametrize("capability", ["search", "extract"])
 def test_subprocess_arguments_preserve_free_text(text, capability, monkeypatch):
     seen = []

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "4.0.3"
+EXPECTED_VERSION = "4.0.4"
 
 
 def _load_plugin_module():
@@ -61,7 +61,7 @@ def test_current_release_surfaces_and_attribution():
     env_template = (ROOT / ".env.template").read_text()
     current_surfaces = "\n".join((readme, release_notes, user_guide, env_template))
 
-    assert "Current release: **v4.0.3**" in readme
+    assert "Current release: **v4.0.4**" in readme
     assert "docs/RELEASE_NOTES_V400.md" in readme
     assert "DonSeTch 2.1.0" in release_notes
     assert "explicit-only" in release_notes

--- a/ui.py
+++ b/ui.py
@@ -434,7 +434,7 @@ def create_server(
     cache_root: str | Path = CACHE_DIR,
     state_path: str | Path | None = None,
     config: Mapping[str, Any] | None = None,
-    plugin_version: str = "4.0.3",
+    plugin_version: str = "4.0.4",
     snapshot_backend: Any = operator_console_v3,
     static_root: str | Path | None = None,
 ) -> ThreadingHTTPServer:


### PR DESCRIPTION
## Summary

Release 4.0.4 with the dash-prefixed query fix and targeted runtime cleanup.

- Preserve query and spans-query values through the public API and subprocess boundary.
- Share budget settings and adapter-signature checks without removing enforcement sites.
- Replace policy-wording checks with executable compatibility tests.
- Update release metadata, install pins, and notes; no provider or tool-schema migration.

## Verification

- Query regressions reproduced before the fixes and green afterward.
- Sterile full suites on the fixes: Hermes 1,043 tests plus 6 subtests; MCP 441 tests.
- 16 local HTTP integration cases through fresh Hermes discovery, both Hermes execution paths, and the installed MCP wheel with both protocol generations.
- Release-version checks, Ruff, generated schemas, and diff/privacy checks passed.
- No paid provider calls; no active-install or gateway changes.

Final 4.0.4 full suite also passes. Schema-test fast-uri updated to 3.1.7; npm audit reports no vulnerabilities.
