### PR TITLE
feat: release 4.1.0 native Hermes backend and DonSeTch 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [v4.0.5] — 2026-09-05
+
+- Support DonSeTch 3.6.1 compact MCP evidence and namespaced diagnostics; retain older structured responses.
+- Preserve rank/URL binding and force stdio only for the DonSeTch child process.
+
 ## [v4.0.4] — 2026-09-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add the opt-in `wsp` native Hermes backend for `web_search` and `web_extract`, using the existing in-process WSP engine. Search and extraction can be selected independently.
 - Keep the Plus tools and existing routing defaults. Native calls return an error rather than starting the CLI fallback when the in-process engine is unavailable.
 - Make the Fastpath doctor aware of native backend selection and profile-specific `HERMES_HOME`.
+- Thanks to [LugMuad](https://github.com/LugMuad) for the native-backend proposal and follow-up testing in [#125](https://github.com/robbyczgw-cla/hermes-web-search-plus/issues/125).
 
 - Support DonSeTch 3.6.1 compact MCP evidence and namespaced diagnostics; retain older structured responses.
 - Preserve rank/URL binding and force stdio only for the DonSeTch child process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 
-## [v4.0.5] — 2026-09-05
+## [v4.1.0] — 2026-09-05
+
+- Add the opt-in `wsp` native Hermes backend for `web_search` and `web_extract`, using the existing in-process WSP engine. Search and extraction can be selected independently.
+- Keep the Plus tools and existing routing defaults. Native calls return an error rather than starting the CLI fallback when the in-process engine is unavailable.
+- Make the Fastpath doctor aware of native backend selection and profile-specific `HERMES_HOME`.
 
 - Support DonSeTch 3.6.1 compact MCP evidence and namespaced diagnostics; retain older structured responses.
 - Preserve rank/URL binding and force stdio only for the DonSeTch child process.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It adds two Hermes tools:
 
 > Ported from [web-search-plus-plugin](https://github.com/robbyczgw-cla/web-search-plus-plugin) for the [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin API.
 
-Current release: **v4.1.0** (unreleased candidate) — see the [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
+Current release: **v4.1.0** — see the [release notes](docs/RELEASE_NOTES_V410.md) and [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
 
 ### What's new in 4.1.0
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ It adds two Hermes tools:
 
 > Ported from [web-search-plus-plugin](https://github.com/robbyczgw-cla/web-search-plus-plugin) for the [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin API.
 
-Current release: **v4.0.4** — see the [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
+Current release: **v4.0.5** — see the [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
+
+### What's new in 4.0.5
+
+The DonSeTch adapter supports the 3.6.1 compact MCP response format while retaining older structured responses. Search titles and snippets remain attached to their source URLs; fetch diagnostics are read from namespaced metadata. See the [4.0.5 release notes](docs/RELEASE_NOTES_V405.md).
 
 ### What's new in 4.0.4
 
@@ -83,7 +87,7 @@ Provider privacy is not uniform. Before sending sensitive queries or URLs, revie
 
 ### Upgrading to 4.0.0
 
-The core tools and existing keyed providers remain available, but the optional Hound integration was removed. If you used Hound, follow the [DonSeTch migration guide](docs/DONSETCH.md#migration-from-hound): install DonSeTch 3.2.1 separately, set `DONSETCH_BIN`, and change explicit `provider="hound"` calls to `provider="donsetch"`.
+The core tools and existing keyed providers remain available, but the optional Hound integration was removed. If you used Hound, follow the [DonSeTch migration guide](docs/DONSETCH.md#migration-from-hound): install DonSeTch 3.6.1 separately, set `DONSETCH_BIN`, and change explicit `provider="hound"` calls to `provider="donsetch"`.
 
 ### Self-hosted / no-paid-key profile
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ It adds two Hermes tools:
 
 > Ported from [web-search-plus-plugin](https://github.com/robbyczgw-cla/web-search-plus-plugin) for the [Hermes Agent](https://github.com/NousResearch/hermes-agent) plugin API.
 
-Current release: **v4.0.5** — see the [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
+Current release: **v4.1.0** (unreleased candidate) — see the [Changelog](CHANGELOG.md). The 4.0.0 DonSeTch migration notes remain in [4.0.0 Release Notes](docs/RELEASE_NOTES_V400.md).
 
-### What's new in 4.0.5
+### What's new in 4.1.0
 
-The DonSeTch adapter supports the 3.6.1 compact MCP response format while retaining older structured responses. Search titles and snippets remain attached to their source URLs; fetch diagnostics are read from namespaced metadata. See the [4.0.5 release notes](docs/RELEASE_NOTES_V405.md).
+The opt-in `wsp` backend routes Hermes' native `web_search` and `web_extract` calls through the existing WSP engine in-process. Existing Plus tools remain available and installation does not select the new backend. See [Native Hermes backend](docs/NATIVE_BACKEND.md) for selection, mixed routing, and runtime limits.
+
+The DonSeTch adapter also supports the 3.6.1 compact MCP response format while retaining older structured responses. Search titles and snippets remain attached to their source URLs; fetch diagnostics are read from namespaced metadata.
 
 ### What's new in 4.0.4
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v4.0.5
+web-search-plus — Hermes Plugin v4.1.0
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "4.0.5"
+__version__ = "4.1.0"
 
 import argparse
 import getpass
@@ -193,7 +193,8 @@ def _get_plugin_config_path() -> Path:
 
 def _get_hermes_config_path() -> Path:
     """Return the default Hermes config path inspected by the fast-path doctor."""
-    return Path(os.environ.get("HERMES_CONFIG", Path.home() / ".hermes" / "config.yaml"))
+    home = Path(os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+    return Path(os.environ.get("HERMES_CONFIG") or home / "config.yaml")
 
 
 def _yamlish_has_list_item(text: str, key: str, item: str) -> bool:
@@ -259,6 +260,42 @@ def _yamlish_nested_list_item(text: str, parent: str, key: str, item: str) -> bo
     return False
 
 
+def _native_backend_hints(text: str) -> List[str]:
+    """Inspect native backend pins; stdlib setup supports simple block YAML.
+
+    Use the real YAML parser when installed (as it is in Hermes), retaining a
+    conservative block-scalar fallback for standalone, dependency-free setup.
+    This is advisory only, never a runtime configuration parser.
+    """
+    try:
+        import yaml
+    except ImportError:
+        web: Dict[str, Any] = {}
+        in_web = False
+        for line in text.splitlines():
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            if not line[0].isspace():
+                in_web = bool(re.fullmatch(r"web:\s*(?:#.*)?", line))
+                continue
+            if in_web:
+                match = re.fullmatch(
+                    r"\s+(backend|search_backend|extract_backend):\s*['\"]?([a-z0-9_-]+)['\"]?\s*(?:#.*)?", line
+                )
+                if match:
+                    web[match[1]] = match[2]
+    else:
+        try:
+            data = yaml.safe_load(text)
+            web = data.get("web", {}) if isinstance(data, dict) else {}
+            if not isinstance(web, dict):
+                web = {}
+        except yaml.YAMLError:
+            web = {}
+    return [kind for kind in ("search", "extract")
+            if (web.get(kind + "_backend") or web.get("backend")) == "wsp"]
+
+
 def _build_fastpath_report(config_path: Optional[Path] = None) -> Dict[str, Any]:
     """Inspect local plugin/Hermes hints that affect perceived WSP latency."""
     config_path = config_path or _get_hermes_config_path()
@@ -304,14 +341,25 @@ def _build_fastpath_report(config_path: Optional[Path] = None) -> Dict[str, Any]
             "recommendation": "On current public Hermes builds, set agent.disabled_toolsets: [web] when you want Web Search Plus to be the preferred web path.",
         },
     ])
+    native_capabilities = _native_backend_hints(config_text)
+    if native_capabilities:
+        checks = [check for check in checks if check["id"] != "legacy_web_toolset_disabled"]
+        checks.append({
+            "id": "native_web_toolset_enabled",
+            "ok": not legacy_web_disabled,
+            "detail": "Native WSP selection needs the Hermes web toolset enabled",
+            "recommendation": "Remove only web from agent.disabled_toolsets; preserve other disabled toolsets.",
+        })
     ok = all(check["ok"] for check in checks if check["id"] in {"plugin_tools_declared", "standalone_setup_available"})
-    preferred = ok and legacy_web_disabled
+    preferred = ok and (not legacy_web_disabled if native_capabilities else legacy_web_disabled)
     return {
         "ok": ok,
+        "mode": "native" if native_capabilities else "plus",
+        "native_capabilities": native_capabilities,
         "preferred_web_path_configured": preferred,
         "hermes_config": str(config_path),
         "checks": checks,
-        "recommended_hermes_config": {
+        "recommended_hermes_config": {} if native_capabilities else {
             "agent.disabled_toolsets": ["web"],
         },
         "notes": [
@@ -335,6 +383,14 @@ def _render_fastpath_report(report: Mapping[str, Any]) -> str:
         lines.append(f"  {marker} {check.get('id')}: {check.get('detail')}")
         if not check.get("ok") and check.get("recommendation"):
             lines.append(f"    Tip: {check.get('recommendation')}")
+    if report.get("mode") == "native":
+        lines.extend([
+            "",
+            "Native WSP selected for: " + ", ".join(report.get("native_capabilities", [])),
+            "Keep the Hermes web toolset enabled. This check inspects config only;",
+            "plugin registration and provider readiness require a runtime smoke.",
+        ])
+        return "\n".join(lines)
     lines.extend([
         "",
         "Recommended Hermes config for current public Hermes builds:",
@@ -1408,6 +1464,8 @@ def _run_search(
     language: Optional[str] = None,
     country: Optional[str] = None,
     subprocess_timeout: int = 75,
+    *,
+    inprocess_only: bool = False,
 ) -> dict:
     """Run a search in-process (fast path), falling back to the subprocess engine.
 
@@ -1418,6 +1476,8 @@ def _run_search(
     timeout = _search_timeout(mode, research_time_budget, subprocess_timeout)
     search = None if _force_subprocess() else _load_search_module()
     if search is None:
+        if inprocess_only:
+            return {"error": "WSP in-process engine unavailable; no sidecar fallback", "results": []}
         return _run_search_subprocess(
             query=query, provider=provider, count=count, exa_depth=exa_depth,
             time_range=time_range, freshness=freshness, search_type=search_type,
@@ -1528,10 +1588,14 @@ def _run_extract(
     spans: bool = False,
     spans_query: Optional[str] = None,
     subprocess_timeout: int = 90,
+    *,
+    inprocess_only: bool = False,
 ) -> dict:
     """Run URL extraction in-process (fast path), falling back to the subprocess."""
     search = None if _force_subprocess() else _load_search_module()
     if search is None:
+        if inprocess_only:
+            return {"error": "WSP in-process engine unavailable; no sidecar fallback", "results": []}
         return _run_extract_subprocess(
             urls, provider=provider, output_format=output_format,
             include_images=include_images, include_raw_html=include_raw_html,
@@ -2048,3 +2112,25 @@ def register(ctx: Any) -> None:
 
     if hasattr(ctx, "register_hook"):
         ctx.register_hook("on_session_start", _on_session_start)
+
+    # Opt-in native Hermes WebSearchProvider bridge (name: wsp).
+    # Selected only via web.search_backend / web.extract_backend / web.backend.
+    # Never auto-selected; Plus tools remain the default surface.
+    try:
+        import importlib.util as _ilu
+
+        _nb_path = _PLUGIN_DIR / "native_backend.py"
+        _nb_name = __name__ + "._native_backend"
+        _nb_mod = sys.modules.get(_nb_name)
+        if _nb_mod is None and _nb_path.is_file():
+            _nb_spec = _ilu.spec_from_file_location(_nb_name, _nb_path)
+            if _nb_spec and _nb_spec.loader:
+                _nb_mod = _ilu.module_from_spec(_nb_spec)
+                # Publish only a completely imported module, under this plugin's
+                # namespace. Host modules called native_backend remain untouched.
+                _nb_spec.loader.exec_module(_nb_mod)
+                sys.modules[_nb_name] = _nb_mod
+        if _nb_mod is not None:
+            _nb_mod.register_native_backend(ctx, sys.modules[__name__])
+    except Exception:  # pragma: no cover - never break Plus registration
+        logger.warning("web-search-plus: native wsp backend registration skipped")

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,11 @@
 """
-web-search-plus — Hermes Plugin v4.0.4
+web-search-plus — Hermes Plugin v4.0.5
 Multi-provider web search, URL extraction, quality reports, and opt-in research mode.
 Ported from robbyczgw-cla/web-search-plus-plugin (OpenClaw) to Hermes Plugin API.
 """
 from __future__ import annotations
 
-__version__ = "4.0.4"
+__version__ = "4.0.5"
 
 import argparse
 import getpass
@@ -697,7 +697,7 @@ def _donsetch_status(env: Mapping[str, str], config: Mapping[str, Any]) -> Dict[
         return {
             "state": "missing",
             "version": None,
-            "tested_version": "3.2.1",
+            "tested_version": "3.6.1",
             "compatibility": "unknown",
             "binary_configured": bool(_clean_env_value(env.get("DONSETCH_BIN") or "")),
         }

--- a/docs/DONSETCH.md
+++ b/docs/DONSETCH.md
@@ -1,7 +1,7 @@
 # DonSeTch local provider
 
 Web Search Plus 4.0 can use [DonSeTch](https://github.com/dondai44423/donsetch)
-3.2.1 as a separately installed local provider for source-only Search and
+3.6.1 as a separately installed local provider for source-only Search and
 Extract. DonSeTch is an independent AGPL-3.0-only project. Web Search Plus
 does not bundle, copy, or redistribute its binary.
 
@@ -16,7 +16,7 @@ routing or fallback.
 The upstream project distributes a platform binary through npm:
 
 ```bash
-npm install -g donsetch@3.2.1
+npm install -g donsetch@3.6.1
 command -v donsetch
 donsetch --version
 donsetch doctor
@@ -99,6 +99,6 @@ longer read by WSP, and `HOUND_MCP_URL` has no effect in version 4.0.
 - In the standalone MCP package, explicit DonSeTch calls get a 195-second outer
   subprocess budget, covering the adapter's 180-second stdio timeout; other
   provider budgets remain unchanged.
-- This integration was tested against DonSeTch 3.2.1 for stdio MCP
+- This integration was tested against DonSeTch 3.6.1 for stdio MCP
   initialization, Search, Fetch, and structured error handling. Successful
   browser/anti-bot execution remains an environment-dependent open gate.

--- a/docs/NATIVE_BACKEND.md
+++ b/docs/NATIVE_BACKEND.md
@@ -1,0 +1,50 @@
+# Native Hermes backend
+
+The `wsp` backend lets Hermes' `web_search` and `web_extract` tools call the existing WSP engine in-process. It addresses the integration requested in [#125](https://github.com/robbyczgw-cla/hermes-web-search-plus/issues/125) without the separate CLI wrapper proposed there.
+
+This is an opt-in interface, not a change in search quality or provider policy. Installing WSP does not select it. `web_search_plus` and `web_extract_plus` retain their current schemas and defaults.
+
+## Select the backend
+
+Use a Hermes version that supports `PluginContext.register_web_search_provider` and the `WebSearchProvider` API. Load and enable the existing `web-search-plus` plugin through Hermes. If your Hermes version asks for a provider capability grant, review and grant it through Hermes; this plugin does not bypass that decision.
+
+In the active profile's Hermes `config.yaml`, explicitly select either capability:
+
+```yaml
+web:
+  search_backend: wsp
+  extract_backend: wsp
+```
+
+For mixed routing, keep your extraction provider:
+
+```yaml
+web:
+  search_backend: wsp
+  extract_backend: firecrawl
+```
+
+The shared `web.backend: wsp` setting is also supported. Per-capability settings take precedence. WSP's own routing configuration still controls which underlying provider its `auto` route uses. Explicit-only providers, including DonSeTch, are not automatically opted into the routing pool.
+
+Native tools require the Hermes `web` toolset enabled. If you previously configured Plus-only Fastpath, remove **only** `web` from `agent.disabled_toolsets`, retaining any other disabled toolsets. Inspect the configuration without changing it:
+
+```bash
+python ~/.hermes/plugins/web-search-plus/setup.py fastpath --json
+```
+
+For another profile, use that profile's plugin path and `HERMES_HOME`, or pass `--config-path` explicitly. The doctor inspects configuration; it does not prove a loaded backend or working credentials. Apply runtime changes in a fresh Hermes process when no work is active.
+
+## Behavior and limits
+
+- No CLI fallback: an unavailable in-process engine produces an error. `WSP_FORCE_SUBPROCESS` is incompatible with the native path; it continues to work for the existing Plus tools.
+- Native search uses WSP's 20-result cap. Hermes may bucket a smaller request before dispatch; the adapter reports the effective cap and Hermes slices the final rows.
+- Native tool schemas do not expose the full Plus feature set. Use Plus tools for per-call provider choice, research mode, locale/domain filters, spans, or detailed quality reports.
+- Extraction preserves requested URL association and reports missing or failed items individually. The native Hermes wrapper also applies its own content-size limits.
+- The bridge uses WSP's existing request timeout. A timeout ends the caller's wait; Python cannot forcibly stop an already-running provider thread. It is not a guarantee that upstream network work was cancelled.
+- Hermes' outer search cache keys on the backend name `wsp`, query and count, not WSP's inner provider settings. After changing inner routing or credentials, use a fresh Hermes process rather than expecting an identical cached query to prove the new settings. Do not share one native runtime across different profiles or credential contexts.
+
+## Rollback
+
+Restore your previous `web.search_backend` and `web.extract_backend` settings (and `web.backend`, if set), then apply them in a fresh process. For Plus-only mode, disable the `web` toolset as before. Disabling or unloading WSP removes its native provider registration through Hermes' registration handle; it does not rewrite backend pins in your configuration.
+
+No separate `web/wsp` wrapper plugin is required. Remove or disable a previously installed wrapper before selecting this backend so two plugins do not compete for the `wsp` name.

--- a/docs/RELEASE_NOTES_V405.md
+++ b/docs/RELEASE_NOTES_V405.md
@@ -1,0 +1,10 @@
+# Web Search Plus 4.0.5
+
+## DonSeTch 3.6.1 compatibility
+
+- Read search titles and snippets from the compact text evidence, matched to the original result rank and URL or handle before domain filtering.
+- Recover search diagnostics and fetch title, status, quality, and site from the DonSeTch namespaced metadata. Do not expose the raw debug envelope.
+- Continue accepting pre-compact structured responses.
+- Pin the child transport to stdio even when the parent environment requests HTTP; leave the parent environment unchanged.
+
+DonSeTch remains a separately installed optional provider. Search and extraction stay source-only. No WSP tool-schema migration or automatic backend selection is introduced.

--- a/docs/RELEASE_NOTES_V410.md
+++ b/docs/RELEASE_NOTES_V410.md
@@ -20,7 +20,7 @@ Native calls do not fall back to the WSP CLI when the in-process engine cannot l
 
 The adapter now reads compact MCP evidence and namespaced fetch diagnostics while retaining older structured responses. Search titles and snippets stay bound to their ranked source URLs. The stdio transport setting applies only to the DonSeTch child process.
 
-[DonSeTch](https://github.com/dondai1234/donsetch), by [Bishesh Bhandari (dondai1234)](https://github.com/dondai1234), is a separately installed AGPL-3.0-only program, not bundled WSP code. It remains explicit-only unless the operator opts it into WSP routing. A local installation still performs outbound web requests and consumes local resources.
+[DonSeTch](https://github.com/dondai44423/donsetch), maintained by [dondai44423](https://github.com/dondai44423), is a separately installed AGPL-3.0-only program, not bundled WSP code. It remains explicit-only unless the operator opts it into WSP routing. A local installation still performs outbound web requests and consumes local resources.
 
 Historical Hound integration and source-enrichment work credit [Hound / Master-Fetch](https://github.com/dondai1234/master-fetch), Bishesh Bhandari's independent MIT-licensed project. The removed Hound provider is not restored by this release.
 

--- a/docs/RELEASE_NOTES_V410.md
+++ b/docs/RELEASE_NOTES_V410.md
@@ -1,0 +1,31 @@
+# Web Search Plus 4.1.0
+
+## Native Hermes tools, backed by WSP
+
+Hermes users can now route `web_search` and `web_extract` through WSP's existing in-process engine. The `wsp` backend is opt-in; installing the plugin does not change routing. Existing Plus tools remain available.
+
+```yaml
+web:
+  search_backend: wsp
+  extract_backend: wsp
+```
+
+Search and extraction can use different backends, for example `search_backend: wsp` with `extract_backend: firecrawl`. Keep the Hermes web toolset enabled for this mode. Remove or disable any separate wrapper registering the same `wsp` name, and use Hermes' plugin capability-grant flow when prompted.
+
+Thanks to [LugMuad](https://github.com/LugMuad) for proposing and testing this integration in [#125](https://github.com/robbyczgw-cla/hermes-web-search-plus/issues/125), including the report that native search can also appear through Hermes' browser toolset. This release handles that native search path through WSP when selected; it does not change Hermes' toolset membership rules.
+
+Native calls do not fall back to the WSP CLI when the in-process engine cannot load. Use Plus tools for per-call provider selection, research mode and other controls absent from Hermes' native schemas. Read the [configuration, cache and timeout limits](NATIVE_BACKEND.md).
+
+## DonSeTch 3.6.1
+
+The adapter now reads compact MCP evidence and namespaced fetch diagnostics while retaining older structured responses. Search titles and snippets stay bound to their ranked source URLs. The stdio transport setting applies only to the DonSeTch child process.
+
+[DonSeTch](https://github.com/dondai1234/donsetch), by [Bishesh Bhandari (dondai1234)](https://github.com/dondai1234), is a separately installed AGPL-3.0-only program, not bundled WSP code. It remains explicit-only unless the operator opts it into WSP routing. A local installation still performs outbound web requests and consumes local resources.
+
+Historical Hound integration and source-enrichment work credit [Hound / Master-Fetch](https://github.com/dondai1234/master-fetch), Bishesh Bhandari's independent MIT-licensed project. The removed Hound provider is not restored by this release.
+
+## Verification and scope
+
+The candidate passed 1,082 tests plus six subtests, isolated real Hermes plugin discovery and unload, native/Plus coexistence, and real native DonSeTch search and two-URL extraction. Lint, generated schemas and schema-boundary checks passed.
+
+The native backend is specific to the Hermes plugin. The matching MCP 4.1.0 release carries the DonSeTch adapter update, not Hermes plugin registration. Neither release automatically changes a running host's configuration.

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/4.0.5"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/4.1.0"
 
 
 class ProviderRequestError(Exception):

--- a/http_client.py
+++ b/http_client.py
@@ -14,7 +14,7 @@ from urllib.request import Request, urlopen
 
 
 TRANSIENT_HTTP_CODES = {429, 503}
-DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/4.0.4"
+DEFAULT_USER_AGENT = "ClawdBot-WebSearchPlus/4.0.5"
 
 
 class ProviderRequestError(Exception):

--- a/native_backend.py
+++ b/native_backend.py
@@ -1,0 +1,318 @@
+"""Opt-in native Hermes WebSearchProvider bridge for Web Search Plus.
+
+Registers as backend name ``wsp``. Selection is strictly explicit via Hermes
+config keys:
+
+* ``web.search_backend: wsp``
+* ``web.extract_backend: wsp``
+* ``web.backend: wsp`` (shared fallback)
+
+Never auto-selected. Never falls back to a subprocess/sidecar path — if the
+in-process WSP engine cannot load, search/extract return structured errors.
+Existing ``web_search_plus`` / ``web_extract_plus`` tools are unaffected.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from agent.web_search_provider import WebSearchProvider
+from tools.web_tools import _load_web_config
+
+logger = logging.getLogger(__name__)
+
+# WSP engine hard-cap (matches web_search_plus schema maximum).
+_WSP_MAX_RESULTS = 20
+
+_NATIVE_BACKEND_NAME = "wsp"
+_NATIVE_DISPLAY_NAME = "Web Search Plus (native)"
+
+
+class WSPNativeBackend(WebSearchProvider):
+    """In-process bridge from Hermes ``web_search``/``web_extract`` to WSP."""
+
+    def __init__(
+        self,
+        plugin: Any = None,
+        *,
+        search_provider: str = "auto",
+        extract_provider: str = "auto",
+    ) -> None:
+        if plugin is None:
+            raise RuntimeError(
+                "WSPNativeBackend requires the web-search-plus plugin module"
+            )
+        self.plugin = plugin
+        self.search_provider = search_provider or "auto"
+        self.extract_provider = extract_provider or "auto"
+
+    # -- identity -----------------------------------------------------------
+
+    @property
+    def name(self) -> str:
+        return _NATIVE_BACKEND_NAME
+
+    @property
+    def display_name(self) -> str:
+        return _NATIVE_DISPLAY_NAME
+
+    # -- selection / capability gates ---------------------------------------
+
+    def _selected(self, capability: str) -> bool:
+        """True when Hermes config pins this backend for *capability*.
+
+        Mirrors Hermes resolution order for a single name check:
+        ``web.{capability}_backend`` then shared ``web.backend``.
+        """
+        try:
+            cfg = _load_web_config() or {}
+        except Exception:  # noqa: BLE001 — config optional at probe time
+            cfg = {}
+        if not isinstance(cfg, dict):
+            return False
+        selected = cfg.get(f"{capability}_backend") or cfg.get("backend") or ""
+        return isinstance(selected, str) and selected.strip().lower() == self.name
+
+    def is_available(self) -> bool:
+        # Strictly opt-in. Must stay False unless explicitly selected so the
+        # registry single-provider shortcut and _get_backend plugin walk never
+        # auto-route onto wsp.
+        if not (self._selected("search") or self._selected("extract")) or not self._inprocess_ready():
+            return False
+        try:
+            engine = self.plugin._load_search_module()
+            config = engine.load_config()
+            auto = config.get("auto_routing", {})
+            disabled = set(auto.get("disabled_providers", []) or [])
+            for capability, pin in (("search", self.search_provider), ("extract", self.extract_provider)):
+                if not self._selected(capability):
+                    continue
+                ids = getattr(engine, capability.upper() + "_PROVIDER_IDS")
+                if capability == "search" and pin == "auto" and auto.get("enabled") is False:
+                    pin = config.get("default_provider") or "auto"
+                candidates = ids if pin == "auto" else (pin,)
+                for provider in candidates:
+                    if provider not in ids or provider in disabled:
+                        continue
+                    if pin == "auto" and not engine._provider_auto_allowed(provider, auto):
+                        continue
+                    if engine.provider_configured(provider, config):
+                        return True
+        except Exception:
+            # Offline config inspection only; never probe vendor I/O here.
+            return False
+        return False
+
+    def supports_search(self) -> bool:
+        return self._selected("search")
+
+    def supports_extract(self) -> bool:
+        return self._selected("extract")
+
+    def is_keyless_available(self) -> bool:
+        # Never participate in the keyless free-tier walk.
+        return False
+
+    # -- in-process readiness (no sidecar) ----------------------------------
+
+    def _inprocess_ready(self) -> bool:
+        force = getattr(self.plugin, "_force_subprocess", None)
+        if callable(force) and force():
+            return False
+        load = getattr(self.plugin, "_load_search_module", None)
+        if not callable(load):
+            return False
+        try:
+            return load() is not None
+        except Exception:  # noqa: BLE001
+            logger.warning("WSP native backend: engine load failed")
+            return False
+
+    @staticmethod
+    def _clamp_count(limit: Any) -> int:
+        try:
+            n = int(limit)
+        except (TypeError, ValueError):
+            n = 5
+        return min(_WSP_MAX_RESULTS, max(1, n))
+
+    # -- search -------------------------------------------------------------
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        if not self._inprocess_ready():
+            return {
+                "success": False,
+                "error": "WSP in-process engine unavailable; no sidecar fallback",
+                "data": {"web": []},
+            }
+        count = self._clamp_count(limit)
+        run = getattr(self.plugin, "_run_search")
+        try:
+            data = run(
+                query=query,
+                provider=self.search_provider,
+                count=count,
+                inprocess_only=True,
+            )
+        except Exception:  # noqa: BLE001 — do not expose vendor exception details
+            logger.warning("WSP native search failed")
+            return {
+                "success": False,
+                "error": "WSP native search failed",
+                "data": {"web": []},
+            }
+
+        if not isinstance(data, dict):
+            return {
+                "success": False,
+                "error": "WSP native search returned malformed payload",
+                "data": {"web": []},
+            }
+
+        if data.get("error"):
+            return {
+                "success": False,
+                "error": "WSP native search failed; check provider readiness and configuration",
+                "data": {"web": []},
+            }
+
+        items = data.get("results")
+        if items is None:
+            nested = data.get("data")
+            if isinstance(nested, dict):
+                items = nested.get("web")
+        if not isinstance(items, list):
+            return {"success": False, "error": "WSP native search returned malformed results", "data": {"web": []}}
+
+        rows: List[Dict[str, Any]] = []
+        for i, item in enumerate(items[:count]):
+            if not isinstance(item, dict):
+                continue
+            rows.append(
+                {
+                    "url": str(item.get("url") or ""),
+                    "title": str(item.get("title") or ""),
+                    "description": str(
+                        item.get("snippet")
+                        or item.get("description")
+                        or item.get("content")
+                        or ""
+                    ),
+                    "position": i + 1,
+                }
+            )
+        return {
+            "success": True,
+            "data": {"web": rows},
+            "metadata": {
+                "backend": self.name,
+                "provider": data.get("provider"),
+                "requested_limit": limit,
+                "effective_limit": count,
+            },
+        }
+
+    # -- extract ------------------------------------------------------------
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        url_list = [u for u in (urls or []) if isinstance(u, str) and u.strip()]
+        if not self._inprocess_ready():
+            return [
+                {
+                    "url": url,
+                    "error": "WSP in-process engine unavailable; no sidecar fallback",
+                }
+                for url in url_list
+            ]
+
+        run = getattr(self.plugin, "_run_extract")
+        output_format = kwargs.get("format") or "markdown"
+        try:
+            data = run(
+                url_list,
+                provider=self.extract_provider,
+                output_format=output_format,
+                inprocess_only=True,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("WSP native extract failed")
+            return [{"url": url, "error": "WSP native extraction failed"} for url in url_list]
+
+        if not isinstance(data, dict):
+            return [
+                {"url": url, "error": "WSP native extract returned malformed payload"}
+                for url in url_list
+            ]
+
+        if data.get("error") and not data.get("results"):
+            return [{"url": url, "error": "WSP native extraction failed; check provider readiness and configuration"} for url in url_list]
+
+        results = data.get("results")
+        if not isinstance(results, list):
+            return [{"url": url, "error": "WSP native extract returned no results"} for url in url_list]
+
+        # Bind every returned row to an explicitly requested URL. Never relabel
+        # unrelated content or silently drop requested failures.
+        by_url: Dict[str, Dict[str, Any]] = {}
+        for row in results:
+            if not isinstance(row, dict) or not isinstance(row.get("url"), str):
+                continue
+            url = row["url"]
+            if url not in url_list or url in by_url:
+                continue
+            content = row.get("content", row.get("markdown", ""))
+            if not isinstance(content, str):
+                by_url[url] = {"url": url, "error": "WSP native extract returned malformed content"}
+                continue
+            normalized = {"url": url, "content": content}
+            for key in ("title", "raw_content"):
+                if isinstance(row.get(key), str):
+                    normalized[key] = row[key]
+            if row.get("error"):
+                normalized["error"] = "WSP extraction failed for this URL"
+            metadata = {key: row[key] for key in (
+                "fetcher", "status", "quality", "lang", "source_type", "page_type",
+                "next_offset", "truncated", "original_content_length",
+            ) if key in row}
+            if metadata:
+                normalized["metadata"] = metadata
+            by_url[url] = normalized
+        return [by_url.get(url, {"url": url, "error": "WSP native extract returned no matching result"})
+                for url in url_list]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": self.display_name,
+            "badge": "opt-in · multi-provider",
+            "tag": (
+                "Routes Hermes web_search/web_extract through Web Search Plus "
+                "in-process. Set web.search_backend / web.extract_backend to 'wsp'."
+            ),
+            "env_vars": [],
+        }
+
+
+def register_native_backend(ctx: Any, plugin: Any) -> Optional[Any]:
+    """Register the wsp backend on *ctx* if the host supports it.
+
+    Returns the registration handle (for dispose/unload) or None when the
+    host PluginContext cannot register web providers.
+    """
+    register = getattr(ctx, "register_web_search_provider", None)
+    if not callable(register):
+        logger.debug(
+            "web-search-plus: host lacks register_web_search_provider; "
+            "skipping native wsp backend"
+        )
+        return None
+    backend = WSPNativeBackend(plugin=plugin)
+    try:
+        handle = register(backend)
+    except Exception:  # noqa: BLE001 — never break Plus tool registration
+        logger.warning(
+            "web-search-plus: failed to register native wsp backend"
+        )
+        return None
+    if handle is not None:
+        logger.info("web-search-plus: registered native wsp WebSearchProvider")
+    return handle

--- a/operator_console_v3.py
+++ b/operator_console_v3.py
@@ -532,7 +532,7 @@ def build_overview(
     config: Mapping[str, Any] | None = None,
     provider_ids: Sequence[str] | None = None,
     state_path: str | Path | None = None,
-    plugin_version: str = "4.0.4",
+    plugin_version: str = "4.0.5",
     now: Callable[[], float] = time.time,
 ) -> dict[str, Any]:
     root = Path(cache_root)

--- a/operator_console_v3.py
+++ b/operator_console_v3.py
@@ -532,7 +532,7 @@ def build_overview(
     config: Mapping[str, Any] | None = None,
     provider_ids: Sequence[str] | None = None,
     state_path: str | Path | None = None,
-    plugin_version: str = "4.0.5",
+    plugin_version: str = "4.1.0",
     now: Callable[[], float] = time.time,
 ) -> dict[str, Any]:
     root = Path(cache_root)

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "4.0.5"
+version: "4.1.0"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []
@@ -22,6 +22,8 @@ optional_env:
 provides_tools:
   - web_search_plus
   - web_extract_plus
+provides_web_providers:
+  - wsp
 provides_hooks:
   - on_session_start
 onboarding:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: web-search-plus
-version: "4.0.4"
+version: "4.0.5"
 description: "Multi-provider web search, URL extraction, quality reports, and opt-in research mode"
 author: robbyczgw-cla
 requires_env: []

--- a/providers.d/donsetch.py
+++ b/providers.d/donsetch.py
@@ -6,6 +6,12 @@ for every URL, then shuts the child down. The adapter projects structured
 ``web_search`` and ``web_fetch`` responses into WSP's source-only envelopes.
 No shell is used. The binary path comes from ``DONSETCH_BIN`` or the
 ``donsetch.binary`` config field — it is a filesystem path, not an API key.
+
+DonSeTch 3.6+ keeps model evidence in the text block and only actionable state
+on ``structuredContent``. Transport diagnostics live under namespaced
+``_meta`` keys (``com.donsetch/search-debug``, ``com.donsetch/fetch-debug``).
+This adapter whitelists those diagnostic fields and still accepts the older
+pre-compact structured shape so 3.2.x binaries keep working.
 """
 
 from __future__ import annotations
@@ -26,13 +32,24 @@ from wsp_sdk import ProviderSpec, extract_result, search_result, source_result
 _ALLOWED_OUTPUT_FORMATS = {"markdown"}
 _ALLOWED_SEARCH_TYPES = {"search", "news"}
 _ALLOWED_INTENTS = {"auto", "web", "code", "paper", "news", "entity"}
-TESTED_VERSION = "3.2.1"
+TESTED_VERSION = "3.6.1"
 STDERR_LIMIT = 2048
 _VERSION_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
 _SECRET_RE = re.compile(
     r"(?i)\b(api[_-]?key|token|secret|password|authorization|bearer)\b\s*[:=]\s*\S+"
 )
 _HOME_RE = re.compile(r"(?i)(/root|/home/[^/\s]+|/Users/[^/\s]+)")
+_SEARCH_HEADER_RE = re.compile(r"^(\d+)\.\s+(.+)$")
+_SEARCH_HINT_RE = re.compile(r"\s+(·\s+⚠.*)$")
+_SEARCH_FOOTER_PREFIXES = (
+    "Weak results",
+    "Degraded retrieval",
+    "No results.",
+    "*degraded:",
+    "*fetch results",
+)
+_SEARCH_DEBUG_KEY = "com.donsetch/search-debug"
+_FETCH_DEBUG_KEY = "com.donsetch/fetch-debug"
 
 _last_stderr = ""
 _stderr_lock = threading.Lock()
@@ -104,6 +121,13 @@ def _url_allowed_by_domains(
     return not include_domains or any(
         _domain_matches(hostname, domain) for domain in include_domains
     )
+
+
+def _hostname_of(url: str) -> str:
+    try:
+        return (urlsplit(url).hostname or "").lower().rstrip(".")
+    except (TypeError, ValueError):
+        return ""
 
 
 def _candidate_binary(key: str | None, config: dict[str, Any]) -> str:
@@ -208,6 +232,39 @@ def inspect_donsetch_readiness(
     return report
 
 
+def _child_env() -> dict[str, str]:
+    """Copy the process env but pin DonSeTch to stdio for this child only."""
+    env = os.environ.copy()
+    env["DONSETCH_TRANSPORT"] = "stdio"
+    return env
+
+
+def _namespaced_meta(meta: Any, key: str) -> dict[str, Any]:
+    if not isinstance(meta, dict):
+        return {}
+    value = meta.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _payload_from_tool_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Decode one MCP tools/call result into structured/text/meta."""
+    if result.get("isError") or result.get("is_error"):
+        raise RuntimeError("donsetch_tool_error")
+    structured = result.get("structuredContent")
+    if not isinstance(structured, dict):
+        structured = result.get("structured_content")
+    if not isinstance(structured, dict):
+        structured = {}
+    meta = result.get("_meta")
+    if not isinstance(meta, dict):
+        meta = {}
+    return {
+        "structured": structured,
+        "text": _text_content(result.get("content")),
+        "meta": meta,
+    }
+
+
 def _mcp_response_from_stdout(stdout: str, request_id: int) -> dict[str, Any]:
     for line in stdout.splitlines():
         try:
@@ -221,17 +278,7 @@ def _mcp_response_from_stdout(stdout: str, request_id: int) -> dict[str, Any]:
         result = message.get("result")
         if not isinstance(result, dict):
             raise RuntimeError("donsetch_mcp_contract_failed")
-        if result.get("isError") or result.get("is_error"):
-            raise RuntimeError("donsetch_tool_error")
-        structured = result.get("structuredContent")
-        if not isinstance(structured, dict):
-            structured = result.get("structured_content")
-        if not isinstance(structured, dict):
-            structured = {}
-        return {
-            "structured": structured,
-            "text": _text_content(result.get("content")),
-        }
+        return _payload_from_tool_result(result)
     raise RuntimeError("donsetch_mcp_contract_failed")
 
 
@@ -266,18 +313,170 @@ def _mcp_result(message: dict[str, Any], request_id: int) -> dict[str, Any]:
     return result
 
 
-def _payload_from_tool_result(result: dict[str, Any]) -> dict[str, Any]:
-    if result.get("isError") or result.get("is_error"):
-        raise RuntimeError("donsetch_tool_error")
-    structured = result.get("structuredContent")
-    if not isinstance(structured, dict):
-        structured = result.get("structured_content")
-    if not isinstance(structured, dict):
-        structured = {}
-    return {
-        "structured": structured,
-        "text": _text_content(result.get("content")),
-    }
+def _split_search_title_host(after_dot: str, expected_host: str | None) -> tuple[str, str]:
+    """Split ``title : host`` after the reference marker, preserving colon titles."""
+    text = after_dot
+    hint_match = _SEARCH_HINT_RE.search(text)
+    if hint_match:
+        text = text[: hint_match.start()]
+    if expected_host:
+        suffix = f" : {expected_host}"
+        if text.endswith(suffix):
+            return text[: -len(suffix)], expected_host
+        # Tolerate trailing path fragments or case differences on the host token.
+        lowered = text.lower()
+        host_l = expected_host.lower()
+        marker = f" : {host_l}"
+        idx = lowered.rfind(marker)
+        if idx >= 0 and idx + len(marker) == len(lowered):
+            return text[:idx], expected_host
+    if " : " not in text:
+        return text, expected_host or ""
+    title, host = text.rsplit(" : ", 1)
+    host = host.strip().split()[0] if host.strip() else ""
+    return title, host
+
+
+def parse_search_evidence(text: str, structured_results: list[dict[str, Any]] | None = None) -> dict[int, dict[str, str]]:
+    """Parse compact DonSeTch search markdown into rank-keyed title/snippet maps.
+
+    Rank binding happens before any domain filter. Malformed or mismatched
+    evidence lines are ignored rather than assigned to a different URL.
+    """
+    hosts_by_rank: dict[int, str] = {}
+    handles_by_rank: dict[int, str] = {}
+    urls_by_rank: dict[int, str] = {}
+    if isinstance(structured_results, list):
+        for index, item in enumerate(structured_results):
+            if not isinstance(item, dict):
+                continue
+            rank = _safe_int(item.get("rank"), index + 1)
+            if rank <= 0:
+                rank = index + 1
+            url = item.get("url") if isinstance(item.get("url"), str) else ""
+            handle = item.get("handle") if isinstance(item.get("handle"), str) else ""
+            urls_by_rank[rank] = url
+            if handle:
+                handles_by_rank[rank] = handle
+            host = _hostname_of(url)
+            if host:
+                hosts_by_rank[rank] = host
+
+    evidence: dict[int, dict[str, str]] = {}
+    current_rank: int | None = None
+    snippet_parts: list[str] = []
+
+    def _flush() -> None:
+        nonlocal current_rank, snippet_parts
+        if current_rank is None:
+            return
+        bucket = evidence.setdefault(current_rank, {"title": "", "snippet": "", "reference": ""})
+        if snippet_parts:
+            bucket["snippet"] = "\n".join(snippet_parts).strip()
+        snippet_parts = []
+
+    for raw_line in (text or "").splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        if not line.startswith("   ") and any(stripped.startswith(prefix) for prefix in _SEARCH_FOOTER_PREFIXES):
+            _flush()
+            current_rank = None
+            continue
+        header = _SEARCH_HEADER_RE.match(line)
+        if header:
+            _flush()
+            rank = int(header.group(1))
+            body = header.group(2).strip()
+            # When structured results are present, only bind ranks they declare.
+            if urls_by_rank and rank not in urls_by_rank:
+                current_rank = None
+                continue
+            expected_host = hosts_by_rank.get(rank)
+            expected_handle = handles_by_rank.get(rank)
+            expected_url = urls_by_rank.get(rank)
+            reference = ""
+            title = ""
+            if " · " in body:
+                reference, after = body.split(" · ", 1)
+                reference = reference.strip()
+                title, _host = _split_search_title_host(after, expected_host)
+            else:
+                reference = body
+            # Reject rank/reference mismatches so evidence never drifts onto another URL.
+            if expected_handle or expected_url:
+                allowed = {value for value in (expected_handle, expected_url) if value}
+                ok = reference in allowed
+                if not ok and expected_url:
+                    ok = reference.rstrip("/") == expected_url.rstrip("/")
+                if not ok:
+                    current_rank = None
+                    continue
+            evidence[rank] = {
+                "title": title.strip(),
+                "snippet": "",
+                "reference": reference,
+            }
+            current_rank = rank
+            snippet_parts = []
+            continue
+        if current_rank is None:
+            continue
+        if line.startswith("   "):
+            snippet_parts.append(line[3:].rstrip())
+            continue
+        # Non-indented non-header body: ignore rather than attaching to the wrong hit.
+    _flush()
+    return evidence
+
+
+def _whitelist_search_debug(meta: dict[str, Any]) -> dict[str, Any]:
+    debug = _namespaced_meta(meta, _SEARCH_DEBUG_KEY)
+    if not debug:
+        return {}
+    out: dict[str, Any] = {}
+    if "intent" in debug:
+        out["intent"] = debug.get("intent")
+    if "cached" in debug:
+        out["cached"] = bool(debug.get("cached"))
+    if "elapsed_ms" in debug:
+        out["elapsed_ms"] = _safe_float(debug.get("elapsed_ms"))
+    if "weak" in debug:
+        out["weak"] = bool(debug.get("weak"))
+    engines = debug.get("engines")
+    if isinstance(engines, list):
+        out["engines"] = engines
+    results = debug.get("results")
+    if isinstance(results, list):
+        cleaned = []
+        for item in results:
+            if not isinstance(item, dict):
+                cleaned.append({})
+                continue
+            entry: dict[str, Any] = {}
+            if "score" in item:
+                entry["score"] = item.get("score")
+            if "consensus" in item:
+                entry["consensus"] = item.get("consensus")
+            if "engines" in item:
+                entry["engines"] = item.get("engines")
+            cleaned.append(entry)
+        out["results"] = cleaned
+    return out
+
+
+def _whitelist_fetch_debug(meta: dict[str, Any]) -> dict[str, Any]:
+    debug = _namespaced_meta(meta, _FETCH_DEBUG_KEY)
+    if not debug:
+        return {}
+    out: dict[str, Any] = {}
+    for key in ("status", "title", "quality", "site", "verdict", "tier"):
+        if key in debug:
+            out[key] = debug.get(key)
+    return out
 
 
 class DonsetchSession:
@@ -317,7 +516,7 @@ class DonsetchSession:
             encoding="utf-8",
             errors="replace",
             bufsize=1,
-            env=os.environ.copy(),
+            env=_child_env(),
         )
         self._stderr_thread = threading.Thread(target=self._collect_stderr, daemon=True)
         self._stderr_thread.start()
@@ -479,51 +678,92 @@ def execute_search(search_module, prov, args, key, config, routing_info):
     if not isinstance(upstream_results, list):
         raise RuntimeError("donsetch_search_contract_failed")
 
+    # Bind text evidence and debug diagnostics by original rank/index before
+    # any domain filtering so dropped hits cannot steal another row's fields.
+    evidence = parse_search_evidence(payload.get("text") or "", upstream_results)
+    debug = _whitelist_search_debug(payload.get("meta") or {})
+    debug_results = debug.get("results") if isinstance(debug.get("results"), list) else []
+
     projected = []
-    for position, item in enumerate(upstream_results, start=1):
+    for index, item in enumerate(upstream_results):
         if not isinstance(item, dict):
             continue
         url = item.get("url")
         if not isinstance(url, str) or not url:
             continue
+        rank = _safe_int(item.get("rank"), index + 1)
+        if rank <= 0:
+            rank = index + 1
+        bound = evidence.get(rank) or {}
+        debug_item = debug_results[index] if index < len(debug_results) and isinstance(debug_results[index], dict) else {}
+
+        # Compact contract: title/snippet live in text. Legacy: still on item.
+        title = str(bound.get("title") or item.get("title") or "")
+        snippet = str(bound.get("snippet") or item.get("snippet") or "")
+        score_raw = item.get("score")
+        if score_raw is None:
+            score_raw = debug_item.get("score")
+        consensus_raw = item.get("consensus")
+        if consensus_raw is None:
+            consensus_raw = debug_item.get("consensus")
+        engines = item.get("engines")
+        if not isinstance(engines, (list, tuple)):
+            engines = debug_item.get("engines")
+        engines = _clean_string_list(engines)
+
         if not _url_allowed_by_domains(url, include_domains, exclude_domains):
             continue
-        engines = _clean_string_list(item.get("engines"))
         projected.append(
             source_result(
                 url,
-                title=str(item.get("title") or ""),
-                snippet=str(item.get("snippet") or ""),
-                score=_safe_float(item.get("score")),
-                position=position,
+                title=title,
+                snippet=snippet,
+                score=_safe_float(score_raw),
+                position=rank,
                 source="donsetch",
                 engines=engines,
-                engines_consensus=str(item.get("consensus") or ""),
+                engines_consensus=str(consensus_raw or ""),
                 source_type="web",
             )
         )
 
     engines = structured.get("engines")
+    if not isinstance(engines, list):
+        engines = debug.get("engines") if isinstance(debug.get("engines"), list) else []
     engines_used = []
     engines_blocked = []
     if isinstance(engines, list):
-        for item in engines:
-            if not isinstance(item, dict):
+        for engine_item in engines:
+            if not isinstance(engine_item, dict):
                 continue
-            name = item.get("engine")
+            name = engine_item.get("engine")
             if not isinstance(name, str) or not name:
                 continue
-            if str(item.get("status", "")).lower() == "ok":
+            if str(engine_item.get("status", "")).lower() == "ok":
                 engines_used.append(name)
             else:
                 engines_blocked.append(name)
+
+    intent = structured.get("intent")
+    if intent in (None, ""):
+        intent = debug.get("intent")
+    cached = structured.get("cached")
+    if cached is None:
+        cached = debug.get("cached", False)
+    weak = structured.get("weak")
+    if weak is None:
+        weak = debug.get("weak", False)
+    elapsed = structured.get("elapsed_ms")
+    if elapsed is None:
+        elapsed = debug.get("elapsed_ms", 0)
+
     metadata = {
         "engines_used": engines_used,
         "engine_blocked": engines_blocked,
-        "intent": str(structured.get("intent") or ""),
-        "cached": bool(structured.get("cached")),
-        "weak": bool(structured.get("weak")),
-        "duration_ms": _safe_float(structured.get("elapsed_ms")),
+        "intent": str(intent or ""),
+        "cached": bool(cached),
+        "weak": bool(weak),
+        "duration_ms": _safe_float(elapsed),
         "provider": "donsetch",
     }
     return search_result(
@@ -538,29 +778,45 @@ def _project_fetch_item(payload: dict[str, Any], fallback_url: str) -> dict[str,
     structured = payload.get("structured")
     if not isinstance(structured, dict):
         return {"url": fallback_url, "error": "donsetch_fetch_contract_failed", "status": 0}
+    debug = _whitelist_fetch_debug(payload.get("meta") or {})
     observed_url = structured.get("url")
     url = observed_url if isinstance(observed_url, str) and observed_url else fallback_url
-    status = _safe_int(structured.get("status"))
+
+    # Compact contract moved title/status/quality/site/verdict into fetch-debug.
+    # Legacy binaries still place them on structuredContent — prefer structured.
+    def _field(name: str, default: Any = None) -> Any:
+        if name in structured and structured.get(name) is not None:
+            return structured.get(name)
+        if name in debug and debug.get(name) is not None:
+            return debug.get(name)
+        return default
+
+    status = _safe_int(_field("status", 0))
+    verdict = str(_field("verdict") or "")
+    title = str(_field("title") or "")
     content = str(payload.get("text") or "")
+    content_ok = structured.get("content_ok")
+    if content_ok is None:
+        content_ok = verdict == "ContentOk" and status and status < 400
     if (
-        not structured.get("content_ok")
-        or structured.get("verdict") in {"Error", "Blocked", "Failed"}
+        not content_ok
+        or verdict in {"Error", "Blocked", "Failed"}
         or status >= 400
         or not content.strip()
     ):
         return {"url": url, "error": "donsetch_fetch_failed", "status": status}
     return source_result(
         url,
-        title=str(structured.get("title") or ""),
+        title=title,
         content=content,
         images=[],
         status=status,
         fetcher="donsetch",
         page_type=str(structured.get("content_kind") or ""),
         source_type="web",
-        quality=_safe_float(structured.get("quality")),
+        quality=_safe_float(_field("quality", 0.0)),
         lang=str(structured.get("lang") or ""),
-        site=str(structured.get("site") or ""),
+        site=str(_field("site") or ""),
         pdf=structured.get("pdf") if isinstance(structured.get("pdf"), dict) else None,
         next_offset=_safe_int(structured.get("next_offset")) if structured.get("next_offset") is not None else None,
     )

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 4.0.4
+Version: 4.0.5
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable, Serper.

--- a/search.py
+++ b/search.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Web Search Plus — Unified Multi-Provider Search and Extraction with Intelligent Auto-Routing
-Version: 4.0.5
+Version: 4.1.0
 Supports search providers: You.com, Serper, Exa, Firecrawl, Tavily, Linkup,
 Brave Search, SerpBase, Querit, Parallel, SearXNG, Keenable.
 Supports extract providers: Firecrawl, Linkup, Parallel, Tavily, Exa, You.com, Keenable, Serper.

--- a/tests/providers_d/test_donsetch_provider.py
+++ b/tests/providers_d/test_donsetch_provider.py
@@ -65,12 +65,14 @@ def test_mcp_response_parser_extracts_structured_content():
         "result": {
             "content": [{"type": "text", "text": "body"}],
             "structuredContent": {"content_ok": True, "status": 200},
+            "_meta": {"com.donsetch/fetch-debug": {"title": "Example", "status": 200}},
         },
     }
     parsed = module["_mcp_response_from_stdout"](json.dumps(response), 2)
     assert parsed == {
         "structured": {"content_ok": True, "status": 200},
         "text": "body",
+        "meta": {"com.donsetch/fetch-debug": {"title": "Example", "status": 200}},
     }
 
 
@@ -93,7 +95,7 @@ def test_stdio_handshake_waits_for_initialize_response(tmp_path):
     )
     binary.chmod(0o700)
     result = module["_call_donsetch_tool"](str(binary), "web_search", {"query": "test"}, 5)
-    assert result == {"structured": {"ok": True}, "text": "body"}
+    assert result == {"structured": {"ok": True}, "text": "body", "meta": {}}
 
 
 def test_search_projects_donsetch_results_and_metadata(monkeypatch):
@@ -510,17 +512,330 @@ def test_version_detection_classifies_missing_tested_compatible_and_incompatible
         path.chmod(0o700)
         return str(path)
 
-    tested = module["inspect_donsetch_readiness"](binary=_version_bin("3.2.1"))
+    tested = module["inspect_donsetch_readiness"](binary=_version_bin("3.6.1"))
     assert tested["state"] == "executable"
-    assert tested["version"] == "3.2.1"
+    assert tested["version"] == "3.6.1"
     assert tested["compatibility"] == "tested"
-    assert tested["tested_version"] == "3.2.1"
+    assert tested["tested_version"] == "3.6.1"
     assert "api_key" not in tested
 
-    other = module["inspect_donsetch_readiness"](binary=_version_bin("3.0.0"))
+    other = module["inspect_donsetch_readiness"](binary=_version_bin("3.2.1"))
     assert other["compatibility"] == "compatible_unverified"
-    assert other["version"] == "3.0.0"
+    assert other["version"] == "3.2.1"
 
     major = module["inspect_donsetch_readiness"](binary=_version_bin("2.3.1"))
     assert major["compatibility"] == "incompatible_major"
     assert major["state"] == "executable"
+
+
+def test_child_env_pins_stdio_transport_even_when_host_sets_http(monkeypatch):
+    _spec, module = _provider()
+    monkeypatch.setenv("DONSETCH_TRANSPORT", "http")
+    monkeypatch.setenv("OTHER_HOST_VAR", "keep-me")
+    env = module["_child_env"]()
+    assert env["DONSETCH_TRANSPORT"] == "stdio"
+    assert env["OTHER_HOST_VAR"] == "keep-me"
+    assert os.environ.get("DONSETCH_TRANSPORT") == "http"
+
+
+def test_parse_search_evidence_handles_handles_urls_colon_titles_and_footers():
+    _spec, module = _provider()
+    structured = [
+        {
+            "rank": 1,
+            "url": "https://docs.rs/tokio/latest/tokio/",
+            "handle": "So9aiJHFd",
+        },
+        {
+            "rank": 2,
+            "url": "https://example.com/path",
+        },
+        {
+            "rank": 3,
+            "url": "https://tokio.rs/tokio/tutorial",
+            "handle": "SUYE3n6Qg",
+        },
+    ]
+    text = "\n".join(
+        [
+            "# Search results",
+            "1. So9aiJHFd · tokio - Rust - Docs.rs : docs.rs",
+            "   Tokio is an event-driven runtime",
+            "   second snippet line",
+            "2. https://example.com/path · Title: with: colons : example.com",
+            "   Example snippet",
+            "3. SUYE3n6Qg · Tutorial | Tokio : tokio.rs · ⚠ needs browser (~+6s)",
+            "   Tutorial body",
+            "Degraded retrieval : 8/9 backends available.",
+            "Weak results : low cross-source agreement.",
+            "4. SBAD · stray should not bind without structured rank : evil.com",
+            "   bad",
+        ]
+    )
+    evidence = module["parse_search_evidence"](text, structured)
+    assert evidence[1]["title"] == "tokio - Rust - Docs.rs"
+    assert evidence[1]["snippet"] == "Tokio is an event-driven runtime\nsecond snippet line"
+    assert evidence[2]["title"] == "Title: with: colons"
+    assert evidence[2]["reference"] == "https://example.com/path"
+    assert evidence[3]["title"] == "Tutorial | Tokio"
+    assert evidence[3]["snippet"] == "Tutorial body"
+    assert 4 not in evidence
+
+
+def test_parse_search_evidence_rejects_mismatched_reference_for_rank():
+    _spec, module = _provider()
+    structured = [
+        {"rank": 1, "url": "https://a.example/x", "handle": "Sreal1"},
+        {"rank": 2, "url": "https://b.example/y", "handle": "Sreal2"},
+    ]
+    text = "\n".join(
+        [
+            "1. Swrong · Stolen title : a.example",
+            "   should not attach to rank 1",
+            "2. Sreal2 · Keep me : b.example",
+            "   ok",
+        ]
+    )
+    evidence = module["parse_search_evidence"](text, structured)
+    assert 1 not in evidence
+    assert evidence[2]["title"] == "Keep me"
+
+
+def test_compact_search_projects_text_evidence_and_debug_meta_before_domain_filter(monkeypatch):
+    spec, module = _provider()
+    calls = []
+
+    def fake_call(binary, tool, arguments, timeout):
+        calls.append((binary, tool, arguments, timeout))
+        return {
+            "structured": {
+                "weak": False,
+                "results": [
+                    {
+                        "rank": 1,
+                        "url": "https://example.org/nope",
+                        "handle": "Snope1",
+                    },
+                    {
+                        "rank": 2,
+                        "url": "https://tokio.rs/tokio/tutorial",
+                        "handle": "Skeep2",
+                    },
+                    {
+                        "rank": 3,
+                        "url": "https://docs.rs/tokio",
+                        "handle": "Sdrop3",
+                    },
+                ],
+            },
+            "text": "\n".join(
+                [
+                    "# Search results",
+                    "1. Snope1 · Nope Title : example.org",
+                    "   nope snippet",
+                    "2. Skeep2 · Tutorial | Tokio : tokio.rs",
+                    "   keep snippet",
+                    "3. Sdrop3 · Docs : docs.rs",
+                    "   other",
+                    "Degraded retrieval : 1/2 backends available.",
+                ]
+            ),
+            "meta": {
+                "com.donsetch/search-debug": {
+                    "intent": "Code",
+                    "cached": False,
+                    "elapsed_ms": 321,
+                    "weak": False,
+                    "engines": [
+                        {"engine": "ddg", "status": "ok"},
+                        {"engine": "brave", "status": "blocked:429"},
+                    ],
+                    "results": [
+                        {"score": 9.9, "consensus": 1, "engines": ["ddg"]},
+                        {"score": 1.5, "consensus": 3, "engines": ["ddg", "brave"]},
+                        {"score": 0.1, "consensus": 1, "engines": ["brave"]},
+                    ],
+                    "noise_field": "must-not-leak",
+                }
+            },
+        }
+
+    monkeypatch.setitem(module, "_call_donsetch_tool", fake_call)
+    result = spec.execute_search(
+        None,
+        "donsetch",
+        _search_args(include_domains=["tokio.rs"]),
+        "/bin/true",
+        {"donsetch": {"timeout": 30}},
+        {},
+    )
+    assert [item["url"] for item in result["results"]] == [
+        "https://tokio.rs/tokio/tutorial"
+    ]
+    hit = result["results"][0]
+    assert hit["title"] == "Tutorial | Tokio"
+    assert hit["snippet"] == "keep snippet"
+    assert hit["score"] == 1.5
+    assert hit["engines_consensus"] == "3"
+    assert hit["engines"] == ["ddg", "brave"]
+    assert hit["position"] == 2
+    assert result["metadata"]["engines_used"] == ["ddg"]
+    assert result["metadata"]["engine_blocked"] == ["brave"]
+    assert result["metadata"]["duration_ms"] == 321.0
+    assert result["metadata"]["intent"] == "Code"
+    dumped = json.dumps(result)
+    assert "noise_field" not in dumped
+    assert "must-not-leak" not in dumped
+
+
+def test_compact_fetch_uses_debug_whitelist_and_ignores_foreign_meta(monkeypatch):
+    spec, module = _provider()
+
+    class FakeSession:
+        def __init__(self, _binary, _timeout):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            return False
+
+        def call(self, tool, arguments):
+            assert tool == "web_fetch"
+            return {
+                "structured": {
+                    "url": "https://example.org/page",
+                    "content_ok": True,
+                    "content_kind": "Article",
+                    "lang": "en",
+                    "next_offset": 1000,
+                },
+                "text": "# Example\nhttps://example.org/page\n\nBody",
+                "meta": {
+                    "com.donsetch/fetch-debug": {
+                        "status": 200,
+                        "title": "Example",
+                        "quality": 0.8,
+                        "site": "example.org",
+                        "verdict": "ContentOk",
+                        "tokens_est": 99,
+                    },
+                    "com.other/noise": {"secret": "nope"},
+                },
+            }
+
+    monkeypatch.setitem(module, "DonsetchSession", FakeSession)
+    result = spec.execute_extract(
+        None,
+        "donsetch",
+        ["https://example.org/page"],
+        "/bin/true",
+        "markdown",
+        False,
+        False,
+        False,
+        {"donsetch": {"timeout": 30}},
+        False,
+    )
+    item = result["results"][0]
+    assert item["title"] == "Example"
+    assert item["status"] == 200
+    assert item["quality"] == 0.8
+    assert item["site"] == "example.org"
+    assert item["content"].startswith("# Example")
+    assert item["next_offset"] == 1000
+    dumped = json.dumps(result)
+    assert "tokens_est" not in dumped
+    assert "com.other/noise" not in dumped
+    assert "nope" not in dumped
+
+
+def test_legacy_search_and_fetch_shapes_still_project(monkeypatch):
+    """Pre-3.6 structured title/snippet/status remain valid."""
+    spec, module = _provider()
+
+    def fake_call(binary, tool, arguments, timeout):
+        return {
+            "structured": {
+                "intent": "Code",
+                "cached": False,
+                "weak": False,
+                "elapsed_ms": 10,
+                "engines": [{"engine": "ddg", "status": "ok"}],
+                "results": [
+                    {
+                        "url": "https://tokio.rs/tokio/tutorial",
+                        "title": "Legacy Title",
+                        "snippet": "Legacy snippet",
+                        "score": 2.0,
+                        "consensus": 2,
+                        "engines": ["ddg"],
+                    }
+                ],
+            },
+            "text": "",
+            "meta": {},
+        }
+
+    monkeypatch.setitem(module, "_call_donsetch_tool", fake_call)
+    search = spec.execute_search(
+        None,
+        "donsetch",
+        _search_args(),
+        "/bin/true",
+        {"donsetch": {"timeout": 5}},
+        {},
+    )
+    assert search["results"][0]["title"] == "Legacy Title"
+    assert search["results"][0]["snippet"] == "Legacy snippet"
+
+    class FakeSession:
+        def __init__(self, *_a):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_e):
+            return False
+
+        def call(self, tool, arguments):
+            return {
+                "structured": {
+                    "url": arguments["url"],
+                    "title": "Legacy Fetch",
+                    "status": 200,
+                    "content_ok": True,
+                    "content_kind": "Page",
+                    "verdict": "ContentOk",
+                    "quality": 0.5,
+                    "site": "example.org",
+                },
+                "text": "legacy body",
+                "meta": {},
+            }
+
+    monkeypatch.setitem(module, "DonsetchSession", FakeSession)
+    extract = spec.execute_extract(
+        None,
+        "donsetch",
+        ["https://example.org/page"],
+        "/bin/true",
+        "markdown",
+        False,
+        False,
+        False,
+        {},
+        False,
+    )
+    assert extract["results"][0]["title"] == "Legacy Fetch"
+    assert extract["results"][0]["content"] == "legacy body"
+
+
+def test_indented_footer_words_remain_source_snippets():
+    _, module = _provider()
+    rows = [{"rank": 1, "url": "https://example.org/", "handle": "Sone"}]
+    text = "1. Sone · Study : example.org\n   Weak results are discussed in this study.\nDegraded retrieval : 1/2 backends available."
+    result = module["parse_search_evidence"](text, rows)
+    assert result[1]["snippet"] == "Weak results are discussed in this study."

--- a/tests/test_native_backend.py
+++ b/tests/test_native_backend.py
@@ -1,0 +1,160 @@
+"""Portable adapter contracts; real Hermes discovery is tested separately."""
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture
+def backend(monkeypatch):
+    abc = ModuleType("agent.web_search_provider")
+    abc.WebSearchProvider = object
+    web = ModuleType("tools.web_tools")
+    config = {"backend": "wsp"}
+    web._load_web_config = lambda: config
+    monkeypatch.setitem(sys.modules, "agent.web_search_provider", abc)
+    monkeypatch.setitem(sys.modules, "tools.web_tools", web)
+    spec = importlib.util.spec_from_file_location(
+        "_wsp_native_unit", Path(__file__).resolve().parents[1] / "native_backend.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    engine = SimpleNamespace(
+        load_config=lambda: {"auto_routing": {}},
+        provider_configured=lambda *args: True,
+        SEARCH_PROVIDER_IDS=("fixture",), EXTRACT_PROVIDER_IDS=("fixture",),
+        _provider_auto_allowed=lambda *args: True,
+    )
+    plugin = SimpleNamespace(
+        _force_subprocess=lambda: False, _load_search_module=lambda: engine,
+        _run_search=Mock(return_value={"provider": "fixture", "results": [
+            {"url": "https://example.org", "title": "Source", "snippet": "Evidence"}]}),
+        _run_extract=Mock(return_value={"results": [
+            {"url": "https://example.org", "title": "Source", "content": "Evidence"}]}),
+    )
+    return SimpleNamespace(module=module, value=module.WSPNativeBackend(plugin),
+                           plugin=plugin, config=config, engine=engine)
+
+
+def test_no_implicit_selection(backend):
+    backend.config.clear()
+    assert not backend.value.is_available()
+    assert not backend.value.supports_search()
+    assert not backend.value.supports_extract()
+
+
+def test_independent_pins(backend):
+    backend.config.update(search_backend="searxng", extract_backend="wsp")
+    assert not backend.value.supports_search()
+    assert backend.value.supports_extract()
+    assert backend.value.is_available()
+
+
+@pytest.mark.parametrize("bad", [[], ["wsp"], 4, {}, True])
+def test_malformed_config(backend, bad):
+    backend.module._load_web_config = lambda: {"search_backend": bad}
+    assert not backend.value.supports_search()
+
+
+def test_requires_exact_plugin(backend):
+    with pytest.raises(RuntimeError):
+        backend.module.WSPNativeBackend()
+
+
+def test_readiness_without_vendor_calls(backend):
+    assert backend.value.is_available()
+    backend.plugin._run_search.assert_not_called()
+    backend.plugin._run_extract.assert_not_called()
+    backend.engine.provider_configured = lambda *args: False
+    assert not backend.value.is_available()
+
+
+def test_readiness_honors_disabled_and_auto_allow(backend):
+    backend.engine.load_config = lambda: {"auto_routing": {"disabled_providers": ["fixture"]}}
+    assert not backend.value.is_available()
+    backend.engine.load_config = lambda: {"auto_routing": {}}
+    backend.engine._provider_auto_allowed = lambda *args: False
+    assert not backend.value.is_available()
+
+
+@pytest.mark.parametrize("failure", ["forced", "missing", "raises"])
+def test_no_subprocess_fallback(backend, failure):
+    if failure == "forced":
+        backend.plugin._force_subprocess = lambda: True
+    elif failure == "missing":
+        backend.plugin._load_search_module = lambda: None
+    else:
+        backend.plugin._load_search_module = Mock(side_effect=RuntimeError("private-data"))
+    assert not backend.value.is_available()
+    assert not backend.value.search("q")["success"]
+    assert backend.value.extract(["https://example.org"])[0]["error"]
+    backend.plugin._run_search.assert_not_called()
+    backend.plugin._run_extract.assert_not_called()
+
+
+def test_search_mapping_limit_and_no_fallback_flag(backend):
+    result = backend.value.search("q", 35)
+    assert result["success"]
+    assert result["data"]["web"][0]["description"] == "Evidence"
+    assert result["metadata"]["effective_limit"] == 20
+    assert backend.plugin._run_search.call_args.kwargs["inprocess_only"] is True
+    assert backend.plugin._run_search.call_args.kwargs["count"] == 20
+
+
+@pytest.mark.parametrize("payload", [None, {}, {"results": {}}, {"data": []}, {"data": None}, {"error": "secret-dummy"}])
+def test_search_malformed_response(backend, payload):
+    backend.plugin._run_search.return_value = payload
+    result = backend.value.search("q")
+    assert result["success"] is False
+    assert "secret-dummy" not in str(result)
+
+
+def test_legacy_search_shape(backend):
+    backend.plugin._run_search.return_value = {"data": {"web": [
+        {"url": "https://example.org", "description": "legacy"}]}}
+    assert backend.value.search("q")["data"]["web"][0]["description"] == "legacy"
+
+
+def test_exception_redaction(backend, caplog):
+    backend.plugin._run_search.side_effect = RuntimeError("secret-dummy")
+    backend.plugin._run_extract.side_effect = RuntimeError("secret-dummy")
+    assert "secret-dummy" not in str(backend.value.search("q"))
+    assert "secret-dummy" not in str(backend.value.extract(["https://example.org"]))
+    assert "secret-dummy" not in caplog.text
+
+
+def test_extract_association_and_missing_failures(backend):
+    backend.plugin._run_extract.return_value = {"results": [
+        {"url": "https://foreign.invalid", "content": "foreign"},
+        {"url": "https://second.invalid", "content": "second"},
+        {"url": "https://example.org", "error": "secret-dummy"},
+    ]}
+    urls = ["https://example.org", "https://missing.invalid", "https://second.invalid"]
+    result = backend.value.extract(urls)
+    assert [r["url"] for r in result] == urls
+    assert result[0]["error"] and result[1]["error"]
+    assert result[2]["content"] == "second"
+    assert "foreign" not in str(result) and "secret-dummy" not in str(result)
+    assert backend.plugin._run_extract.call_args.kwargs["inprocess_only"] is True
+
+
+def test_extract_format_metadata(backend):
+    backend.plugin._run_extract.return_value = {"results": [
+        {"url": "https://example.org", "markdown": "text", "truncated": True}]}
+    row = backend.value.extract(["https://example.org"], format="html")[0]
+    assert row["content"] == "text" and row["metadata"]["truncated"]
+    assert backend.plugin._run_extract.call_args.kwargs["output_format"] == "html"
+
+
+def test_registration_and_older_host(backend):
+    handle = object()
+    ctx = SimpleNamespace(register_web_search_provider=Mock(return_value=handle))
+    assert backend.module.register_native_backend(ctx, backend.plugin) is handle
+    registered = ctx.register_web_search_provider.call_args.args[0]
+    assert registered.plugin is backend.plugin
+    assert backend.module.register_native_backend(object(), backend.plugin) is None
+    ctx.register_web_search_provider.side_effect = RuntimeError("failure")
+    assert backend.module.register_native_backend(ctx, backend.plugin) is None

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -935,6 +935,61 @@ def test_fastpath_cli_outputs_json_without_core_patch_dependency(tmp_path, capsy
     assert "never_defer" not in json.dumps(data)
 
 
+def test_native_inprocess_only_never_falls_back(tmp_path, monkeypatch):
+    monkeypatch.setattr(wsp, "_load_search_module", lambda: None)
+    monkeypatch.setattr(wsp, "_force_subprocess", lambda: False)
+    def forbidden(*args, **kwargs):
+        raise AssertionError("native must not launch a subprocess")
+    monkeypatch.setattr(wsp, "_run_search_subprocess", forbidden)
+    monkeypatch.setattr(wsp, "_run_extract_subprocess", forbidden)
+    assert wsp._run_search("query", inprocess_only=True)["error"]
+    assert wsp._run_extract(["https://example.org"], inprocess_only=True)["error"]
+
+
+def test_fastpath_config_path_respects_profile_home(tmp_path, monkeypatch):
+    monkeypatch.delenv("HERMES_CONFIG", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    assert wsp._get_hermes_config_path() == tmp_path / "config.yaml"
+    explicit = tmp_path / "explicit.yaml"
+    monkeypatch.setenv("HERMES_CONFIG", str(explicit))
+    assert wsp._get_hermes_config_path() == explicit
+
+
+def test_fastpath_native_selection_keeps_web_enabled(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text("web:\n  search_backend: wsp\nagent:\n  disabled_toolsets: []\n")
+    report = wsp._build_fastpath_report(path)
+    assert report["mode"] == "native"
+    assert report["native_capabilities"] == ["search"]
+    assert report["preferred_web_path_configured"] is True
+    assert report["recommended_hermes_config"] == {}
+    assert "disabled_toolsets: [web]" not in wsp._render_fastpath_report(report)
+
+
+def test_fastpath_native_selection_reports_disabled_web_conflict(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text("web:\n  backend: wsp\nagent:\n  disabled_toolsets: [web, browser]\n")
+    report = wsp._build_fastpath_report(path)
+    assert report["native_capabilities"] == ["search", "extract"]
+    assert report["preferred_web_path_configured"] is False
+    checks = {row["id"]: row for row in report["checks"]}
+    assert checks["native_web_toolset_enabled"]["ok"] is False
+    assert "Remove only web" in checks["native_web_toolset_enabled"]["recommendation"]
+    assert "disabled_toolsets: [web]" not in wsp._render_fastpath_report(report)
+
+
+def test_fastpath_native_overrides_and_unrelated_sections(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text(
+        "other:\n  search_backend: wsp\nweb:\n  backend: wsp\n"
+        "  search_backend: searxng\n  extract_backend: 'wsp' # explicit\n"
+    )
+    report = wsp._build_fastpath_report(path)
+    assert report["native_capabilities"] == ["extract"]
+    path.write_text("other:\n  backend: wsp\nweb:\n  search_backend: searxng\n")
+    assert wsp._build_fastpath_report(path)["mode"] == "plus"
+
+
 def test_fastpath_report_handles_missing_hermes_config(tmp_path):
     config_path = tmp_path / "missing-config.yaml"
 

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "4.0.4"
+EXPECTED_VERSION = "4.0.5"
 
 
 def _load_plugin_module():
@@ -61,7 +61,7 @@ def test_current_release_surfaces_and_attribution():
     env_template = (ROOT / ".env.template").read_text()
     current_surfaces = "\n".join((readme, release_notes, user_guide, env_template))
 
-    assert "Current release: **v4.0.4**" in readme
+    assert f"Current release: **v{EXPECTED_VERSION}**" in readme
     assert "docs/RELEASE_NOTES_V400.md" in readme
     assert "DonSeTch 2.1.0" in release_notes
     assert "explicit-only" in release_notes

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "4.0.5"
+EXPECTED_VERSION = "4.1.0"
 
 
 def _load_plugin_module():

--- a/ui.py
+++ b/ui.py
@@ -434,7 +434,7 @@ def create_server(
     cache_root: str | Path = CACHE_DIR,
     state_path: str | Path | None = None,
     config: Mapping[str, Any] | None = None,
-    plugin_version: str = "4.0.5",
+    plugin_version: str = "4.1.0",
     snapshot_backend: Any = operator_console_v3,
     static_root: str | Path | None = None,
 ) -> ThreadingHTTPServer:

--- a/ui.py
+++ b/ui.py
@@ -434,7 +434,7 @@ def create_server(
     cache_root: str | Path = CACHE_DIR,
     state_path: str | Path | None = None,
     config: Mapping[str, Any] | None = None,
-    plugin_version: str = "4.0.4",
+    plugin_version: str = "4.0.5",
     snapshot_backend: Any = operator_console_v3,
     static_root: str | Path | None = None,
 ) -> ThreadingHTTPServer:


### PR DESCRIPTION
## Summary

- Add opt-in native Hermes `wsp` search/extract registration with independent selection and no WSP CLI fallback.
- Preserve Plus tools and update setup diagnostics for native configuration.
- Support DonSeTch 3.6.1 compact MCP responses and retain older structured contracts.

Addresses #125. Thanks to @LugMuad for the proposal and follow-up testing. Hermes toolset membership itself is unchanged.

## Verification

- 1,082 tests and six subtests passed.
- Isolated real plugin discovery, native/Plus dispatch and unload passed.
- Real native DonSeTch search and two-URL extraction passed.
- Ruff, compile, generated docs/schemas and schema-boundary checks passed.

See `docs/RELEASE_NOTES_V410.md` for configuration and upstream attribution.
